### PR TITLE
fix(AXE-29): fiabiliser autosave + activer règles Bugbot

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,31 @@
+# Bugbot — AxeL Job (Axeljob)
+
+Règles de revue automatique pour les PRs GitHub.
+
+## Produit
+
+- Ne pas casser l’éditeur Beta canvas (`CvEditorBetaView`, layout v3) ni le parcours Stable (`ProfileView`).
+- Toute persistance CV passe par `PUT/PATCH /api/cv` ; le layout doit rester v3 valide (pas de data URL image — AXE-40).
+- Autosave : flush à l’unmount, `isActive=false`, `pagehide` / onglet caché ; après undo/redo inclure `layout` dans le payload (AXE-29).
+
+## Sécurité
+
+- Pas de HTML riche hors whitelist (`strong`/`em`/`u`/`s`/`span` style limité) côté front et backend.
+- Pas d’`eval`, pas d’injection dans `dangerouslySetInnerHTML` sans sanitize.
+- Pas de secrets (`.env`, clés Stripe/Supabase) dans le diff.
+
+## Qualité CI
+
+- Aligné sur `scripts/pre-push.sh` : ruff, black **24.10.0**, mypy, pytest, eslint, `test:unit`.
+- Ne pas reformater avec Black 26.x.
+- Pas de push direct sur `main` ; 1 issue Linear = 1 branche = 1 PR (`Fixes AXE-XX` + `Closes #N`).
+
+## Frontend
+
+- Respecter `docs/DESIGN-cohere.md` / tokens design system pour l’UI shell.
+- Préférer des changements ciblés ; pas de refactors hors scope du ticket.
+
+## Backend
+
+- Erreurs layout → HTTP 400 claires (`LayoutValidationError`).
+- Uploads images canvas via `/api/cv/upload-canvas-asset`, pas d’embed base64 dans le JSON.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3995,7 +3995,7 @@ export default function App() {
             )}
           </header>
           <div className="page-content" data-analytics-section="profil_editor">
-            <ProfileView onSaveSuccess={handleProfileSaveSuccess} session={session} refreshKey={profileRefreshKey} usage={usage} onUpgradeClick={handleUpgradeClick} onUsageRefresh={loadUsage} onBillingPortalClick={() => setManageSubscriptionModalOpen(true)} templatesList={templatesList} templateId={templateId} templateOptions={templateOptions} onTemplateIdChange={handleUserPickTemplate} onTemplateOptionsChange={setTemplateOptions} onPhotoSessionExpired={handlePhotoSessionExpired} />
+            <ProfileView isActive={view === 'profil'} onSaveSuccess={handleProfileSaveSuccess} session={session} refreshKey={profileRefreshKey} usage={usage} onUpgradeClick={handleUpgradeClick} onUsageRefresh={loadUsage} onBillingPortalClick={() => setManageSubscriptionModalOpen(true)} templatesList={templatesList} templateId={templateId} templateOptions={templateOptions} onTemplateIdChange={handleUserPickTemplate} onTemplateOptionsChange={setTemplateOptions} onPhotoSessionExpired={handlePhotoSessionExpired} />
           </div>
         </div>
 

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -99,6 +99,7 @@ import EditorCvImportModal from './EditorCvImportModal.jsx';
 
 import {
   buildCanvasPdfFilename,
+  formatPdfExportError,
   sameLayout,
   blockSupportsEditHint,
   dismissCanvasEditHint,
@@ -125,6 +126,7 @@ function CvEditorBeta({
   templatesList,
   onTemplateIdChange,
   onTemplateOptionsChange,
+  isActive = true,
 }) {
   const [cv, setCv] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -178,7 +180,9 @@ function CvEditorBeta({
       setSelectedBlockRect(null);
     }
     if (!cv || profileLoadError) return;
-    autoSaveRef.current?.schedule(cv);
+    // Inclure le layout post-undo/redo : layoutRef peut encore être l’ancien
+    // jusqu’au prochain render (AXE-29).
+    autoSaveRef.current?.schedule({ ...cv, layout: newLayout });
   }, [cv, profileLoadError]);
 
   const layoutHistory = useLayoutHistory(() => createBlankLayoutV3(), {
@@ -226,6 +230,7 @@ function CvEditorBeta({
   const autoSave = useAutoSave({
     saveFn,
     saveFnKey: `${templateId}|${JSON.stringify(templateOptions || {})}`,
+    isActive,
   });
   autoSaveRef.current = autoSave;
 
@@ -1024,7 +1029,7 @@ function CvEditorBeta({
     } catch (err) {
       if (preopenedWindow && !preopenedWindow.closed) preopenedWindow.close();
       console.error('[cv-editor-beta] export PDF layout', err);
-      setPdfExportError(`${err?.message || 'Impossible de telecharger le PDF.'}${getDownloadPermissionHint()}`);
+      setPdfExportError(formatPdfExportError(err, getDownloadPermissionHint()));
     } finally {
       setPdfExporting(false);
     }

--- a/frontend/src/lib/canvasEditorUtils.js
+++ b/frontend/src/lib/canvasEditorUtils.js
@@ -77,6 +77,19 @@ export function buildCanvasPdfFilename(cv) {
   return `${parts.join(' - ') || 'CV'}.pdf`;
 }
 
+/**
+ * Message d’échec export PDF (AXE-29) — visible via role="alert", pas seulement console.
+ * @param {unknown} err
+ * @param {string} [hint]
+ */
+export function formatPdfExportError(err, hint = '') {
+  const base =
+    err && typeof err === 'object' && typeof err.message === 'string' && err.message
+      ? err.message
+      : 'Impossible de telecharger le PDF.';
+  return `${base}${hint || ''}`;
+}
+
 /** Égalité structurelle tolérante de deux layouts (référence ou JSON). */
 export function sameLayout(a, b) {
   if (a === b) return true;

--- a/frontend/src/lib/useAutoSave.js
+++ b/frontend/src/lib/useAutoSave.js
@@ -10,7 +10,8 @@
  *    hasPending) -- utilise par `AutoSaveIndicator`.
  *
  * Installe egalement un garde `beforeunload` qui empeche l utilisateur de
- * fermer la fenetre tant qu il reste des modifications en attente.
+ * fermer la fenetre tant qu il reste des modifications en attente, et un
+ * flush sur `pagehide` / onglet cache / `isActive=false` (AXE-29).
  *
  * IMPORTANT : `saveFn` est capture **par reference**. Pour qu un changement
  * de `saveFn` soit pris en compte (par exemple si templateId change), il
@@ -31,12 +32,47 @@ export const AUTO_SAVE_INITIAL_STATE = Object.freeze({
 });
 
 /**
+ * Handlers de cycle de vie (testables hors React).
+ * @param {() => { flush: () => Promise<any>, hasPendingChanges: () => boolean, dispose: () => void } | null} getScheduler
+ */
+export function createAutoSaveLifecycleHandlers(getScheduler) {
+  const flushIfAny = () => {
+    const sch = typeof getScheduler === 'function' ? getScheduler() : null;
+    if (!sch) return Promise.resolve();
+    return sch.flush();
+  };
+
+  return {
+    /** Vue Profil quittée (display:none) ou isActive false. */
+    onInactive: flushIfAny,
+    /** Fermeture / navigation navigateur (pagehide). */
+    onPageHide: flushIfAny,
+    /** Onglet passé en arrière-plan. */
+    onVisibilityHidden: () => {
+      if (typeof document !== 'undefined' && document.visibilityState !== 'hidden') {
+        return Promise.resolve();
+      }
+      return flushIfAny();
+    },
+    /** Cleanup React : flush pending puis dispose. */
+    onUnmount: (scheduler) => {
+      if (!scheduler) return Promise.resolve();
+      const flushPromise = scheduler.hasPendingChanges()
+        ? scheduler.flush()
+        : Promise.resolve();
+      return flushPromise.finally(() => scheduler.dispose());
+    },
+  };
+}
+
+/**
  * @param {{
  *   saveFn: (payload: any) => Promise<any>,
  *   delayMs?: number,
  *   maxRetries?: number,
  *   baseRetryDelayMs?: number,
- *   saveFnKey?: any,    // change cette cle pour forcer un re-init du scheduler.
+ *   saveFnKey?: any,
+ *   isActive?: boolean,
  * }} options
  */
 export function useAutoSave({
@@ -45,15 +81,13 @@ export function useAutoSave({
   maxRetries = AUTO_SAVE_DEFAULTS.maxRetries,
   baseRetryDelayMs = AUTO_SAVE_DEFAULTS.baseRetryDelayMs,
   saveFnKey,
+  isActive = true,
 } = {}) {
   const [state, setState] = useState(AUTO_SAVE_INITIAL_STATE);
   const schedulerRef = useRef(null);
   const saveFnRef = useRef(saveFn);
+  const wasActiveRef = useRef(isActive);
 
-  // Synchronise la ref a chaque rerender (en effet pour ne pas violer la
-  // regle React 19 "no ref updates during render"). Le scheduler appelle
-  // toujours `saveFnRef.current(...)`, donc il prend la version la plus
-  // recente sans avoir besoin d etre recree a chaque changement de `saveFn`.
   useEffect(() => {
     saveFnRef.current = saveFn;
   }, [saveFn]);
@@ -70,33 +104,50 @@ export function useAutoSave({
       },
     });
     schedulerRef.current = scheduler;
+    const life = createAutoSaveLifecycleHandlers(() => schedulerRef.current);
     return () => {
       active = false;
-      const flushPromise = scheduler.hasPendingChanges()
-        ? scheduler.flush()
-        : Promise.resolve();
-      void flushPromise.finally(() => scheduler.dispose());
+      void life.onUnmount(scheduler);
       if (schedulerRef.current === scheduler) schedulerRef.current = null;
     };
-    // saveFnKey permet de re-init le scheduler quand la cible de sauvegarde
-    // change (changement de session, de profil, etc.).
   }, [delayMs, maxRetries, baseRetryDelayMs, saveFnKey]);
+
+  // AXE-29 : flush quand la vue Profil devient inactive (App garde le panel monté).
+  useEffect(() => {
+    const life = createAutoSaveLifecycleHandlers(() => schedulerRef.current);
+    const wasActive = wasActiveRef.current;
+    wasActiveRef.current = isActive;
+    if (wasActive && !isActive) {
+      void life.onInactive();
+    }
+  }, [isActive]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return undefined;
-    const handler = (event) => {
+    const life = createAutoSaveLifecycleHandlers(() => schedulerRef.current);
+
+    const onBeforeUnload = (event) => {
       const sch = schedulerRef.current;
       if (!sch || !sch.hasPendingChanges()) return undefined;
-      // Specification : pour qu un navigateur affiche le dialog
-      // "Voulez-vous quitter ?", il faut soit setter returnValue, soit
-      // preventDefault. Chrome ignore le message custom mais affiche son
-      // propre dialog generique.
       event.preventDefault();
       event.returnValue = '';
       return '';
     };
-    window.addEventListener('beforeunload', handler);
-    return () => window.removeEventListener('beforeunload', handler);
+    const onPageHide = () => {
+      void life.onPageHide();
+    };
+    const onVisibility = () => {
+      void life.onVisibilityHidden();
+    };
+
+    window.addEventListener('beforeunload', onBeforeUnload);
+    window.addEventListener('pagehide', onPageHide);
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      window.removeEventListener('beforeunload', onBeforeUnload);
+      window.removeEventListener('pagehide', onPageHide);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
   }, []);
 
   return {

--- a/frontend/tests/unit/useAutoSave.test.js
+++ b/frontend/tests/unit/useAutoSave.test.js
@@ -1,0 +1,152 @@
+/**
+ * Tests AXE-29 : cycle de vie autosave (flush unmount / inactive / pagehide).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createAutoSaveScheduler } from '../../src/lib/autoSaveScheduler.js';
+import { createAutoSaveLifecycleHandlers } from '../../src/lib/useAutoSave.js';
+import { formatPdfExportError } from '../../src/lib/canvasEditorUtils.js';
+
+function createFakeClock() {
+  let currentTime = 1_000_000;
+  const tasks = [];
+  let nextId = 1;
+
+  function setTimeoutFn(cb, ms) {
+    const id = nextId++;
+    tasks.push({ id, cb, runAt: currentTime + ms });
+    return id;
+  }
+
+  function clearTimeoutFn(id) {
+    const idx = tasks.findIndex((t) => t.id === id);
+    if (idx >= 0) tasks.splice(idx, 1);
+  }
+
+  function now() {
+    return currentTime;
+  }
+
+  function advance(ms) {
+    currentTime += ms;
+  }
+
+  async function runDue() {
+    while (true) {
+      const due = tasks
+        .filter((t) => t.runAt <= currentTime)
+        .sort((a, b) => a.runAt - b.runAt);
+      if (due.length === 0) break;
+      const next = due[0];
+      const idx = tasks.indexOf(next);
+      tasks.splice(idx, 1);
+      await next.cb();
+      await new Promise((r) => queueMicrotask(r));
+    }
+  }
+
+  async function runAll(maxAdvanceMs = 60_000) {
+    let safety = 100;
+    while (tasks.length > 0 && safety > 0) {
+      const minTime = Math.min(...tasks.map((t) => t.runAt));
+      const delta = Math.max(0, minTime - currentTime);
+      if (delta > maxAdvanceMs) break;
+      advance(delta);
+      await runDue();
+      safety -= 1;
+    }
+  }
+
+  return { setTimeoutFn, clearTimeoutFn, now, advance, runDue, runAll, tasks };
+}
+
+test('onUnmount flush puis dispose quand des changements sont pending', async () => {
+  const clock = createFakeClock();
+  const calls = [];
+  const scheduler = createAutoSaveScheduler({
+    saveFn: async (payload) => {
+      calls.push(payload);
+    },
+    delayMs: 1500,
+    setTimeoutFn: clock.setTimeoutFn,
+    clearTimeoutFn: clock.clearTimeoutFn,
+    now: clock.now,
+  });
+  const life = createAutoSaveLifecycleHandlers(() => scheduler);
+  scheduler.schedule({ prenom: 'Ada', layout: { version: 3, pages: [{ blocks: [] }] } });
+  assert.equal(scheduler.hasPendingChanges(), true);
+
+  await life.onUnmount(scheduler);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].prenom, 'Ada');
+  assert.equal(scheduler.hasPendingChanges(), false);
+});
+
+test('onInactive flush avant changement de vue (isActive false)', async () => {
+  const clock = createFakeClock();
+  const calls = [];
+  const scheduler = createAutoSaveScheduler({
+    saveFn: async (payload) => {
+      calls.push(payload);
+    },
+    delayMs: 5000,
+    setTimeoutFn: clock.setTimeoutFn,
+    clearTimeoutFn: clock.clearTimeoutFn,
+    now: clock.now,
+  });
+  const life = createAutoSaveLifecycleHandlers(() => scheduler);
+  scheduler.schedule({ nom: 'Lovelace' });
+  await life.onInactive();
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].nom, 'Lovelace');
+});
+
+test('onPageHide flush les changements pending', async () => {
+  const clock = createFakeClock();
+  const calls = [];
+  const scheduler = createAutoSaveScheduler({
+    saveFn: async (payload) => {
+      calls.push(payload);
+    },
+    delayMs: 5000,
+    setTimeoutFn: clock.setTimeoutFn,
+    clearTimeoutFn: clock.clearTimeoutFn,
+    now: clock.now,
+  });
+  const life = createAutoSaveLifecycleHandlers(() => scheduler);
+  scheduler.schedule({ titre: 'Engineer' });
+  await life.onPageHide();
+  assert.equal(calls.length, 1);
+});
+
+test('formatPdfExportError produit un message visible', () => {
+  assert.equal(
+    formatPdfExportError(new Error('Quota dépassé'), ' — autorisez les téléchargements'),
+    'Quota dépassé — autorisez les téléchargements',
+  );
+  assert.equal(formatPdfExportError(null), 'Impossible de telecharger le PDF.');
+});
+
+test('schedule après undo conserve le layout fourni au flush', async () => {
+  const clock = createFakeClock();
+  const calls = [];
+  const scheduler = createAutoSaveScheduler({
+    saveFn: async (payload) => {
+      calls.push(payload);
+    },
+    delayMs: 100,
+    setTimeoutFn: clock.setTimeoutFn,
+    clearTimeoutFn: clock.clearTimeoutFn,
+    now: clock.now,
+  });
+  const layoutAfterUndo = {
+    version: 3,
+    pages: [{ id: 'p1', blocks: [{ id: 't1', type: 'text', content: 'après undo', x: 0, y: 0, w: 10, h: 10, z: 1 }] }],
+  };
+  scheduler.schedule({ prenom: 'Ada', layout: layoutAfterUndo });
+  await scheduler.flush();
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].layout.pages[0].blocks[0].content, 'après undo');
+});


### PR DESCRIPTION
## Summary
- Flush autosave quand la vue Profil devient inactive (`isActive`), au `pagehide` / onglet caché, et à l’unmount.
- Undo/redo planifie un save avec le `layout` post-historique (raccourcis inclus).
- Message d’échec export PDF centralisé (`formatPdfExportError`) + tests lifecycle `useAutoSave`.
- Ajoute `.cursor/BUGBOT.md` pour guider les reviews Bugbot sur ce repo.

Fixes AXE-29
Closes #51

## Bugbot
Activer les reviews auto sur `presidentaxel/Axeljob` dans [Cursor Automations → Bugbot](https://cursor.com/automations/from-cursor/bugbot) (toggle repo, pas `manualTriggerOnly`). Commenter `cursor review` ou `bugbot run` pour un run manuel.

## Test plan
- [ ] Modifier le canvas Beta, naviguer vers Adapter un CV sans attendre → recharger Profil → modif persistée
- [ ] Undo (Ctrl+Z) puis navigation → état après undo sauvegardé
- [ ] Forcer un échec export PDF → bandeau `role="alert"` visible
- [ ] CI verte ; Bugbot commente la PR après activation dashboard


Made with [Cursor](https://cursor.com)