### PR TITLE
feat(AXE-32): onboarding 3 étapes + empty states actionnables

### DIFF
--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -97,6 +97,7 @@ import EditorFloatingTextToolbar from './EditorFloatingTextToolbar.jsx';
 import EditorImageEditPopover from './EditorImageEditPopover.jsx';
 import EditorCanvaTransferModal from './EditorCanvaTransferModal.jsx';
 import EditorCvImportModal from './EditorCvImportModal.jsx';
+import EditorOnboardingTour from './EditorOnboardingTour.jsx';
 
 import {
   buildCanvasPdfFilename,
@@ -109,6 +110,11 @@ import {
   isCanvasEditHintDismissed,
   isSemanticEditNoteDismissed,
 } from '../../lib/canvasEditorUtils.js';
+import {
+  dismissEditorOnboarding,
+  isEditorOnboardingDismissed,
+  shouldShowEditorOnboarding,
+} from '../../lib/editorOnboarding.js';
 import {
   listNonFaithfulBlocks,
   summarizeNonFaithfulBlocks,
@@ -150,6 +156,7 @@ function CvEditorBeta({
   const [sidebarSection, setSidebarSection] = useState('sections');
   const [placementPreset, setPlacementPreset] = useState(null);
   const [startupPromptOpen, setStartupPromptOpen] = useState(false);
+  const [onboardingDismissed, setOnboardingDismissed] = useState(() => isEditorOnboardingDismissed());
   const [pdfExportError, setPdfExportError] = useState('');
   const [atsOptimizeMessage, setAtsOptimizeMessage] = useState('');
   const autoHeightPendingRef = useRef(new Map());
@@ -372,6 +379,25 @@ function CvEditorBeta({
     setStartupPromptOpen(false);
     setSidebarSection('design');
   }, []);
+
+  const handleEmptyAddSection = useCallback(() => {
+    setSidebarSection('sections');
+  }, []);
+
+  const handleEmptyChooseTemplate = useCallback(() => {
+    setSidebarSection('design');
+  }, []);
+
+  const handleDismissOnboarding = useCallback(() => {
+    dismissEditorOnboarding();
+    setOnboardingDismissed(true);
+  }, []);
+
+  const onboardingOpen = shouldShowEditorOnboarding({
+    dismissed: onboardingDismissed,
+    loading,
+    startupPromptOpen,
+  });
 
   const handleGenerateStarterCanvas = useCallback(() => {
     const templates = templatesList || [];
@@ -1429,12 +1455,18 @@ function CvEditorBeta({
               onBlockAutoHeight={handleBlockAutoHeight}
               onAddPage={handleAddCanvasPage}
               onRemovePage={handleRemoveCanvasPage}
+              onEmptyAddSection={handleEmptyAddSection}
+              onEmptyChooseTemplate={handleEmptyChooseTemplate}
             />
             {importToast && (
               <div className="cv-editor-beta-import-toast" role="status">
                 Canvas généré - {importToast}
               </div>
             )}
+            <EditorOnboardingTour
+              open={onboardingOpen}
+              onDismiss={handleDismissOnboarding}
+            />
             {startupPromptOpen && (
               <section className="cv-editor-beta-start-panel" role="dialog" aria-modal="true" aria-label="Démarrer le canvas">
                 <div className="cv-editor-beta-start-panel__backdrop" aria-hidden />

--- a/frontend/src/components/editor/EditorCanvaSidebar.jsx
+++ b/frontend/src/components/editor/EditorCanvaSidebar.jsx
@@ -41,10 +41,30 @@ import '../../styles/EditorCanvaSidebar.css';
 
 /** Rail principal AXE-31 : 4 familles guidantes. */
 const SECTIONS = [
-  { id: 'sections', label: 'Sections CV', icon: HiDocumentText },
-  { id: 'design', label: 'Design', icon: HiSwatch },
-  { id: 'import', label: 'Importer', icon: HiArrowUpTray },
-  { id: 'position', label: 'Position', icon: HiArrowsPointingOut },
+  {
+    id: 'sections',
+    label: 'Sections CV',
+    title: 'Sections CV — contenu lié à ton profil (expériences, formations…)',
+    icon: HiDocumentText,
+  },
+  {
+    id: 'design',
+    label: 'Design',
+    title: 'Design — modèles, décorations et outils de composition',
+    icon: HiSwatch,
+  },
+  {
+    id: 'import',
+    label: 'Importer',
+    title: 'Importer — images décoratives uniquement (pas de PDF/Word ici)',
+    icon: HiArrowUpTray,
+  },
+  {
+    id: 'position',
+    label: 'Position',
+    title: 'Position — calques, taille et ordre des blocs',
+    icon: HiArrowsPointingOut,
+  },
 ];
 
 const DESIGN_TABS = [
@@ -280,7 +300,7 @@ export default function EditorCanvaSidebar({
     <aside className={`editor-canva-shell${placementActive ? ' editor-canva-shell--placing' : ''}`} aria-label="Outils canvas">
       {placementActive && (
         <p className="editor-canva-shell__place-hint" role="status">
-          Cliquez sur le canevas pour placer l’élément · Échap pour annuler
+          Cliquez sur le canevas pour placer · un fantôme suit le curseur · Échap pour annuler
         </p>
       )}
       <nav className="editor-canva-rail" aria-label="Familles d’outils">
@@ -293,7 +313,7 @@ export default function EditorCanvaSidebar({
               type="button"
               aria-current={active ? 'true' : undefined}
               className={active ? 'editor-canva-rail__btn editor-canva-rail__btn--active' : 'editor-canva-rail__btn'}
-              title={section.label}
+              title={section.title || section.label}
               onClick={() => toggleSection(section.id)}
             >
               {Icon ? <Icon size={22} aria-hidden /> : null}

--- a/frontend/src/components/editor/EditorOnboardingTour.jsx
+++ b/frontend/src/components/editor/EditorOnboardingTour.jsx
@@ -1,0 +1,81 @@
+import { useEffect, useId, useState } from 'react';
+import { EDITOR_ONBOARDING_STEPS } from '../../lib/editorOnboarding.js';
+import '../../styles/EditorOnboardingTour.css';
+
+/**
+ * Tour d'accueil 3 étapes (AXE-32) — dismissable, une seule fois.
+ */
+export default function EditorOnboardingTour({ open = false, onDismiss }) {
+  const titleId = useId();
+  const [stepIndex, setStepIndex] = useState(0);
+
+  useEffect(() => {
+    if (open) setStepIndex(0);
+  }, [open]);
+
+  if (!open) return null;
+
+  const steps = EDITOR_ONBOARDING_STEPS;
+  const step = steps[stepIndex] || steps[0];
+  const isLast = stepIndex >= steps.length - 1;
+
+  const finish = () => {
+    onDismiss?.();
+  };
+
+  return (
+    <section
+      className="editor-onboarding"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+    >
+      <div className="editor-onboarding__backdrop" aria-hidden />
+      <div className="editor-onboarding__card">
+        <p className="editor-onboarding__eyebrow">
+          Prise en main · {stepIndex + 1}/{steps.length}
+        </p>
+        <h2 id={titleId} className="editor-onboarding__title">{step.title}</h2>
+        <p className="editor-onboarding__body">{step.body}</p>
+        <ol className="editor-onboarding__dots" aria-hidden>
+          {steps.map((s, i) => (
+            <li
+              key={s.id}
+              className={
+                i === stepIndex
+                  ? 'editor-onboarding__dot editor-onboarding__dot--active'
+                  : 'editor-onboarding__dot'
+              }
+            />
+          ))}
+        </ol>
+        <div className="editor-onboarding__actions">
+          <button
+            type="button"
+            className="editor-onboarding__skip"
+            onClick={finish}
+          >
+            Passer
+          </button>
+          {!isLast ? (
+            <button
+              type="button"
+              className="editor-onboarding__next"
+              onClick={() => setStepIndex((i) => Math.min(i + 1, steps.length - 1))}
+            >
+              Suivant
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="editor-onboarding__next"
+              onClick={finish}
+            >
+              C’est compris
+            </button>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/editor/FreeCanvas.jsx
+++ b/frontend/src/components/editor/FreeCanvas.jsx
@@ -834,12 +834,8 @@ export default function FreeCanvas({
                   />
                   );
                 })}
-                {blocks.length === 0 && (
-                  <div
-                    className="free-canvas-page-empty"
-                    role="status"
-                    onPointerDown={(e) => e.stopPropagation()}
-                  >
+                {blocks.length === 0 && !placing && (
+                  <div className="free-canvas-page-empty" role="status">
                     <p className="free-canvas-page-empty__title">Cette page est vide</p>
                     <p className="free-canvas-page-empty__text">
                       Ajoute une section CV ou pars d’un modèle pour démarrer.

--- a/frontend/src/components/editor/FreeCanvas.jsx
+++ b/frontend/src/components/editor/FreeCanvas.jsx
@@ -130,6 +130,8 @@ export default function FreeCanvas({
   onDropImage,
   onAddPage,
   onRemovePage,
+  onEmptyAddSection,
+  onEmptyChooseTemplate,
 }) {
   const viewportRef = useRef(null);
   const blockElementsRef = useRef({});
@@ -833,9 +835,38 @@ export default function FreeCanvas({
                   );
                 })}
                 {blocks.length === 0 && (
-                  <p className="free-canvas-page-empty">
-                    Page {pageIndex + 1} vide - choisissez un élément dans la barre latérale, puis cliquez ici pour le placer
-                  </p>
+                  <div
+                    className="free-canvas-page-empty"
+                    role="status"
+                    onPointerDown={(e) => e.stopPropagation()}
+                  >
+                    <p className="free-canvas-page-empty__title">Cette page est vide</p>
+                    <p className="free-canvas-page-empty__text">
+                      Ajoute une section CV ou pars d’un modèle pour démarrer.
+                    </p>
+                    <div className="free-canvas-page-empty__actions">
+                      <button
+                        type="button"
+                        className="free-canvas-page-empty__btn free-canvas-page-empty__btn--primary"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onEmptyAddSection?.();
+                        }}
+                      >
+                        Ajouter une section
+                      </button>
+                      <button
+                        type="button"
+                        className="free-canvas-page-empty__btn"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onEmptyChooseTemplate?.();
+                        }}
+                      >
+                        Partir d’un modèle
+                      </button>
+                    </div>
+                  </div>
                 )}
               </div>
             </div>

--- a/frontend/src/lib/editorOnboarding.js
+++ b/frontend/src/lib/editorOnboarding.js
@@ -1,0 +1,78 @@
+/**
+ * Persistance de l'onboarding éditeur Beta (AXE-32).
+ *
+ * Pur (pas de React) pour rester testable via `node --test`.
+ * Même pattern que `betaMode.js` : storage injectable.
+ */
+
+export const EDITOR_ONBOARDING_DISMISSED_KEY = 'cv_bot_editor_onboarding_dismissed_v1';
+
+/** Étapes affichées dans le tour (ordre stable). */
+export const EDITOR_ONBOARDING_STEPS = Object.freeze([
+  {
+    id: 'sections',
+    title: 'Ajoute ton contenu',
+    body: 'Dans « Sections CV », place identité, expériences, formations… Ces blocs sont liés à ton profil.',
+  },
+  {
+    id: 'design',
+    title: 'Choisis look et modèle',
+    body: 'Dans « Design », pars d’un modèle ATS-safe ou ajoute des décorations (formes, texte, icônes).',
+  },
+  {
+    id: 'place',
+    title: 'Place sur le canvas',
+    body: 'Clique un élément puis clique la page pour le poser. Échap annule. « Importer » sert aux images uniquement.',
+  },
+]);
+
+function resolveStorage(storage) {
+  if (storage) return storage;
+  if (typeof globalThis !== 'undefined' && globalThis.localStorage) {
+    return globalThis.localStorage;
+  }
+  return null;
+}
+
+/**
+ * @param {Storage | null} [storage]
+ * @returns {boolean}
+ */
+export function isEditorOnboardingDismissed(storage) {
+  const s = resolveStorage(storage);
+  if (!s) return false;
+  try {
+    return s.getItem(EDITOR_ONBOARDING_DISMISSED_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Marque l'onboarding comme terminé (complété ou skip).
+ * @param {Storage | null} [storage]
+ * @returns {boolean} true si persisté
+ */
+export function dismissEditorOnboarding(storage) {
+  const s = resolveStorage(storage);
+  if (!s) return false;
+  try {
+    s.setItem(EDITOR_ONBOARDING_DISMISSED_KEY, '1');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Décide si le tour doit s'afficher (logique pure, testable).
+ * @param {{ dismissed?: boolean, loading?: boolean, startupPromptOpen?: boolean }} state
+ * @returns {boolean}
+ */
+export function shouldShowEditorOnboarding(state = {}) {
+  if (state.dismissed) return false;
+  if (state.loading) return false;
+  // Le démarrage guidé AXE-28 a priorité quand le layout serveur est absent.
+  if (state.startupPromptOpen) return false;
+  return true;
+}

--- a/frontend/src/styles/EditorOnboardingTour.css
+++ b/frontend/src/styles/EditorOnboardingTour.css
@@ -1,0 +1,109 @@
+.editor-onboarding {
+  position: absolute;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.editor-onboarding__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(23, 23, 28, 0.35);
+  pointer-events: auto;
+}
+
+.editor-onboarding__card {
+  position: relative;
+  z-index: 1;
+  width: min(420px, calc(100% - 32px));
+  padding: 24px;
+  border-radius: 16px;
+  border: 1px solid var(--color-card-border, #f2f2f2);
+  background: var(--color-canvas, #ffffff);
+  color: var(--color-ink, #212121);
+  pointer-events: auto;
+}
+
+.editor-onboarding__eyebrow {
+  margin: 0 0 8px;
+  font-family: CohereMono, Arial, ui-sans-serif, system-ui, sans-serif;
+  font-size: 12px;
+  letter-spacing: 0.28px;
+  text-transform: uppercase;
+  color: var(--color-muted, #93939f);
+}
+
+.editor-onboarding__title {
+  margin: 0 0 10px;
+  font-size: 24px;
+  font-weight: 400;
+  line-height: 1.3;
+}
+
+.editor-onboarding__body {
+  margin: 0 0 18px;
+  font-size: 16px;
+  line-height: 1.5;
+  color: var(--color-body-muted, #616161);
+}
+
+.editor-onboarding__dots {
+  display: flex;
+  gap: 6px;
+  list-style: none;
+  margin: 0 0 20px;
+  padding: 0;
+}
+
+.editor-onboarding__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 9999px;
+  background: var(--color-hairline, #d9d9dd);
+}
+
+.editor-onboarding__dot--active {
+  background: var(--color-primary, #17171c);
+}
+
+.editor-onboarding__actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+}
+
+.editor-onboarding__skip {
+  padding: 8px 0;
+  border: none;
+  background: transparent;
+  color: var(--color-slate, #75758a);
+  font-size: 14px;
+  font-weight: 500;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.editor-onboarding__next {
+  padding: 12px 24px;
+  border: none;
+  border-radius: 32px;
+  background: var(--color-primary, #17171c);
+  color: var(--color-on-dark, #ffffff);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.editor-onboarding__next:hover {
+  opacity: 0.92;
+}
+
+.editor-onboarding__skip:focus-visible,
+.editor-onboarding__next:focus-visible {
+  outline: 2px solid var(--color-focus-blue, #4c6ee6);
+  outline-offset: 2px;
+}

--- a/frontend/src/styles/FreeCanvas.css
+++ b/frontend/src/styles/FreeCanvas.css
@@ -146,7 +146,8 @@
   background: rgba(255, 255, 255, 0.92);
   color: var(--color-body-muted, #616161);
   text-align: center;
-  pointer-events: auto;
+  /* Laisser passer les clics de placement ; seuls les CTA capturent le pointeur. */
+  pointer-events: none;
   z-index: 2;
 }
 
@@ -170,6 +171,7 @@
   flex-wrap: wrap;
   gap: 8px;
   justify-content: center;
+  pointer-events: auto;
 }
 
 .free-canvas-page-empty__btn {

--- a/frontend/src/styles/FreeCanvas.css
+++ b/frontend/src/styles/FreeCanvas.css
@@ -138,11 +138,59 @@
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
-  color: #94a3b8;
-  font-style: italic;
-  font-size: 10pt;
+  width: min(220mm, 88%);
   margin: 0;
-  pointer-events: none;
+  padding: 16px 18px;
+  border: 1px dashed var(--color-hairline, #d9d9dd);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--color-body-muted, #616161);
+  text-align: center;
+  pointer-events: auto;
+  z-index: 2;
+}
+
+.free-canvas-page-empty__title {
+  margin: 0 0 6px;
+  font-size: 11pt;
+  font-style: normal;
+  font-weight: 500;
+  color: var(--color-ink, #212121);
+}
+
+.free-canvas-page-empty__text {
+  margin: 0 0 12px;
+  font-size: 9.5pt;
+  line-height: 1.4;
+  font-style: normal;
+}
+
+.free-canvas-page-empty__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+}
+
+.free-canvas-page-empty__btn {
+  padding: 8px 14px;
+  border: 1px solid var(--color-primary, #17171c);
+  border-radius: 32px;
+  background: transparent;
+  color: var(--color-primary, #17171c);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.free-canvas-page-empty__btn--primary {
+  background: var(--color-primary, #17171c);
+  color: var(--color-on-dark, #ffffff);
+}
+
+.free-canvas-page-empty__btn:focus-visible {
+  outline: 2px solid var(--color-focus-blue, #4c6ee6);
+  outline-offset: 2px;
 }
 
 /* Grille 5 mm (P3.7) - visible en mode edition */

--- a/frontend/tests/unit/editorOnboarding.test.js
+++ b/frontend/tests/unit/editorOnboarding.test.js
@@ -1,0 +1,62 @@
+/**
+ * Tests unitaires onboarding éditeur Beta (AXE-32).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  EDITOR_ONBOARDING_DISMISSED_KEY,
+  EDITOR_ONBOARDING_STEPS,
+  dismissEditorOnboarding,
+  isEditorOnboardingDismissed,
+  shouldShowEditorOnboarding,
+} from '../../src/lib/editorOnboarding.js';
+
+function makeFakeStorage() {
+  const store = new Map();
+  return {
+    getItem: (key) => (store.has(key) ? store.get(key) : null),
+    setItem: (key, value) => { store.set(key, String(value)); },
+    removeItem: (key) => { store.delete(key); },
+    _raw: store,
+  };
+}
+
+test('EDITOR_ONBOARDING_STEPS : exactement 3 étapes ordonnées', () => {
+  assert.equal(EDITOR_ONBOARDING_STEPS.length, 3);
+  assert.equal(EDITOR_ONBOARDING_STEPS[0].id, 'sections');
+  assert.equal(EDITOR_ONBOARDING_STEPS[1].id, 'design');
+  assert.equal(EDITOR_ONBOARDING_STEPS[2].id, 'place');
+});
+
+test('isEditorOnboardingDismissed : false par défaut', () => {
+  assert.equal(isEditorOnboardingDismissed(makeFakeStorage()), false);
+});
+
+test('dismissEditorOnboarding : persiste et ne réaffiche plus', () => {
+  const storage = makeFakeStorage();
+  assert.equal(dismissEditorOnboarding(storage), true);
+  assert.equal(storage.getItem(EDITOR_ONBOARDING_DISMISSED_KEY), '1');
+  assert.equal(isEditorOnboardingDismissed(storage), true);
+  assert.equal(
+    shouldShowEditorOnboarding({ dismissed: true, loading: false, startupPromptOpen: false }),
+    false,
+  );
+});
+
+test('shouldShowEditorOnboarding : masqué pendant loading ou startup AXE-28', () => {
+  assert.equal(shouldShowEditorOnboarding({ dismissed: false, loading: true }), false);
+  assert.equal(
+    shouldShowEditorOnboarding({ dismissed: false, loading: false, startupPromptOpen: true }),
+    false,
+  );
+  assert.equal(
+    shouldShowEditorOnboarding({ dismissed: false, loading: false, startupPromptOpen: false }),
+    true,
+  );
+});
+
+test('dismissEditorOnboarding : storage absent -> false', () => {
+  assert.equal(dismissEditorOnboarding(null), false);
+});


### PR DESCRIPTION
## Summary
- Tour d’accueil 3 étapes au premier usage Beta (Passer / Suivant / C’est compris), persisté localement
- Empty state canvas avec CTA « Ajouter une section » et « Partir d’un modèle »
- Tooltips pédagogiques sur le rail + feedback placement clarifié

## Linear
Fixes AXE-32

## GitHub issue
Closes #59

## Test plan
- [ ] Premier chargement Beta (storage clean) → tour 3 étapes après (ou sans) démarrage AXE-28
- [ ] Passer / C’est compris → le tour ne revient plus au reload
- [ ] Page vide → CTA ouvrent Sections CV / Design
- [ ] `node --test tests/unit/editorOnboarding.test.js` OK
- [ ] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks` OK


Made with [Cursor](https://cursor.com)