### PR TITLE
feat(AXE-33): placement drag sidebar, ghost et auto-sélection

### DIFF
--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -52,6 +52,7 @@ import { blockSupportsStyleToolbar } from '../../lib/canvasBlockToolbar.js';
 import { buildCanvasFontFamilies } from '../../lib/canvasFontOptions.js';
 import { selectAllInEditableRoot, clearDocumentTextSelection, toggleTextCaseOnBlockContent } from '../../lib/canvasRichTextFormat.js';
 import { getLastBlockIdOnPage, createImageBlockPreset } from '../../lib/freeCanvasBlockPresets.js';
+import { placementPartialAtPoint } from '../../lib/canvasSidebarPlacement.js';
 import { addUserCanvasImage } from '../../lib/canvasImageLibrary.js';
 import {
   createCanvasLayoutBlank,
@@ -735,23 +736,33 @@ function CvEditorBeta({
     setPlacementPreset(null);
   }, []);
 
-  const handlePlaceBlockAt = useCallback((pageIndex, xMm, yMm) => {
-    if (!placementPreset) return;
-    const w = placementPreset.w ?? 20;
-    const h = placementPreset.h ?? 10;
-    const partial = {
-      ...placementPreset,
-      x: Math.max(0, xMm - w / 2),
-      y: Math.max(0, yMm - h / 2),
-    };
-    delete partial.placementMode;
-    const next = addBlockToPage(layout, pageIndex, partial);
+  const commitPlacedPreset = useCallback((pageIndex, xMm, yMm, preset, { enterEdit = false } = {}) => {
+    if (!preset) return;
+    const { x, y, partial } = placementPartialAtPoint(preset, xMm, yMm);
+    const next = addBlockToPage(layout, pageIndex, { ...partial, x, y });
     commitLayout(next);
     const newId = getLastBlockIdOnPage(next, pageIndex);
-    if (newId) setSelectedBlockIds([newId]);
+    if (newId) {
+      setSelectedBlockIds([newId]);
+      setImageEditBlockId(null);
+      if (enterEdit || partial.type === 'text' || partial.type === 'title') {
+        setEditingBlockId(newId);
+      } else {
+        setEditingBlockId(null);
+      }
+    }
     setPlacementPreset(null);
     if (cv) autoSave.schedule(cv);
-  }, [placementPreset, layout, commitLayout, cv, autoSave]);
+  }, [layout, commitLayout, cv, autoSave]);
+
+  const handlePlaceBlockAt = useCallback((pageIndex, xMm, yMm) => {
+    if (!placementPreset) return;
+    commitPlacedPreset(pageIndex, xMm, yMm, placementPreset);
+  }, [placementPreset, commitPlacedPreset]);
+
+  const handleDropBlockPreset = useCallback((pageIndex, xMm, yMm, preset) => {
+    commitPlacedPreset(pageIndex, xMm, yMm, preset);
+  }, [commitPlacedPreset]);
 
   const handlePlaceBlockRect = useCallback((pageIndex, rect) => {
     if (!placementPreset) return;
@@ -762,7 +773,7 @@ function CvEditorBeta({
       w: Math.max(rect.w, 12),
       h: Math.max(rect.h, 8),
     };
-    const enterEdit = partial.type === 'text';
+    const enterEdit = partial.type === 'text' || partial.type === 'title';
     delete partial.placementMode;
     const next = addBlockToPage(layout, pageIndex, partial);
     commitLayout(next);
@@ -770,6 +781,7 @@ function CvEditorBeta({
     if (newId) {
       setSelectedBlockIds([newId]);
       if (enterEdit) setEditingBlockId(newId);
+      else setEditingBlockId(null);
     }
     setPlacementPreset(null);
     if (cv) autoSave.schedule(cv);
@@ -1394,6 +1406,7 @@ function CvEditorBeta({
           onShowGridChange={setShowCanvasGrid}
           onSnapEnabledChange={setCanvasSnapEnabled}
           onBeginPlacement={handleBeginPlacement}
+          onCancelPlacement={handleCancelPlacement}
           onSelectBlock={handleSelectBlock}
           onBlockPatch={handleBlockPatchById}
           onBlockBringToFront={handleBlockBringToFront}
@@ -1438,6 +1451,7 @@ function CvEditorBeta({
               onPlaceBlockAt={handlePlaceBlockAt}
               onPlaceBlockRect={handlePlaceBlockRect}
               onDropImage={handleDropImage}
+              onDropBlockPreset={handleDropBlockPreset}
               onCancelPlacement={handleCancelPlacement}
               onSelectBlock={handleSelectBlock}
               onBlockPositionChange={handleBlockPositionChange}

--- a/frontend/src/components/editor/EditorCanvaSidebar.jsx
+++ b/frontend/src/components/editor/EditorCanvaSidebar.jsx
@@ -15,6 +15,10 @@ import {
   syncUserCanvasImagesFromLayout,
   toSafeCanvasImageSrc,
 } from '../../lib/canvasImageLibrary.js';
+import {
+  CANVAS_BLOCK_PRESET_MIME,
+  serializeBlockPreset,
+} from '../../lib/canvasSidebarPlacement.js';
 import { CANVAS_ICON_ENTRIES, createIconBlockPreset } from '../../lib/canvasIconLibrary.js';
 import { ELEMENT_SHAPE_ITEMS, createShapeBlockPreset } from '../../lib/canvasShapePresets.js';
 import { TEXT_PRESET_ITEMS, createTextBlockPreset } from '../../lib/canvasTextPresets.js';
@@ -138,14 +142,10 @@ function ImageHistoryTile({ entry, disabled, onBeginPlacement, onRemove }) {
 }
 
 function PlacementTile({ disabled, preset, onBeginPlacement, className, title, children }) {
+  const draggedRef = useRef(false);
+
   const startPlacement = () => {
     if (!disabled && preset) onBeginPlacement?.(preset);
-  };
-
-  const onPointerDown = (e) => {
-    if (disabled || !preset) return;
-    e.preventDefault();
-    startPlacement();
   };
 
   return (
@@ -154,11 +154,31 @@ function PlacementTile({ disabled, preset, onBeginPlacement, className, title, c
       className={className}
       disabled={disabled}
       title={title}
-      onPointerDown={onPointerDown}
+      draggable={!disabled && Boolean(preset)}
+      onDragStart={(e) => {
+        if (disabled || !preset) {
+          e.preventDefault();
+          return;
+        }
+        const raw = serializeBlockPreset(preset);
+        if (!raw) {
+          e.preventDefault();
+          return;
+        }
+        draggedRef.current = true;
+        e.dataTransfer.setData(CANVAS_BLOCK_PRESET_MIME, raw);
+        e.dataTransfer.effectAllowed = 'copy';
+      }}
+      onDragEnd={() => {
+        // Laisse passer le cycle click post-drag avant reset.
+        requestAnimationFrame(() => {
+          draggedRef.current = false;
+        });
+      }}
       onClick={(e) => {
         e.preventDefault();
-        // Entrée / Espace : detail === 0 (pas un clic pointeur).
-        if (e.detail === 0) startPlacement();
+        if (draggedRef.current) return;
+        startPlacement();
       }}
     >
       {children}
@@ -184,6 +204,7 @@ export default function EditorCanvaSidebar({
   onShowGridChange,
   onSnapEnabledChange,
   onBeginPlacement,
+  onCancelPlacement,
   onSelectBlock,
   onBlockPatch,
   onBlockBringToFront,
@@ -299,9 +320,18 @@ export default function EditorCanvaSidebar({
   return (
     <aside className={`editor-canva-shell${placementActive ? ' editor-canva-shell--placing' : ''}`} aria-label="Outils canvas">
       {placementActive && (
-        <p className="editor-canva-shell__place-hint" role="status">
-          Cliquez sur le canevas pour placer · un fantôme suit le curseur · Échap pour annuler
-        </p>
+        <div className="editor-canva-shell__place-hint" role="status">
+          <p className="editor-canva-shell__place-hint-text">
+            Cliquez sur le canevas pour placer · ou glissez depuis la sidebar · Échap pour annuler
+          </p>
+          <button
+            type="button"
+            className="editor-canva-shell__place-cancel"
+            onClick={() => onCancelPlacement?.()}
+          >
+            Annuler (Échap)
+          </button>
+        </div>
       )}
       <nav className="editor-canva-rail" aria-label="Familles d’outils">
         {SECTIONS.map((section) => {

--- a/frontend/src/components/editor/FreeCanvas.jsx
+++ b/frontend/src/components/editor/FreeCanvas.jsx
@@ -32,6 +32,11 @@ import { nextOverlappingBlockId } from '../../lib/freeCanvasSelection.js';
 import { blockIdsInMarquee, normalizeMarqueeRect } from '../../lib/canvasMarqueeUtils.js';
 import { clearDocumentTextSelection } from '../../lib/canvasRichTextFormat.js';
 import { CANVAS_IMAGE_DROP_MIME } from '../../lib/canvasImageLibrary.js';
+import {
+  CANVAS_BLOCK_PRESET_MIME,
+  dataTransferHasBlockPreset,
+  parseBlockPreset,
+} from '../../lib/canvasSidebarPlacement.js';
 import { snapBlockGeometry, snapBlockPosition } from '../../lib/freeCanvasSnap.js';
 import '../../styles/FreeCanvas.css';
 import '../../styles/CanvasTemplateFidelity.css';
@@ -128,6 +133,7 @@ export default function FreeCanvas({
   onPlaceBlockRect,
   onCancelPlacement,
   onDropImage,
+  onDropBlockPreset,
   onAddPage,
   onRemovePage,
   onEmptyAddSection,
@@ -561,20 +567,34 @@ export default function FreeCanvas({
   }, [interactable, onSelectBlock, onBlockResizeChange, endDrag, setCanvasBusy, onResizeStart, handleResizePointerMove, handleResizePointerUp]);
 
   const handlePageDragOver = useCallback((event) => {
-    if (!event.dataTransfer?.types?.includes(CANVAS_IMAGE_DROP_MIME)) return;
+    const types = event.dataTransfer?.types;
+    const hasImage = types?.includes?.(CANVAS_IMAGE_DROP_MIME);
+    const hasPreset = dataTransferHasBlockPreset(event.dataTransfer);
+    if (!hasImage && !hasPreset) return;
     event.preventDefault();
     event.dataTransfer.dropEffect = 'copy';
   }, []);
 
   const handlePageDrop = useCallback((event) => {
-    const dataUrl = event.dataTransfer?.getData(CANVAS_IMAGE_DROP_MIME);
-    if (!dataUrl || typeof onDropImage !== 'function') return;
-    event.preventDefault();
-    event.stopPropagation();
     const pageIndex = pageIndexFromElement(event.currentTarget);
     const pt = clientPointToPageMm(event.clientX, event.clientY, event.currentTarget);
-    onDropImage(pageIndex, pt.x, pt.y, dataUrl);
-  }, [onDropImage]);
+
+    const dataUrl = event.dataTransfer?.getData(CANVAS_IMAGE_DROP_MIME);
+    if (dataUrl && typeof onDropImage === 'function') {
+      event.preventDefault();
+      event.stopPropagation();
+      onDropImage(pageIndex, pt.x, pt.y, dataUrl);
+      return;
+    }
+
+    const rawPreset = event.dataTransfer?.getData(CANVAS_BLOCK_PRESET_MIME);
+    const preset = parseBlockPreset(rawPreset);
+    if (preset && typeof onDropBlockPreset === 'function') {
+      event.preventDefault();
+      event.stopPropagation();
+      onDropBlockPreset(pageIndex, pt.x, pt.y, preset);
+    }
+  }, [onDropImage, onDropBlockPreset]);
 
   const [placeCursor, setPlaceCursor] = useState(null);
 
@@ -702,7 +722,9 @@ export default function FreeCanvas({
       ? 'Icône'
       : placementPreset?.type === 'image'
         ? 'Image'
-        : placementPreset?.type || 'Élément';
+        : placementPreset?.type === 'text' || placementPreset?.type === 'title'
+          ? 'Texte'
+          : placementPreset?.type || 'Élément';
 
   return (
     <div
@@ -717,7 +739,12 @@ export default function FreeCanvas({
           style={{ left: placeCursor.x, top: placeCursor.y }}
           aria-hidden
         >
-          {placeLabel}
+          <span className="free-canvas-placement-ghost__type">{placeLabel}</span>
+          <span className="free-canvas-placement-ghost__hint">
+            {placementPreset?.placementMode === 'draw-rect'
+              ? 'Glissez pour dessiner · Échap annule'
+              : 'Cliquez pour placer · Échap annule'}
+          </span>
         </div>
       )}
       <div className="free-canvas-pages-stack">

--- a/frontend/src/lib/canvasSidebarPlacement.js
+++ b/frontend/src/lib/canvasSidebarPlacement.js
@@ -1,0 +1,75 @@
+/**
+ * Drag & drop de presets depuis la sidebar vers le canvas (AXE-33).
+ *
+ * Sérialisation JSON dans un type MIME dédié pour coexister avec
+ * `CANVAS_IMAGE_DROP_MIME` (images).
+ */
+
+export const CANVAS_BLOCK_PRESET_MIME = 'application/x-cv-canvas-block-preset';
+
+/**
+ * Sérialise un preset de bloc pour dataTransfer.
+ * @param {object|null|undefined} preset
+ * @returns {string} JSON ou chaîne vide si invalide
+ */
+export function serializeBlockPreset(preset) {
+  if (!preset || typeof preset !== 'object' || typeof preset.type !== 'string') {
+    return '';
+  }
+  try {
+    return JSON.stringify(preset);
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Parse un preset depuis dataTransfer.
+ * @param {string|null|undefined} raw
+ * @returns {object|null}
+ */
+export function parseBlockPreset(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || typeof parsed.type !== 'string') {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Détermine si un DataTransfer contient un preset de bloc (types HTML5).
+ * @param {DataTransfer | { types?: ArrayLike<string> } | null | undefined} dataTransfer
+ * @returns {boolean}
+ */
+export function dataTransferHasBlockPreset(dataTransfer) {
+  const types = dataTransfer?.types;
+  if (!types) return false;
+  if (typeof types.includes === 'function') {
+    return types.includes(CANVAS_BLOCK_PRESET_MIME);
+  }
+  return Array.from(types).includes(CANVAS_BLOCK_PRESET_MIME);
+}
+
+/**
+ * Calcule x/y pour centrer un preset sur un point (mm).
+ * @param {object} preset
+ * @param {number} xMm
+ * @param {number} yMm
+ * @returns {{ x: number, y: number, partial: object }}
+ */
+export function placementPartialAtPoint(preset, xMm, yMm) {
+  const w = Number(preset?.w) > 0 ? Number(preset.w) : 20;
+  const h = Number(preset?.h) > 0 ? Number(preset.h) : 10;
+  const partial = { ...preset };
+  delete partial.placementMode;
+  return {
+    x: Math.max(0, xMm - w / 2),
+    y: Math.max(0, yMm - h / 2),
+    partial: { ...partial, w, h },
+  };
+}

--- a/frontend/src/styles/EditorCanvaSidebar.css
+++ b/frontend/src/styles/EditorCanvaSidebar.css
@@ -342,13 +342,39 @@
   z-index: 5;
   margin: 0;
   padding: 6px 10px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
   font-size: 0.72rem;
   font-weight: 500;
   color: var(--color-ink, #212121);
   background: var(--color-pale-green, #edfce9);
   border: 1px solid var(--color-hairline, #d9d9dd);
   border-radius: 8px;
-  pointer-events: none;
+  pointer-events: auto;
+}
+
+.editor-canva-shell__place-hint-text {
+  margin: 0;
+  flex: 1 1 auto;
+}
+
+.editor-canva-shell__place-cancel {
+  flex: 0 0 auto;
+  padding: 4px 10px;
+  border: 1px solid var(--color-primary, #17171c);
+  border-radius: 9999px;
+  background: var(--color-canvas, #ffffff);
+  color: var(--color-primary, #17171c);
+  font-size: 0.68rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.editor-canva-shell__place-cancel:focus-visible {
+  outline: 2px solid var(--color-focus-blue, #4c6ee6);
+  outline-offset: 2px;
 }
 
 .editor-canva-drawer__hint--subtle {

--- a/frontend/src/styles/FreeCanvas.css
+++ b/frontend/src/styles/FreeCanvas.css
@@ -883,8 +883,12 @@
 .free-canvas-placement-ghost {
   position: fixed;
   z-index: 10040;
-  transform: translate(-50%, -50%);
-  padding: 4px 10px;
+  transform: translate(12px, 12px);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-width: 220px;
+  padding: 6px 10px;
   font-size: 0.72rem;
   font-weight: 500;
   color: var(--color-primary, #17171c);
@@ -892,6 +896,17 @@
   border: 1px dashed var(--color-hairline, #d9d9dd);
   border-radius: 8px;
   pointer-events: none;
+  box-shadow: none;
+}
+
+.free-canvas-placement-ghost__type {
+  font-weight: 500;
+}
+
+.free-canvas-placement-ghost__hint {
+  font-size: 0.65rem;
+  font-weight: 400;
+  color: var(--color-muted, #93939f);
 }
 
 .free-canvas-draw-rect-preview {

--- a/frontend/tests/unit/canvasSidebarPlacement.test.js
+++ b/frontend/tests/unit/canvasSidebarPlacement.test.js
@@ -1,0 +1,67 @@
+/**
+ * Tests unitaires drag-from-sidebar (AXE-33).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  CANVAS_BLOCK_PRESET_MIME,
+  dataTransferHasBlockPreset,
+  parseBlockPreset,
+  placementPartialAtPoint,
+  serializeBlockPreset,
+} from '../../src/lib/canvasSidebarPlacement.js';
+
+test('serializeBlockPreset / parseBlockPreset round-trip', () => {
+  const preset = {
+    type: 'experiences',
+    bind: 'experiences',
+    w: 80,
+    h: 40,
+    style: { section_label: 'EXP' },
+  };
+  const raw = serializeBlockPreset(preset);
+  assert.ok(raw.includes('experiences'));
+  const back = parseBlockPreset(raw);
+  assert.equal(back.type, 'experiences');
+  assert.equal(back.w, 80);
+  assert.equal(back.bind, 'experiences');
+});
+
+test('serializeBlockPreset : invalide -> chaîne vide', () => {
+  assert.equal(serializeBlockPreset(null), '');
+  assert.equal(serializeBlockPreset({}), '');
+  assert.equal(serializeBlockPreset({ type: 1 }), '');
+});
+
+test('parseBlockPreset : invalide -> null', () => {
+  assert.equal(parseBlockPreset(null), null);
+  assert.equal(parseBlockPreset('{'), null);
+  assert.equal(parseBlockPreset('{"foo":1}'), null);
+});
+
+test('dataTransferHasBlockPreset', () => {
+  assert.equal(dataTransferHasBlockPreset(null), false);
+  assert.equal(
+    dataTransferHasBlockPreset({ types: [CANVAS_BLOCK_PRESET_MIME] }),
+    true,
+  );
+  assert.equal(
+    dataTransferHasBlockPreset({ types: ['text/plain'] }),
+    false,
+  );
+});
+
+test('placementPartialAtPoint centre le bloc et retire placementMode', () => {
+  const { x, y, partial } = placementPartialAtPoint(
+    { type: 'text', content: 'Hi', w: 40, h: 10, placementMode: 'draw-rect' },
+    100,
+    50,
+  );
+  assert.equal(x, 80);
+  assert.equal(y, 45);
+  assert.equal(partial.type, 'text');
+  assert.equal(partial.placementMode, undefined);
+  assert.equal(partial.w, 40);
+});


### PR DESCRIPTION
## Summary
- Drag & drop natif depuis la sidebar vers le canvas (en plus du clic-pour-placer)
- Ghost curseur avec « Cliquez pour placer · Échap annule » + bouton Annuler visible
- Après pose : sélection auto + édition inline pour texte/titre (toolbar contextuelle)

## Linear
Fixes AXE-33

## GitHub issue
Closes #61

## Test plan
- [ ] Clic tuile sidebar → ghost + clic canvas place le bloc sélectionné
- [ ] Drag tuile → drop sur page place le bloc
- [ ] Échap / bouton Annuler annulent le mode placement
- [ ] Texte placé ouvre l’édition inline ; autres blocs montrent la chrome toolbar
- [ ] `node --test tests/unit/canvasSidebarPlacement.test.js` OK
- [ ] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks` OK


Made with [Cursor](https://cursor.com)