### PR TITLE
feat(AXE-31): refonte sidebar Sections CV / Design / Importer / Position

### DIFF
--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -147,7 +147,7 @@ function CvEditorBeta({
   const [showCanvasGrid, setShowCanvasGrid] = useState(false);
   const [canvasSnapEnabled, setCanvasSnapEnabled] = useState(true);
   const [imageEditBlockId, setImageEditBlockId] = useState(null);
-  const [sidebarSection, setSidebarSection] = useState('elements');
+  const [sidebarSection, setSidebarSection] = useState('sections');
   const [placementPreset, setPlacementPreset] = useState(null);
   const [startupPromptOpen, setStartupPromptOpen] = useState(false);
   const [pdfExportError, setPdfExportError] = useState('');
@@ -370,7 +370,7 @@ function CvEditorBeta({
 
   const handleChooseAtsSafeTemplate = useCallback(() => {
     setStartupPromptOpen(false);
-    setSidebarSection('models');
+    setSidebarSection('design');
   }, []);
 
   const handleGenerateStarterCanvas = useCallback(() => {

--- a/frontend/src/components/editor/EditorCanvaSidebar.jsx
+++ b/frontend/src/components/editor/EditorCanvaSidebar.jsx
@@ -93,7 +93,10 @@ function ImageHistoryTile({ entry, disabled, onBeginPlacement, onRemove }) {
         draggable={!disabled}
         title={entry.label || 'Glisser sur le canevas ou cliquer pour placer'}
         onPointerDown={onPointerDown}
-        onClick={(e) => e.preventDefault()}
+        onClick={(e) => {
+          e.preventDefault();
+          if (e.detail === 0 && !disabled && preset) onBeginPlacement?.(preset);
+        }}
         onDragStart={onDragStart}
       >
         <span className="editor-canva-image-history__thumb-label" aria-hidden>
@@ -115,11 +118,16 @@ function ImageHistoryTile({ entry, disabled, onBeginPlacement, onRemove }) {
 }
 
 function PlacementTile({ disabled, preset, onBeginPlacement, className, title, children }) {
+  const startPlacement = () => {
+    if (!disabled && preset) onBeginPlacement?.(preset);
+  };
+
   const onPointerDown = (e) => {
     if (disabled || !preset) return;
     e.preventDefault();
-    onBeginPlacement?.(preset);
+    startPlacement();
   };
+
   return (
     <button
       type="button"
@@ -127,7 +135,11 @@ function PlacementTile({ disabled, preset, onBeginPlacement, className, title, c
       disabled={disabled}
       title={title}
       onPointerDown={onPointerDown}
-      onClick={(e) => e.preventDefault()}
+      onClick={(e) => {
+        e.preventDefault();
+        // Entrée / Espace : detail === 0 (pas un clic pointeur).
+        if (e.detail === 0) startPlacement();
+      }}
     >
       {children}
     </button>
@@ -271,7 +283,7 @@ export default function EditorCanvaSidebar({
           Cliquez sur le canevas pour placer l’élément · Échap pour annuler
         </p>
       )}
-      <nav className="editor-canva-rail" role="tablist" aria-label="Familles d’outils">
+      <nav className="editor-canva-rail" aria-label="Familles d’outils">
         {SECTIONS.map((section) => {
           const Icon = section.icon;
           const active = railActiveId === section.id;
@@ -279,8 +291,7 @@ export default function EditorCanvaSidebar({
             <button
               key={section.id}
               type="button"
-              role="tab"
-              aria-selected={active}
+              aria-current={active ? 'true' : undefined}
               className={active ? 'editor-canva-rail__btn editor-canva-rail__btn--active' : 'editor-canva-rail__btn'}
               title={section.label}
               onClick={() => toggleSection(section.id)}
@@ -297,7 +308,6 @@ export default function EditorCanvaSidebar({
             'editor-canva-drawer',
             openSection === 'fonts' ? 'editor-canva-drawer--fill' : '',
           ].filter(Boolean).join(' ')}
-          role="tabpanel"
         >
           {openSection === 'sections' && (
             <>
@@ -329,15 +339,14 @@ export default function EditorCanvaSidebar({
           {showDesignDrawer && (
             <>
               <h3 className="editor-canva-drawer__title">Design</h3>
-              <div className="editor-canva-design-tabs" role="tablist" aria-label="Sous-sections Design">
+              <div className="editor-canva-design-tabs" role="group" aria-label="Sous-sections Design">
                 {DESIGN_TABS.map((tab) => {
                   const active = effectiveDesignTab === tab.id;
                   return (
                     <button
                       key={tab.id}
                       type="button"
-                      role="tab"
-                      aria-selected={active}
+                      aria-pressed={active}
                       className={
                         active
                           ? 'editor-canva-design-tabs__btn editor-canva-design-tabs__btn--active'

--- a/frontend/src/components/editor/EditorCanvaSidebar.jsx
+++ b/frontend/src/components/editor/EditorCanvaSidebar.jsx
@@ -2,12 +2,9 @@ import { useEffect, useRef, useState } from 'react';
 import {
   HiArrowUpTray,
   HiArrowsPointingOut,
-  HiDocumentDuplicate,
-  HiSparkles,
-  HiSquares2X2,
+  HiDocumentText,
   HiSwatch,
   HiTrash,
-  HiWrench,
 } from 'react-icons/hi2';
 import { uploadCanvasImageFile } from '../../lib/uploadCanvasAsset.js';
 import {
@@ -22,8 +19,13 @@ import { CANVAS_ICON_ENTRIES, createIconBlockPreset } from '../../lib/canvasIcon
 import { ELEMENT_SHAPE_ITEMS, createShapeBlockPreset } from '../../lib/canvasShapePresets.js';
 import { TEXT_PRESET_ITEMS, createTextBlockPreset } from '../../lib/canvasTextPresets.js';
 import {
+  CV_SECTION_ITEMS,
+  createCvSectionBlockPreset,
+} from '../../lib/canvasCvSectionPresets.js';
+import {
   createImageBlockPreset,
 } from '../../lib/freeCanvasBlockPresets.js';
+import { listAllBlocks } from '../../lib/cvLayoutModelV3.js';
 import CanvasShapeSvg from './CanvasShapeSvg.jsx';
 import {
   EditorCanvaColorPanel,
@@ -37,19 +39,35 @@ import EditorCanvaPositionDrawer from './EditorCanvaPositionDrawer.jsx';
 import TemplateMiniPreview from './TemplateMiniPreview.jsx';
 import '../../styles/EditorCanvaSidebar.css';
 
+/** Rail principal AXE-31 : 4 familles guidantes. */
 const SECTIONS = [
-  { id: 'models', label: 'Modèles', icon: HiDocumentDuplicate },
-  { id: 'elements', label: 'Éléments', icon: HiSquares2X2 },
-  { id: 'text', label: 'Texte', icon: HiSwatch },
-  { id: 'icons', label: 'Icônes', icon: HiSparkles },
-  { id: 'import', label: 'Image', icon: HiArrowUpTray },
+  { id: 'sections', label: 'Sections CV', icon: HiDocumentText },
+  { id: 'design', label: 'Design', icon: HiSwatch },
+  { id: 'import', label: 'Importer', icon: HiArrowUpTray },
   { id: 'position', label: 'Position', icon: HiArrowsPointingOut },
-  { id: 'tools', label: 'Outils', icon: HiWrench },
+];
+
+const DESIGN_TABS = [
+  { id: 'models', label: 'Modèles' },
+  { id: 'decoration', label: 'Décoration' },
+  { id: 'tools', label: 'Outils' },
 ];
 
 const TEXT_PRESETS = TEXT_PRESET_ITEMS;
 
 const STYLE_PANEL_SECTIONS = new Set(['fonts', 'colors', 'effects', 'shape-style']);
+const RAIL_SECTION_IDS = new Set(SECTIONS.map((s) => s.id));
+
+function layoutHasContent(layout) {
+  return listAllBlocks(layout).length > 0;
+}
+
+function confirmDestructive(message) {
+  if (typeof window === 'undefined' || typeof window.confirm !== 'function') {
+    return true;
+  }
+  return window.confirm(message);
+}
 
 function ImageHistoryTile({ entry, disabled, onBeginPlacement, onRemove }) {
   const safeSrc = toSafeCanvasImageSrc(entry?.dataUrl);
@@ -118,7 +136,7 @@ function PlacementTile({ disabled, preset, onBeginPlacement, className, title, c
 
 export default function EditorCanvaSidebar({
   disabled = false,
-  openSection = 'elements',
+  openSection = 'sections',
   onOpenSectionChange,
   placementActive = false,
   templatesList = [],
@@ -152,6 +170,7 @@ export default function EditorCanvaSidebar({
   const [iconColor, setIconColor] = useState('#1e293b');
   const [importing, setImporting] = useState(false);
   const [transferSourceKey, setTransferSourceKey] = useState('');
+  const [designTab, setDesignTab] = useState('models');
   const fileInputRef = useRef(null);
 
   const refreshProposals = () => setProposals(listLayoutProposals());
@@ -166,11 +185,54 @@ export default function EditorCanvaSidebar({
     refreshImageHistory();
   }, [openSection, layout]);
 
+  const prevSectionRef = useRef(openSection);
+  useEffect(() => {
+    const prev = prevSectionRef.current;
+    prevSectionRef.current = openSection;
+    const wasDesign = prev === 'design' || prev === 'models';
+    const isDesign = openSection === 'design' || openSection === 'models';
+    if (openSection === 'models' || (isDesign && !wasDesign)) {
+      setDesignTab('models');
+    }
+  }, [openSection]);
+
   const handleSaveProposal = () => {
     if (typeof onSaveProposal !== 'function') return;
     onSaveProposal(proposalName.trim() || 'mon modèle');
     setProposalName('');
     refreshProposals();
+  };
+
+  const handlePickBlankSafe = () => {
+    if (layoutHasContent(layout)) {
+      const ok = confirmDestructive(
+        'Remplacer le canvas actuel par une page blanche ? Les blocs présents seront retirés de cette vue (le CV de base n’est pas effacé).',
+      );
+      if (!ok) return;
+    }
+    onPickBlank?.();
+  };
+
+  const handleApplyTemplateSafe = (template) => {
+    if (!template) return;
+    if (layoutHasContent(layout)) {
+      const name = template.name || template.id || 'ce modèle';
+      const ok = confirmDestructive(
+        `Appliquer le modèle « ${name} » ? La mise en page actuelle de ce canvas sera remplacée (brouillon local sauvegardé si possible).`,
+      );
+      if (!ok) return;
+    }
+    onApplyCanvasTemplate?.(template);
+  };
+
+  const handleLoadProposalSafe = (proposalLayout) => {
+    if (layoutHasContent(layout)) {
+      const ok = confirmDestructive(
+        'Appliquer cette proposition locale ? La mise en page actuelle de ce canvas sera remplacée.',
+      );
+      if (!ok) return;
+    }
+    onLoadProposal?.(proposalLayout);
   };
 
   const handleImageFile = async (e) => {
@@ -195,6 +257,13 @@ export default function EditorCanvaSidebar({
     onOpenSectionChange?.(openSection === id ? null : id);
   };
 
+  const railActiveId = RAIL_SECTION_IDS.has(openSection)
+    ? openSection
+    : (STYLE_PANEL_SECTIONS.has(openSection) ? null : openSection);
+
+  const showDesignDrawer = openSection === 'design' || openSection === 'models';
+  const effectiveDesignTab = openSection === 'models' ? 'models' : designTab;
+
   return (
     <aside className={`editor-canva-shell${placementActive ? ' editor-canva-shell--placing' : ''}`} aria-label="Outils canvas">
       {placementActive && (
@@ -202,10 +271,10 @@ export default function EditorCanvaSidebar({
           Cliquez sur le canevas pour placer l’élément · Échap pour annuler
         </p>
       )}
-      <nav className="editor-canva-rail" role="tablist">
+      <nav className="editor-canva-rail" role="tablist" aria-label="Familles d’outils">
         {SECTIONS.map((section) => {
           const Icon = section.icon;
-          const active = openSection === section.id;
+          const active = railActiveId === section.id;
           return (
             <button
               key={section.id}
@@ -226,132 +295,270 @@ export default function EditorCanvaSidebar({
         <div
           className={[
             'editor-canva-drawer',
-            openSection === 'text' || openSection === 'fonts' ? 'editor-canva-drawer--fill' : '',
+            openSection === 'fonts' ? 'editor-canva-drawer--fill' : '',
           ].filter(Boolean).join(' ')}
           role="tabpanel"
         >
-          {openSection === 'models' && (
+          {openSection === 'sections' && (
             <>
-              <button
-                type="button"
-                className="editor-canva-drawer__btn editor-canva-drawer__btn--primary editor-canva-drawer__btn--full"
-                disabled={disabled}
-                onClick={onPickBlank}
-              >
-                Page blanche
-              </button>
-              <button
-                type="button"
-                className="editor-canva-drawer__btn editor-canva-drawer__btn--full"
-                disabled={disabled}
-                onClick={handleSaveProposal}
-              >
-                Enregistrer les modifs
-              </button>
-              <input
-                type="text"
-                className="editor-canva-drawer__input"
-                placeholder="Nom"
-                value={proposalName}
-                onChange={(ev) => setProposalName(ev.target.value)}
-              />
-              <h4 className="editor-canva-drawer__subtitle">Modèles CV</h4>
+              <h3 className="editor-canva-drawer__title">Sections CV</h3>
               <p className="editor-canva-drawer__hint editor-canva-drawer__hint--subtle">
-                Le CV affiché est enregistré sur ton compte. Chaque autre modèle
-                garde un brouillon local sur ce navigateur (non synchronisé entre
-                appareils).
+                Blocs liés à ton CV de base (contenu partagé avec le mode Stable). Clique puis place sur le canevas.
               </p>
-              <div className="editor-canva-template-grid">
-                {(templatesList || []).map((t) => {
-                  if (!t?.id) return null;
+              <div className="editor-canva-drawer__grid editor-canva-drawer__grid--sections">
+                {CV_SECTION_ITEMS.map((item) => {
+                  const preset = createCvSectionBlockPreset(item.type);
+                  return (
+                    <PlacementTile
+                      key={item.type}
+                      disabled={disabled}
+                      preset={preset}
+                      onBeginPlacement={onBeginPlacement}
+                      className="editor-canva-drawer__tile editor-canva-drawer__tile--section"
+                      title={item.description}
+                    >
+                      <span className="editor-canva-drawer__tile-label">{item.label}</span>
+                      <span className="editor-canva-drawer__tile-hint">{item.description}</span>
+                    </PlacementTile>
+                  );
+                })}
+              </div>
+            </>
+          )}
+
+          {showDesignDrawer && (
+            <>
+              <h3 className="editor-canva-drawer__title">Design</h3>
+              <div className="editor-canva-design-tabs" role="tablist" aria-label="Sous-sections Design">
+                {DESIGN_TABS.map((tab) => {
+                  const active = effectiveDesignTab === tab.id;
                   return (
                     <button
-                      key={t.id}
+                      key={tab.id}
                       type="button"
-                      className="editor-canva-template-card"
-                      disabled={disabled}
-                      title={t.description || t.name}
-                      onClick={() => onApplyCanvasTemplate?.(t)}
+                      role="tab"
+                      aria-selected={active}
+                      className={
+                        active
+                          ? 'editor-canva-design-tabs__btn editor-canva-design-tabs__btn--active'
+                          : 'editor-canva-design-tabs__btn'
+                      }
+                      onClick={() => {
+                        setDesignTab(tab.id);
+                        if (openSection !== 'design') onOpenSectionChange?.('design');
+                      }}
                     >
-                      <span className="editor-canva-template-card__thumb">
-                        <TemplateMiniPreview templateId={t.id} />
-                      </span>
-                      <span className="editor-canva-template-card__name">{t.name || t.id}</span>
+                      {tab.label}
                     </button>
                   );
                 })}
               </div>
-              {proposals.length > 0 && (
+
+              {effectiveDesignTab === 'models' && (
                 <>
-                  <h4 className="editor-canva-drawer__subtitle">Mes propositions</h4>
-                  {proposals.map((p) => (
-                    <div key={p.id} className="editor-canva-drawer__proposal">
-                      <strong>{p.name}</strong>
-                      <div className="editor-canva-drawer__proposal-actions">
-                        <button type="button" disabled={disabled} onClick={() => onLoadProposal?.(p.layout)}>Appliquer</button>
-                        <button type="button" onClick={() => { deleteLayoutProposal(p.id); refreshProposals(); }}>×</button>
-                      </div>
-                    </div>
-                  ))}
+                  <p className="editor-canva-drawer__hint editor-canva-drawer__hint--subtle">
+                    Choisis un modèle pour structurer la page. Les actions ci-dessous remplacent la mise en page du canvas.
+                  </p>
+                  <button
+                    type="button"
+                    className="editor-canva-drawer__btn editor-canva-drawer__btn--full"
+                    disabled={disabled}
+                    onClick={handlePickBlankSafe}
+                  >
+                    Page blanche
+                  </button>
+                  <button
+                    type="button"
+                    className="editor-canva-drawer__btn editor-canva-drawer__btn--full"
+                    disabled={disabled}
+                    onClick={handleSaveProposal}
+                    title="Enregistre une proposition de mise en page sur ce navigateur uniquement (pas le CV cloud)."
+                  >
+                    Sauver la mise en page (local)
+                  </button>
+                  <input
+                    type="text"
+                    className="editor-canva-drawer__input"
+                    placeholder="Nom de la proposition locale"
+                    value={proposalName}
+                    onChange={(ev) => setProposalName(ev.target.value)}
+                    aria-label="Nom de la proposition locale"
+                  />
+                  <h4 className="editor-canva-drawer__subtitle">Modèles CV</h4>
+                  <p className="editor-canva-drawer__hint editor-canva-drawer__hint--subtle">
+                    Le CV affiché est enregistré sur ton compte. Chaque autre modèle
+                    garde un brouillon local sur ce navigateur (non synchronisé entre
+                    appareils).
+                  </p>
+                  <div className="editor-canva-template-grid">
+                    {(templatesList || []).map((t) => {
+                      if (!t?.id) return null;
+                      return (
+                        <button
+                          key={t.id}
+                          type="button"
+                          className="editor-canva-template-card"
+                          disabled={disabled}
+                          title={t.description || t.name}
+                          onClick={() => handleApplyTemplateSafe(t)}
+                        >
+                          <span className="editor-canva-template-card__thumb">
+                            <TemplateMiniPreview templateId={t.id} />
+                          </span>
+                          <span className="editor-canva-template-card__name">{t.name || t.id}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                  {proposals.length > 0 && (
+                    <>
+                      <h4 className="editor-canva-drawer__subtitle">Mes propositions locales</h4>
+                      {proposals.map((p) => (
+                        <div key={p.id} className="editor-canva-drawer__proposal">
+                          <strong>{p.name}</strong>
+                          <div className="editor-canva-drawer__proposal-actions">
+                            <button
+                              type="button"
+                              disabled={disabled}
+                              onClick={() => handleLoadProposalSafe(p.layout)}
+                            >
+                              Appliquer
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => {
+                                deleteLayoutProposal(p.id);
+                                refreshProposals();
+                              }}
+                            >
+                              ×
+                            </button>
+                          </div>
+                        </div>
+                      ))}
+                    </>
+                  )}
+                </>
+              )}
+
+              {effectiveDesignTab === 'decoration' && (
+                <>
+                  <p className="editor-canva-drawer__hint editor-canva-drawer__hint--subtle">
+                    Éléments décoratifs (non liés au contenu CV). Pour ajouter du contenu métier, utilise « Sections CV ».
+                  </p>
+                  <h4 className="editor-canva-drawer__subtitle">Formes</h4>
+                  <div className="editor-canva-drawer__shape-grid">
+                    {ELEMENT_SHAPE_ITEMS.map((item) => {
+                      const preset = createShapeBlockPreset(item.type);
+                      return (
+                        <PlacementTile
+                          key={item.type}
+                          disabled={disabled}
+                          preset={preset}
+                          onBeginPlacement={onBeginPlacement}
+                          className="editor-canva-drawer__shape-tile"
+                          title={item.label}
+                        >
+                          <span className="editor-canva-drawer__shape-preview">
+                            <CanvasShapeSvg type={item.type} style={preset?.style} preview />
+                          </span>
+                          <span className="editor-canva-drawer__shape-label">{item.label}</span>
+                        </PlacementTile>
+                      );
+                    })}
+                  </div>
+                  <h4 className="editor-canva-drawer__subtitle">Texte libre</h4>
+                  <div className="editor-canva-drawer__grid">
+                    {TEXT_PRESETS.map((item) => {
+                      const preset = createTextBlockPreset(item.type);
+                      return (
+                        <PlacementTile
+                          key={item.type}
+                          disabled={disabled}
+                          preset={preset}
+                          onBeginPlacement={onBeginPlacement}
+                          className="editor-canva-drawer__tile"
+                        >
+                          {item.label}
+                        </PlacementTile>
+                      );
+                    })}
+                  </div>
+                  {selectedBlock && onBlockStylePatch && (
+                    <>
+                      <h4 className="editor-canva-drawer__subtitle">Police</h4>
+                      <EditorCanvaFontPanel
+                        block={selectedBlock}
+                        onBlockStylePatch={onBlockStylePatch}
+                        fontFamilies={fontFamilies}
+                      />
+                    </>
+                  )}
+                  <h4 className="editor-canva-drawer__subtitle">Icônes</h4>
+                  <label className="editor-canva-drawer__field editor-canva-drawer__field--row">
+                    Couleur
+                    <input type="color" value={iconColor} onChange={(e) => setIconColor(e.target.value)} />
+                  </label>
+                  <div className="editor-canva-icon-grid">
+                    {CANVAS_ICON_ENTRIES.map((entry) => (
+                      <PlacementTile
+                        key={entry.name}
+                        disabled={disabled}
+                        preset={createIconBlockPreset(entry.name, iconColor)}
+                        onBeginPlacement={onBeginPlacement}
+                        className="editor-canva-icon-tile"
+                        title={entry.label}
+                      >
+                        <CanvasIconGlyph name={entry.name} color={iconColor} size={22} />
+                      </PlacementTile>
+                    ))}
+                  </div>
+                </>
+              )}
+
+              {effectiveDesignTab === 'tools' && (
+                <>
+                  <h4 className="editor-canva-drawer__subtitle">Aide à la composition</h4>
+                  <label className="editor-canva-drawer__toggle">
+                    <input type="checkbox" checked={showGrid} onChange={(e) => onShowGridChange?.(e.target.checked)} />
+                    Afficher la grille
+                  </label>
+                  <label className="editor-canva-drawer__toggle">
+                    <input type="checkbox" checked={snapEnabled} onChange={(e) => onSnapEnabledChange?.(e.target.checked)} />
+                    Magnétisme (snap)
+                  </label>
+                  <h4 className="editor-canva-drawer__subtitle">Transfert</h4>
+                  <p className="editor-canva-drawer__hint editor-canva-drawer__hint--subtle">
+                    Ajoutez des éléments depuis un autre brouillon sans remplacer ce canvas.
+                  </p>
+                  <label className="editor-canva-drawer__field">
+                    Brouillon source
+                    <select
+                      value={transferSourceKey}
+                      onChange={(e) => setTransferSourceKey(e.target.value)}
+                      disabled={disabled || transferDraftOptions.length === 0}
+                    >
+                      <option value="">Choisir un brouillon</option>
+                      {transferDraftOptions.map((draft) => (
+                        <option key={draft.contextKey} value={draft.contextKey}>
+                          {draft.label || draft.contextKey}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <button
+                    type="button"
+                    className="editor-canva-drawer__btn editor-canva-drawer__btn--full"
+                    disabled={disabled || !transferSourceKey}
+                    onClick={() => onOpenTransferFromDraft?.(transferSourceKey)}
+                  >
+                    Transférer des éléments
+                  </button>
                 </>
               )}
             </>
           )}
-          {openSection === 'elements' && (
-            <>
-              <h3 className="editor-canva-drawer__title">Éléments</h3>
-              <p className="editor-canva-drawer__hint editor-canva-drawer__hint--subtle">
-                Formes vectorielles - cliquez puis placez sur le canevas.
-              </p>
-              <div className="editor-canva-drawer__shape-grid">
-                {ELEMENT_SHAPE_ITEMS.map((item) => {
-                  const preset = createShapeBlockPreset(item.type);
-                  return (
-                    <PlacementTile
-                      key={item.type}
-                      disabled={disabled}
-                      preset={preset}
-                      onBeginPlacement={onBeginPlacement}
-                      className="editor-canva-drawer__shape-tile"
-                      title={item.label}
-                    >
-                      <span className="editor-canva-drawer__shape-preview">
-                        <CanvasShapeSvg type={item.type} style={preset?.style} preview />
-                      </span>
-                      <span className="editor-canva-drawer__shape-label">{item.label}</span>
-                    </PlacementTile>
-                  );
-                })}
-              </div>
-            </>
-          )}
-          {openSection === 'text' && (
-            <>
-              <h3 className="editor-canva-drawer__title">Texte</h3>
-              <div className="editor-canva-drawer__grid">
-                {TEXT_PRESETS.map((item) => {
-                  const preset = createTextBlockPreset(item.type);
-                  return (
-                    <PlacementTile
-                      key={item.type}
-                      disabled={disabled}
-                      preset={preset}
-                      onBeginPlacement={onBeginPlacement}
-                      className="editor-canva-drawer__tile"
-                    >
-                      {item.label}
-                    </PlacementTile>
-                  );
-                })}
-              </div>
-              {selectedBlock && onBlockStylePatch && (
-                <>
-                  <h4 className="editor-canva-drawer__subtitle">Police</h4>
-                  <EditorCanvaFontPanel block={selectedBlock} onBlockStylePatch={onBlockStylePatch} fontFamilies={fontFamilies} />
-                </>
-              )}
-            </>
-          )}
+
           {openSection === 'fonts' && selectedBlock && (
             <EditorCanvaFontPanel block={selectedBlock} onBlockStylePatch={onBlockStylePatch} fontFamilies={fontFamilies} />
           )}
@@ -367,34 +574,12 @@ export default function EditorCanvaSidebar({
           {STYLE_PANEL_SECTIONS.has(openSection) && !selectedBlock && (
             <p className="editor-canva-drawer__hint">Sélectionnez un bloc pour modifier son style.</p>
           )}
-          {openSection === 'icons' && (
-            <>
-              <h3 className="editor-canva-drawer__title">Icônes</h3>
-              <label className="editor-canva-drawer__field editor-canva-drawer__field--row">
-                Couleur
-                <input type="color" value={iconColor} onChange={(e) => setIconColor(e.target.value)} />
-              </label>
-              <div className="editor-canva-icon-grid">
-                {CANVAS_ICON_ENTRIES.map((entry) => (
-                  <PlacementTile
-                    key={entry.name}
-                    disabled={disabled}
-                    preset={createIconBlockPreset(entry.name, iconColor)}
-                    onBeginPlacement={onBeginPlacement}
-                    className="editor-canva-icon-tile"
-                    title={entry.label}
-                  >
-                    <CanvasIconGlyph name={entry.name} color={iconColor} size={22} />
-                  </PlacementTile>
-                ))}
-              </div>
-            </>
-          )}
+
           {openSection === 'import' && (
             <>
-              <h3 className="editor-canva-drawer__title">Image</h3>
+              <h3 className="editor-canva-drawer__title">Importer une image</h3>
               <p className="editor-canva-drawer__hint editor-canva-drawer__hint--subtle">
-                Importez une image, puis placez-la sur le canevas par glisser-déposer ou en cliquant sur une vignette.
+                Images décoratives uniquement (PNG, JPG…). L’import d’un CV PDF ou Word n’est pas encore disponible ici.
               </p>
               <button
                 type="button"
@@ -426,6 +611,7 @@ export default function EditorCanvaSidebar({
               )}
             </>
           )}
+
           {openSection === 'position' && (
             <EditorCanvaPositionDrawer
               layout={layout}
@@ -437,46 +623,6 @@ export default function EditorCanvaSidebar({
               onBlockZStep={onBlockZStep}
               onReorderLayers={onReorderLayers}
             />
-          )}
-          {openSection === 'tools' && (
-            <>
-              <h3 className="editor-canva-drawer__title">Outils</h3>
-              <label className="editor-canva-drawer__toggle">
-                <input type="checkbox" checked={showGrid} onChange={(e) => onShowGridChange?.(e.target.checked)} />
-                Afficher la grille
-              </label>
-              <label className="editor-canva-drawer__toggle">
-                <input type="checkbox" checked={snapEnabled} onChange={(e) => onSnapEnabledChange?.(e.target.checked)} />
-                Magnétisme (snap)
-              </label>
-              <h4 className="editor-canva-drawer__subtitle">Transfert</h4>
-              <p className="editor-canva-drawer__hint editor-canva-drawer__hint--subtle">
-                Ajoutez des éléments depuis un autre brouillon sans remplacer ce canvas.
-              </p>
-              <label className="editor-canva-drawer__field">
-                Brouillon source
-                <select
-                  value={transferSourceKey}
-                  onChange={(e) => setTransferSourceKey(e.target.value)}
-                  disabled={disabled || transferDraftOptions.length === 0}
-                >
-                  <option value="">Choisir un brouillon</option>
-                  {transferDraftOptions.map((draft) => (
-                    <option key={draft.contextKey} value={draft.contextKey}>
-                      {draft.label || draft.contextKey}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <button
-                type="button"
-                className="editor-canva-drawer__btn editor-canva-drawer__btn--full"
-                disabled={disabled || !transferSourceKey}
-                onClick={() => onOpenTransferFromDraft?.(transferSourceKey)}
-              >
-                Transférer des éléments
-              </button>
-            </>
           )}
         </div>
       )}

--- a/frontend/src/components/editor/EditorInsertToolbar.jsx
+++ b/frontend/src/components/editor/EditorInsertToolbar.jsx
@@ -17,12 +17,13 @@ const ICON_BY_TYPE = {
 };
 
 /**
- * Barre d insertion de blocs (P3.5) - visible en mode canvas libre.
+ * Barre d insertion de blocs (legacy) - décorations uniquement.
+ * Le parcours guidé passe par EditorCanvaSidebar (AXE-31 : Sections CV vs Design).
  */
 export default function EditorInsertToolbar({ onInsert, disabled = false }) {
   return (
-    <div className="editor-insert-toolbar" role="toolbar" aria-label="Insérer un bloc">
-      <span className="editor-insert-toolbar-label">Insérer</span>
+    <div className="editor-insert-toolbar" role="toolbar" aria-label="Insérer une décoration">
+      <span className="editor-insert-toolbar-label">Décoration</span>
       <div className="editor-insert-toolbar-actions">
         {INSERT_TOOLBAR_ITEMS.map((item) => {
           const Icon = ICON_BY_TYPE[item.type];

--- a/frontend/src/lib/canvasCvSectionPresets.js
+++ b/frontend/src/lib/canvasCvSectionPresets.js
@@ -1,0 +1,151 @@
+/**
+ * Presets d'insertion des sections CV sémantiques (AXE-31).
+ *
+ * Distingués des décorations (formes, texte libre, icônes, images) :
+ * chaque preset se lie au CV de base via `bind`.
+ */
+
+import { PAGE_USABLE_WIDTH_MM } from './cvLayoutModelV3.js';
+
+const W = PAGE_USABLE_WIDTH_MM;
+
+/** @type {ReadonlyArray<{ type: string, label: string, description: string }>} */
+export const CV_SECTION_ITEMS = Object.freeze([
+  {
+    type: 'identity',
+    label: 'Identité',
+    description: 'Nom, prénom et titre professionnel',
+  },
+  {
+    type: 'photo',
+    label: 'Photo',
+    description: 'Photo de profil du CV',
+  },
+  {
+    type: 'contact',
+    label: 'Contact',
+    description: 'Email, téléphone, LinkedIn',
+  },
+  {
+    type: 'resume',
+    label: 'Profil',
+    description: 'Résumé / accroche',
+  },
+  {
+    type: 'experiences',
+    label: 'Expériences',
+    description: 'Expérience professionnelle',
+  },
+  {
+    type: 'formations',
+    label: 'Formations',
+    description: 'Parcours de formation',
+  },
+  {
+    type: 'skills',
+    label: 'Compétences',
+    description: 'Compétences techniques',
+  },
+  {
+    type: 'languages',
+    label: 'Langues',
+    description: 'Langues parlées',
+  },
+  {
+    type: 'certifications',
+    label: 'Certifications',
+    description: 'Certifications et diplômes',
+  },
+  {
+    type: 'projets',
+    label: 'Projets',
+    description: 'Projets mis en avant',
+  },
+]);
+
+const PRESETS_BY_TYPE = Object.freeze({
+  identity: {
+    type: 'identity',
+    bind: ['prenom', 'nom', 'titre_professionnel'],
+    w: W,
+    h: 22,
+    style: { align: 'left' },
+  },
+  photo: {
+    type: 'photo',
+    w: 28,
+    h: 28,
+    style: { shape: 'circle' },
+  },
+  contact: {
+    type: 'contact',
+    bind: ['email', 'telephone', 'linkedin'],
+    w: W,
+    h: 12,
+    style: {},
+  },
+  resume: {
+    type: 'resume',
+    bind: 'resume',
+    w: W,
+    h: 24,
+    style: { section_label: 'PROFIL' },
+  },
+  experiences: {
+    type: 'experiences',
+    bind: 'experiences',
+    w: W,
+    h: 80,
+    style: { section_label: 'EXPÉRIENCE PROFESSIONNELLE', format: 'compact' },
+  },
+  formations: {
+    type: 'formations',
+    bind: 'formations',
+    w: W,
+    h: 30,
+    style: { section_label: 'FORMATION' },
+  },
+  skills: {
+    type: 'skills',
+    bind: 'competences.techniques',
+    w: W,
+    h: 22,
+    style: { section_label: 'COMPÉTENCES', format: 'chips' },
+  },
+  languages: {
+    type: 'languages',
+    bind: 'langues',
+    w: W,
+    h: 18,
+    style: { section_label: 'LANGUES' },
+  },
+  certifications: {
+    type: 'certifications',
+    bind: 'certifications',
+    w: W,
+    h: 24,
+    style: { section_label: 'CERTIFICATIONS', list_format: 'list' },
+  },
+  projets: {
+    type: 'projets',
+    bind: 'projets',
+    w: W,
+    h: 28,
+    style: { section_label: 'PROJETS' },
+  },
+});
+
+/**
+ * Fabrique un bloc partiel prêt pour placement (sans x/y/z).
+ * @param {string} type
+ * @returns {object|null}
+ */
+export function createCvSectionBlockPreset(type) {
+  const preset = PRESETS_BY_TYPE[type];
+  if (!preset) return null;
+  return {
+    ...preset,
+    style: { ...(preset.style || {}) },
+    ...(Array.isArray(preset.bind) ? { bind: [...preset.bind] } : {}),
+  };
+}

--- a/frontend/src/styles/EditorCanvaSidebar.css
+++ b/frontend/src/styles/EditorCanvaSidebar.css
@@ -78,10 +78,6 @@
   color: var(--color-primary, #17171c);
 }
 
-.editor-canva-drawer__grid--sections {
-  grid-template-columns: 1fr;
-}
-
 .editor-canva-drawer__tile--section {
   display: flex;
   flex-direction: column;
@@ -161,6 +157,11 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 6px;
+}
+
+/* Après la règle 2 colonnes : une seule colonne pour Sections CV (Bugbot #58). */
+.editor-canva-drawer__grid--sections {
+  grid-template-columns: 1fr;
 }
 
 .editor-canva-drawer__btn,

--- a/frontend/src/styles/EditorCanvaSidebar.css
+++ b/frontend/src/styles/EditorCanvaSidebar.css
@@ -43,10 +43,64 @@
 }
 
 .editor-canva-rail__label {
-  font-size: 0.58rem;
+  font-size: 0.55rem;
   font-weight: 600;
   line-height: 1.1;
   text-align: center;
+}
+
+.editor-canva-design-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0 0 12px;
+}
+
+.editor-canva-design-tabs__btn {
+  padding: 6px 10px;
+  border: 1px solid var(--color-hairline, #d9d9dd);
+  border-radius: 9999px;
+  background: var(--color-canvas, #ffffff);
+  color: var(--color-body-muted, #616161);
+  font-size: 0.72rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.editor-canva-design-tabs__btn:hover {
+  border-color: var(--color-muted, #93939f);
+  color: var(--color-ink, #212121);
+}
+
+.editor-canva-design-tabs__btn--active {
+  border-color: var(--color-primary, #17171c);
+  background: var(--color-pale-green, #edfce9);
+  color: var(--color-primary, #17171c);
+}
+
+.editor-canva-drawer__grid--sections {
+  grid-template-columns: 1fr;
+}
+
+.editor-canva-drawer__tile--section {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  text-align: left;
+  padding: 10px 12px;
+}
+
+.editor-canva-drawer__tile-label {
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--color-ink, #212121);
+}
+
+.editor-canva-drawer__tile-hint {
+  font-size: 0.68rem;
+  line-height: 1.3;
+  color: var(--color-muted, #93939f);
 }
 
 .editor-canva-drawer {

--- a/frontend/tests/unit/canvasCvSectionPresets.test.js
+++ b/frontend/tests/unit/canvasCvSectionPresets.test.js
@@ -1,0 +1,55 @@
+/**
+ * Tests unitaires des presets Sections CV (AXE-31).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isSemanticBlockType, sanitizeBlock } from '../../src/lib/cvLayoutModelV3.js';
+import {
+  CV_SECTION_ITEMS,
+  createCvSectionBlockPreset,
+} from '../../src/lib/canvasCvSectionPresets.js';
+
+test('CV_SECTION_ITEMS couvre les types sémantiques utiles', () => {
+  assert.ok(CV_SECTION_ITEMS.length >= 8);
+  const types = new Set(CV_SECTION_ITEMS.map((i) => i.type));
+  for (const required of ['identity', 'experiences', 'formations', 'skills', 'contact']) {
+    assert.ok(types.has(required), `manque ${required}`);
+  }
+});
+
+test('createCvSectionBlockPreset : expériences liées au CV', () => {
+  const preset = createCvSectionBlockPreset('experiences');
+  assert.equal(preset.type, 'experiences');
+  assert.equal(preset.bind, 'experiences');
+  assert.ok(preset.w > 0 && preset.h > 0);
+  assert.ok(isSemanticBlockType(preset.type));
+  const block = sanitizeBlock({ ...preset, x: 10, y: 10 });
+  assert.equal(block.type, 'experiences');
+  assert.equal(block.bind, 'experiences');
+});
+
+test('createCvSectionBlockPreset : identité avec bind tableau', () => {
+  const preset = createCvSectionBlockPreset('identity');
+  assert.ok(Array.isArray(preset.bind));
+  assert.ok(preset.bind.includes('prenom'));
+  const copy = createCvSectionBlockPreset('identity');
+  copy.bind.push('x');
+  assert.notEqual(preset.bind.length, copy.bind.length);
+});
+
+test('createCvSectionBlockPreset : type inconnu -> null', () => {
+  assert.equal(createCvSectionBlockPreset('inconnu'), null);
+  assert.equal(createCvSectionBlockPreset('text'), null);
+});
+
+test('tous les items produisent un bloc sanitisable', () => {
+  for (const item of CV_SECTION_ITEMS) {
+    const preset = createCvSectionBlockPreset(item.type);
+    assert.ok(preset, item.type);
+    const block = sanitizeBlock({ ...preset, x: 10, y: 20 });
+    assert.equal(block.type, item.type);
+    assert.ok(isSemanticBlockType(block.type));
+  }
+});


### PR DESCRIPTION
## Summary
- Rail Canva réorganisé en 4 familles : **Sections CV**, **Design** (modèles / décoration / outils), **Importer** (images), **Position**
- Presets sémantiques pour placer expériences, formations, etc. distincts des décorations
- Libellés honnêtes + confirmations avant page blanche / changement de modèle

## Linear
Fixes AXE-31

## GitHub issue
Closes #57

## Test plan
- [ ] Ouvrir l’éditeur Beta : le rail montre Sections CV / Design / Importer / Position
- [ ] Sections CV : placer une expérience / contact / compétences sur le canvas
- [ ] Design → Décoration : formes / texte / icônes restent placables
- [ ] Importer : hint « images uniquement », pas de promesse PDF/Word
- [ ] Page blanche ou modèle avec canvas non vide → confirmation
- [ ] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks` OK
- [ ] Tests unit `canvasCvSectionPresets` + `editorTemplateUtils` verts


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout d’une bibliothèque de sections CV prêtes à insérer : identité, photo, contact, expériences, formations, compétences et autres.
  * Réorganisation de la barre latérale en familles dédiées aux sections, au design, à l’importation et au positionnement.
  * Regroupement des outils de modèles, texte, icônes et composition dans un panneau Design.
  * Ajout de contrôles pour les décorations, la mise en page et le transfert entre brouillons.

* **Améliorations**
  * Les suppressions d’éléments importants demandent désormais une confirmation lorsque le canevas contient du contenu.
  * L’importation d’images est clairement identifiée comme décorative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->