### PR TITLE
feat(AXE-28): démarrage guidé + reset Page blanche fiable

### DIFF
--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -33,8 +33,8 @@ import {
   BLANK_CANVAS_CONTEXT_KEY,
   IMPORTED_CANVAS_CONTEXT_KEY,
   canvasContextLabel,
+  clearCanvasDraft,
   getActiveCanvasContext,
-  getCanvasDraftPrefs,
   listCanvasDrafts,
   loadCanvasDraft,
   saveCanvasDraft,
@@ -66,7 +66,7 @@ import {
   createStarterLayoutV3,
   duplicateBlocks,
   findBlock,
-  isEmptyLayoutV3,
+  layoutPayloadForPersist,
   migrateLayoutToV3,
   moveBlocksBy,
   removeBlocks,
@@ -81,6 +81,7 @@ import {
   isAutoHeightBlockType,
   isSemanticBlockType,
 } from '../../lib/cvLayoutModelV3.js';
+import { isAtsSafe, sortTemplatesForEditor } from '../../lib/editorTemplateUtils.js';
 import { resetTemplateOptionsToDefaults } from '../../lib/templateOptionsSchema.js';
 import { reflowColumnBlocksOnPage } from '../../lib/layoutReflow.js';
 import { moveBlockToPage } from '../../lib/canvasPageTransfer.js';
@@ -222,7 +223,7 @@ function CvEditorBeta({
     };
     const layoutToSave = payload.layout !== undefined ? payload.layout : layoutRef.current;
     if (layoutToSave !== undefined) {
-      body.layout = layoutToSave && !isEmptyLayoutV3(layoutToSave) ? layoutToSave : null;
+      body.layout = layoutPayloadForPersist(layoutToSave);
     }
     return apiPut('/api/cv', body);
   }, [templateId, templateOptions, profileLoadError]);
@@ -272,6 +273,7 @@ function CvEditorBeta({
 
   const openCanvasContext = useCallback((contextKey, nextLayout) => {
     const hydrated = migrateLayoutToV3(nextLayout || createCanvasLayoutBlank());
+    layoutRef.current = hydrated;
     resetLayout(hydrated);
     setSelectedBlockIds([]);
     setEditingBlockId(null);
@@ -282,7 +284,13 @@ function CvEditorBeta({
     setActiveCanvasContext(contextKey);
     saveCanvasDraft(contextKey, hydrated, { label: canvasContextLabel(contextKey, templatesList) });
     refreshCanvasDrafts();
-    if (cv) autoSave.schedule(cv);
+    if (cv) {
+      const payload = { ...cv, layout: layoutPayloadForPersist(hydrated) };
+      autoSave.schedule(payload);
+      // Flush immédiat pour Page blanche / génération (AXE-28) — ne pas
+      // dépendre du debounce avant une navigation.
+      void autoSave.flush();
+    }
   }, [resetLayout, templatesList, refreshCanvasDrafts, cv, autoSave]);
 
   useEffect(() => {
@@ -340,35 +348,49 @@ function CvEditorBeta({
     autoSave.flush();
   }, [autoSave]);
 
-  const requestCanvasContextSwitch = useCallback(({ contextKey, label, baseLayout }) => {
-    if (!contextKey || !baseLayout) return;
-    const currentLayout = layoutRef.current;
-    saveCurrentCanvasDraft();
-    const draft = loadCanvasDraft(contextKey);
-    const targetLayout = resolveTemplateContextLayout(contextKey, baseLayout, draft?.layout);
-    const candidates = currentLayout && contextKey !== activeLayoutContextKey
-      ? detectTransferCandidates(currentLayout, baseLayout)
-      : [];
-    if (getCanvasDraftPrefs().showTransferPrompt && candidates.length > 0) {
-      setTransferRequest({
-        mode: 'switch',
-        contextKey,
-        label,
-        targetLayout,
-        candidates,
-      });
+  const handlePickBlankCanvas = useCallback(() => {
+    // Reset explicite : ignorer le brouillon local et forcer layout null côté API.
+    clearCanvasDraft(BLANK_CANVAS_CONTEXT_KEY);
+    const blank = createBlankLayoutV3();
+    openCanvasContext(BLANK_CANVAS_CONTEXT_KEY, blank);
+  }, [openCanvasContext]);
+
+  const handleChooseAtsSafeTemplate = useCallback(() => {
+    setStartupPromptOpen(false);
+    setSidebarSection('models');
+  }, []);
+
+  const handleGenerateStarterCanvas = useCallback(() => {
+    const templates = templatesList || [];
+    const current = templates.find((t) => t?.id === templateId);
+    const preferred =
+      (current && isAtsSafe(current) ? current : null)
+      || sortTemplatesForEditor(templates).find(isAtsSafe)
+      || current
+      || templates[0];
+
+    if (preferred && cv) {
+      const adapted = buildAdaptedCanvasLayoutForCv(cv, preferred, {
+        templatesList: templates,
+        templateId: preferred.id,
+      }).layout;
+      if (onTemplateIdChange) onTemplateIdChange(preferred.id);
+      openCanvasContext(templateCanvasContextKey(preferred.id), adapted);
       return;
     }
-    openCanvasContext(contextKey, targetLayout);
-  }, [activeLayoutContextKey, saveCurrentCanvasDraft, openCanvasContext]);
 
-  const handlePickBlankCanvas = useCallback(() => {
-    requestCanvasContextSwitch({
-      contextKey: BLANK_CANVAS_CONTEXT_KEY,
-      label: 'Page blanche',
-      baseLayout: createCanvasLayoutBlank(),
-    });
-  }, [requestCanvasContextSwitch]);
+    openCanvasContext(
+      preferred ? templateCanvasContextKey(preferred.id) : BLANK_CANVAS_CONTEXT_KEY,
+      preferred ? buildTemplateCanvasLayout(preferred) : createStarterLayoutV3(),
+    );
+  }, [
+    templatesList,
+    templateId,
+    cv,
+    onTemplateIdChange,
+    openCanvasContext,
+    buildTemplateCanvasLayout,
+  ]);
 
   const applyImportedCvToCanvas = useCallback(async (nextCv, {
     layoutHints = {},
@@ -498,23 +520,6 @@ function CvEditorBeta({
   useEffect(() => () => {
     if (importCleanupRef.current) importCleanupRef.current();
   }, []);
-
-  const handleGenerateStarterCanvas = useCallback(() => {
-    const selectedTemplate = (templatesList || []).find((t) => t?.id === templateId);
-    if (selectedTemplate) {
-      requestCanvasContextSwitch({
-        contextKey: templateCanvasContextKey(selectedTemplate.id),
-        label: selectedTemplate.name || selectedTemplate.id,
-        baseLayout: buildTemplateCanvasLayout(selectedTemplate),
-      });
-      return;
-    }
-    requestCanvasContextSwitch({
-      contextKey: BLANK_CANVAS_CONTEXT_KEY,
-      label: 'Page blanche',
-      baseLayout: createStarterLayoutV3(),
-    });
-  }, [templatesList, templateId, requestCanvasContextSwitch, buildTemplateCanvasLayout]);
 
   const handleAddCanvasPage = useCallback(() => {
     if (!layout || !canAppendBlankPage(layout)) return;
@@ -1411,44 +1416,54 @@ function CvEditorBeta({
               </div>
             )}
             {startupPromptOpen && (
-              <section className="cv-editor-beta-start-panel" aria-label="Demarrer le canvas">
-                <span className="cv-editor-beta-start-panel__eyebrow">Démarrer en Beta</span>
-                <h2>Importez ou générez votre CV visuel</h2>
-                <p>
-                  Importez un PDF/Word pour voir instantanément une mise en page Canva
-                  adaptée à votre profil, ou générez depuis les données déjà enregistrées.
-                </p>
-                <div className="cv-editor-beta-start-panel__actions">
-                  <button
-                    type="button"
-                    className="cv-editor-beta-start-panel__import"
-                    onClick={() => {
-                      clearCanvasSelection();
-                      setImportError('');
-                      setImportModalOpen(true);
-                    }}
-                  >
-                    Importer mon CV
-                  </button>
-                  <button
-                    type="button"
-                    className="cv-editor-beta-start-panel__primary"
-                    onClick={handleGenerateStarterCanvas}
-                  >
-                    Générer depuis mon profil
-                  </button>
-                  <button
-                    type="button"
-                    className="cv-editor-beta-start-panel__secondary"
-                    onClick={handlePickBlankCanvas}
-                  >
-                    Page blanche
-                  </button>
+              <section className="cv-editor-beta-start-panel" role="dialog" aria-modal="true" aria-label="Démarrer le canvas">
+                <div className="cv-editor-beta-start-panel__backdrop" aria-hidden />
+                <div className="cv-editor-beta-start-panel__card">
+                  <span className="cv-editor-beta-start-panel__eyebrow">Démarrer en Beta</span>
+                  <h2>Comment veux-tu commencer ?</h2>
+                  <p>
+                    Ton profil est chargé, mais aucune mise en page canvas n&apos;est encore
+                    enregistrée. Choisis une option pour ne pas rester sur une page vide.
+                  </p>
+                  <div className="cv-editor-beta-start-panel__actions">
+                    <button
+                      type="button"
+                      className="cv-editor-beta-start-panel__primary"
+                      onClick={handleGenerateStarterCanvas}
+                    >
+                      Générer depuis mon profil
+                    </button>
+                    <button
+                      type="button"
+                      className="cv-editor-beta-start-panel__secondary"
+                      onClick={handleChooseAtsSafeTemplate}
+                    >
+                      Choisir un modèle ATS-safe
+                    </button>
+                    <button
+                      type="button"
+                      className="cv-editor-beta-start-panel__import"
+                      onClick={() => {
+                        clearCanvasSelection();
+                        setImportError('');
+                        setImportModalOpen(true);
+                      }}
+                    >
+                      Importer mon CV
+                    </button>
+                    <button
+                      type="button"
+                      className="cv-editor-beta-start-panel__advanced"
+                      onClick={handlePickBlankCanvas}
+                    >
+                      Page blanche (avancé)
+                    </button>
+                  </div>
+                  <p className="cv-editor-beta-start-panel__hint">
+                    « Générer depuis mon profil » crée une mise en page ATS-safe à partir de
+                    tes données. « Page blanche » efface le layout serveur (reload → canvas vide).
+                  </p>
                 </div>
-                <p className="cv-editor-beta-start-panel__hint">
-                  L&apos;import analyse sections, densité et choisit un template - blocs
-                  redimensionnés et vides masqués automatiquement.
-                </p>
               </section>
             )}
             {transferRequest && (

--- a/frontend/src/lib/canvasLayoutDrafts.js
+++ b/frontend/src/lib/canvasLayoutDrafts.js
@@ -103,6 +103,16 @@ export function saveCanvasDraft(contextKey, layout, meta = {}) {
   return entry;
 }
 
+/** Supprime le brouillon local d’un contexte (reset Page blanche AXE-28). */
+export function clearCanvasDraft(contextKey) {
+  const key = String(contextKey || BLANK_CANVAS_CONTEXT_KEY);
+  const drafts = readJson(DRAFTS_STORAGE_KEY, {});
+  if (!(key in drafts)) return false;
+  delete drafts[key];
+  writeJson(DRAFTS_STORAGE_KEY, drafts);
+  return true;
+}
+
 export function listCanvasDrafts(templatesList = []) {
   const drafts = readJson(DRAFTS_STORAGE_KEY, {});
   return Object.values(drafts)

--- a/frontend/src/lib/canvasTemplateRestore.js
+++ b/frontend/src/lib/canvasTemplateRestore.js
@@ -81,8 +81,9 @@ export function mergeTemplateBaseWithDraft(baseLayout, draftLayout) {
   });
 }
 
-export function resolveTemplateContextLayout(contextKey, baseLayout, draftLayout) {
-  if (!draftLayout) return baseLayout;
+export function resolveTemplateContextLayout(contextKey, baseLayout, draftLayout, options = {}) {
+  const { forceBase = false } = options;
+  if (forceBase || !draftLayout) return baseLayout;
   if (String(contextKey || '').startsWith('template:')) {
     return mergeTemplateBaseWithDraft(baseLayout, draftLayout);
   }

--- a/frontend/src/lib/cvLayoutModelV3.js
+++ b/frontend/src/lib/cvLayoutModelV3.js
@@ -454,6 +454,16 @@ export function isEmptyLayoutV3(layout) {
   return layout.pages.every((p) => !p || !Array.isArray(p.blocks) || p.blocks.length === 0);
 }
 
+/**
+ * Valeur `layout` à envoyer au PUT /api/cv (AXE-28).
+ * Layout vide → `null` (reset explicite) ; sinon objet v3.
+ */
+export function layoutPayloadForPersist(layout) {
+  if (layout === undefined) return undefined;
+  if (!layout || isEmptyLayoutV3(layout)) return null;
+  return layout;
+}
+
 // ---------------------------------------------------------------------------
 // Operations pures sur les blocs
 // ---------------------------------------------------------------------------

--- a/frontend/src/styles/CvEditorBeta.css
+++ b/frontend/src/styles/CvEditorBeta.css
@@ -317,11 +317,24 @@
 
 .cv-editor-beta-start-panel {
   position: absolute;
-  top: 50%;
-  left: 50%;
+  inset: 0;
   z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto;
+}
+
+.cv-editor-beta-start-panel__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(238, 236, 231, 0.88);
+}
+
+.cv-editor-beta-start-panel__card {
+  position: relative;
+  z-index: 1;
   width: min(92%, 440px);
-  transform: translate(-50%, -50%);
   padding: 1.5rem;
   background: var(--color-canvas);
   border: 1px solid var(--color-card-border);
@@ -365,13 +378,26 @@
 }
 
 .cv-editor-beta-start-panel__primary,
-.cv-editor-beta-start-panel__secondary {
+.cv-editor-beta-start-panel__secondary,
+.cv-editor-beta-start-panel__import,
+.cv-editor-beta-start-panel__advanced {
   border-radius: 32px;
   padding: 0.62rem 1.1rem;
   font-family: var(--editor-font-family);
   font-size: 0.84rem;
   font-weight: 500;
   cursor: pointer;
+}
+
+.cv-editor-beta-start-panel__import {
+  border: 1px solid var(--color-hairline);
+  background: var(--color-soft-stone);
+  color: var(--color-ink);
+}
+
+.cv-editor-beta-start-panel__import:hover {
+  border-color: var(--color-primary);
+  background: var(--color-canvas);
 }
 
 .cv-editor-beta-start-panel__primary {
@@ -393,6 +419,19 @@
 
 .cv-editor-beta-start-panel__secondary:hover {
   background: var(--color-soft-stone);
+}
+
+.cv-editor-beta-start-panel__advanced {
+  border: none;
+  background: transparent;
+  color: var(--color-slate);
+  text-decoration: underline;
+  padding-left: 0.35rem;
+  padding-right: 0.35rem;
+}
+
+.cv-editor-beta-start-panel__advanced:hover {
+  color: var(--color-ink);
 }
 
 .cv-editor-beta-start-panel__hint {

--- a/frontend/tests/unit/canvasLayoutDrafts.test.js
+++ b/frontend/tests/unit/canvasLayoutDrafts.test.js
@@ -5,6 +5,7 @@ import {
   BLANK_CANVAS_CONTEXT_KEY,
   IMPORTED_CANVAS_CONTEXT_KEY,
   canvasContextLabel,
+  clearCanvasDraft,
   getActiveCanvasContext,
   getCanvasDraftPrefs,
   listCanvasDrafts,
@@ -73,4 +74,12 @@ test('canvasContextLabel utilise les noms de templates', () => {
     canvasContextLabel('template:modern', [{ id: 'modern', name: 'Moderne' }]),
     'Moderne',
   );
+});
+
+test('clearCanvasDraft supprime un brouillon local (reset Page blanche)', () => {
+  saveCanvasDraft(BLANK_CANVAS_CONTEXT_KEY, { pages: [{ blocks: [] }] }, { label: 'Blank' });
+  assert.ok(loadCanvasDraft(BLANK_CANVAS_CONTEXT_KEY));
+  assert.equal(clearCanvasDraft(BLANK_CANVAS_CONTEXT_KEY), true);
+  assert.equal(loadCanvasDraft(BLANK_CANVAS_CONTEXT_KEY), null);
+  assert.equal(clearCanvasDraft(BLANK_CANVAS_CONTEXT_KEY), false);
 });

--- a/frontend/tests/unit/canvasTemplateRestore.test.js
+++ b/frontend/tests/unit/canvasTemplateRestore.test.js
@@ -64,3 +64,10 @@ test('resolveTemplateContextLayout fusionne pour template:* seulement', () => {
   const untouched = resolveTemplateContextLayout('imported', base, draft);
   assert.equal(untouched.pages[0].blocks.length, draft.pages[0].blocks.length);
 });
+
+test('resolveTemplateContextLayout forceBase ignore le brouillon', () => {
+  const base = createCanvasLayoutForTemplate(template);
+  const draft = { ...base, pages: [{ ...base.pages[0], blocks: [] }] };
+  const forced = resolveTemplateContextLayout('template:modern', base, draft, { forceBase: true });
+  assert.equal(forced, base);
+});

--- a/frontend/tests/unit/cvLayoutModelV3.test.js
+++ b/frontend/tests/unit/cvLayoutModelV3.test.js
@@ -43,6 +43,7 @@ import {
   isAutoHeightBlockType,
   isNonSemanticBlockType,
   isSemanticBlockType,
+  layoutPayloadForPersist,
   listAllBlocks,
   migrateLayoutToV3,
   moveBlockBy,
@@ -295,6 +296,14 @@ test('isEmptyLayoutV3 : true sur blank, false sur starter', () => {
   assert.equal(isEmptyLayoutV3(createBlankLayoutV3({ idHelpers })), true);
   assert.equal(isEmptyLayoutV3(createStarterLayoutV3({ idHelpers })), false);
   assert.equal(isEmptyLayoutV3(null), true);
+});
+
+test('layoutPayloadForPersist : undefined / null / empty → null pour reset API', () => {
+  assert.equal(layoutPayloadForPersist(undefined), undefined);
+  assert.equal(layoutPayloadForPersist(null), null);
+  assert.equal(layoutPayloadForPersist(createBlankLayoutV3({ idHelpers })), null);
+  const starter = createStarterLayoutV3({ idHelpers });
+  assert.equal(layoutPayloadForPersist(starter), starter);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Écran de démarrage modal (backdrop) quand un CV a du contenu mais pas de `layout` : Générer depuis mon profil, Choisir un modèle ATS-safe, Importer, Page blanche (avancé).
- « Page blanche » purge le brouillon local, persiste `layout: null` via `layoutPayloadForPersist` + flush immédiat autosave.
- « Générer depuis mon profil » utilise le même pipeline ATS-safe que l’application de template (`buildAdaptedCanvasLayoutForCv`).

Fixes AXE-28
Closes #53

## Test plan
- [ ] Ouvrir l’éditeur Beta avec un profil chargé et sans layout → overlay de choix, canvas non utilisable derrière
- [ ] « Générer depuis mon profil » → layout ATS-safe rempli, overlay fermé, reload conserve le layout
- [ ] « Choisir un modèle ATS-safe » → sidebar Modèles, appliquer un template
- [ ] « Page blanche (avancé) » → canvas vide ; reload → overlay de nouveau ; `GET /api/cv` sans layout / layout null
- [ ] Tests unitaires : `clearCanvasDraft`, `layoutPayloadForPersist`, `forceBase` ; backend `test_cv_layout_persistence.py` (déjà couvert)


Made with [Cursor](https://cursor.com)