### PR TITLE
feat(AXE-34): panneau calques simplifié (actions d'abord, Avancé masqué)

### DIFF
--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -906,6 +906,19 @@ function CvEditorBeta({
     if (cv) autoSave.schedule(cv);
   }, [layout, commitLayout, cv, autoSave]);
 
+  const handleBlocksPatch = useCallback((patches) => {
+    if (!Array.isArray(patches) || !patches.length) return;
+    let next = layout;
+    for (const item of patches) {
+      if (!item?.id) continue;
+      const { id, ...patch } = item;
+      if (!Object.keys(patch).length) continue;
+      next = updateBlock(next, id, patch);
+    }
+    commitLayout(next, { groupKey: `blocks-patch:${patches.map((p) => p.id).join(',')}` });
+    if (cv) autoSave.schedule(cv);
+  }, [layout, commitLayout, cv, autoSave]);
+
   const handleBlockStylePatch = useCallback((stylePatch) => {
     const targetIds = selectedBlockIds.length > 1 ? selectedBlockIds : (selectedBlockId ? [selectedBlockId] : []);
     if (!targetIds.length) return;
@@ -1396,6 +1409,7 @@ function CvEditorBeta({
           layout={layout}
           fontFamilies={canvasFontFamilies}
           selectedBlockId={selectedBlockId}
+          selectedBlockIds={selectedBlockIds}
           selectedBlock={selectedBlock}
           onBlockStylePatch={handleBlockStylePatch}
           templatesList={templatesList}
@@ -1409,10 +1423,14 @@ function CvEditorBeta({
           onCancelPlacement={handleCancelPlacement}
           onSelectBlock={handleSelectBlock}
           onBlockPatch={handleBlockPatchById}
+          onBlocksPatch={handleBlocksPatch}
           onBlockBringToFront={handleBlockBringToFront}
           onBlockSendToBack={handleBlockSendToBack}
           onBlockZStep={handleBlockZStep}
           onReorderLayers={handleReorderLayers}
+          onDeleteSelected={handleDeleteSelectedBlock}
+          onDuplicateSelected={handleDuplicateSelectedBlock}
+          onToggleLock={handleToggleSelectedBlockLock}
           onPickBlank={handlePickBlankCanvas}
           onApplyCanvasTemplate={handleApplyCanvasTemplate}
           onLoadProposal={handleLoadLayoutProposal}

--- a/frontend/src/components/editor/EditorCanvaPositionDrawer.jsx
+++ b/frontend/src/components/editor/EditorCanvaPositionDrawer.jsx
@@ -1,24 +1,44 @@
 import { useCallback, useMemo, useState } from 'react';
-import { getBlockTypeLabel } from '../../lib/blockInspectorSchema.js';
-import { listAllBlocks } from '../../lib/cvLayoutModelV3.js';
+import {
+  HiBars3BottomLeft,
+  HiBars3,
+  HiBars3BottomRight,
+  HiDocumentDuplicate,
+  HiLockClosed,
+  HiLockOpen,
+  HiTrash,
+} from 'react-icons/hi2';
+import { getBlockDisplayName } from '../../lib/blockInspectorSchema.js';
+import {
+  computeBlockHorizontalAlign,
+  computeHorizontalDistribute,
+  computeLayerLabelPatch,
+} from '../../lib/canvasEditorUtils.js';
+import { isNonSemanticBlockType, listAllBlocks } from '../../lib/cvLayoutModelV3.js';
 import '../../styles/EditorCanvaPositionDrawer.css';
 
 const LAYER_DRAG_MIME = 'application/x-cv-canvas-layer';
 
 /**
- * Panneau Position / calques (drawer sidebar) avec onglets.
+ * Panneau Position / calques (drawer sidebar) — actions simples d'abord (AXE-34).
  */
 export default function EditorCanvaPositionDrawer({
   layout,
   selectedBlockId,
+  selectedBlockIds = [],
   onSelectBlock,
   onBlockPatch,
+  onBlocksPatch,
   onBlockBringToFront,
   onBlockSendToBack,
   onBlockZStep,
   onReorderLayers,
+  onDeleteSelected,
+  onDuplicateSelected,
+  onToggleLock,
 }) {
   const [activeTab, setActiveTab] = useState('position');
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const [dragLayerId, setDragLayerId] = useState(null);
   const [dragOverId, setDragOverId] = useState(null);
 
@@ -27,6 +47,48 @@ export default function EditorCanvaPositionDrawer({
     [layout],
   );
   const selected = blocks.find((b) => b.id === selectedBlockId);
+  const multiIds = selectedBlockIds?.length ? selectedBlockIds : (selectedBlockId ? [selectedBlockId] : []);
+  const canDistribute = multiIds.length >= 3;
+  const canRename = selected && isNonSemanticBlockType(selected.type);
+  const locked = Boolean(selected?.locked);
+
+  const applyAlign = useCallback((align) => {
+    const targets = multiIds.length ? multiIds : (selectedBlockId ? [selectedBlockId] : []);
+    if (!targets.length) return;
+    const patches = [];
+    for (const id of targets) {
+      const block = blocks.find((b) => b.id === id);
+      if (!block || block.locked) continue;
+      const patch = computeBlockHorizontalAlign(block, align);
+      if (patch) patches.push({ id, ...patch });
+    }
+    if (!patches.length) return;
+    if (typeof onBlocksPatch === 'function') {
+      onBlocksPatch(patches);
+      return;
+    }
+    patches.forEach(({ id, ...patch }) => onBlockPatch?.(id, patch));
+  }, [blocks, multiIds, onBlockPatch, onBlocksPatch, selectedBlockId]);
+
+  const applyDistribute = useCallback(() => {
+    if (!canDistribute) return;
+    const selectedBlocks = multiIds
+      .map((id) => blocks.find((b) => b.id === id))
+      .filter(Boolean);
+    const patches = computeHorizontalDistribute(selectedBlocks);
+    if (!patches.length) return;
+    if (typeof onBlocksPatch === 'function') {
+      onBlocksPatch(patches);
+      return;
+    }
+    patches.forEach(({ id, x }) => onBlockPatch?.(id, { x }));
+  }, [blocks, canDistribute, multiIds, onBlockPatch, onBlocksPatch]);
+
+  const handleRename = useCallback((value) => {
+    if (!selected || !canRename) return;
+    const patch = computeLayerLabelPatch(selected, value);
+    if (patch) onBlockPatch?.(selected.id, patch);
+  }, [canRename, onBlockPatch, selected]);
 
   const handleLayerDragStart = useCallback((blockId, event) => {
     setDragLayerId(blockId);
@@ -109,25 +171,116 @@ export default function EditorCanvaPositionDrawer({
             </p>
           )}
           {selected && (
-            <div className="editor-canva-position-drawer__geom">
-              {['x', 'y', 'w', 'h', 'z'].map((key) => (
-                <label key={key}>
-                  {key.toUpperCase()}
+            <>
+              <p className="editor-canva-position-drawer__selection-name">
+                {getBlockDisplayName(selected)}
+                {multiIds.length > 1 ? ` · ${multiIds.length} sélectionnés` : ''}
+              </p>
+
+              <div className="editor-canva-position-drawer__section">
+                <p className="editor-canva-position-drawer__section-label">Aligner</p>
+                <div className="editor-canva-position-drawer__action-row" role="group" aria-label="Alignement horizontal">
+                  <button type="button" title="Aligner à gauche" aria-label="Aligner à gauche" disabled={locked && multiIds.length <= 1} onClick={() => applyAlign('left')}>
+                    <HiBars3BottomLeft size={16} aria-hidden />
+                  </button>
+                  <button type="button" title="Centrer" aria-label="Centrer" disabled={locked && multiIds.length <= 1} onClick={() => applyAlign('center')}>
+                    <HiBars3 size={16} aria-hidden />
+                  </button>
+                  <button type="button" title="Aligner à droite" aria-label="Aligner à droite" disabled={locked && multiIds.length <= 1} onClick={() => applyAlign('right')}>
+                    <HiBars3BottomRight size={16} aria-hidden />
+                  </button>
+                  <button
+                    type="button"
+                    className="editor-canva-position-drawer__action-text"
+                    title={canDistribute ? 'Distribuer horizontalement' : 'Sélectionnez au moins 3 éléments'}
+                    aria-label="Distribuer horizontalement"
+                    disabled={!canDistribute}
+                    onClick={applyDistribute}
+                  >
+                    Distribuer
+                  </button>
+                </div>
+              </div>
+
+              <div className="editor-canva-position-drawer__section">
+                <p className="editor-canva-position-drawer__section-label">Plan</p>
+                <div className="editor-canva-position-drawer__action-row editor-canva-position-drawer__action-row--wrap">
+                  <button type="button" className="editor-canva-position-drawer__action-text" onClick={() => onBlockBringToFront?.(selected.id)}>
+                    Premier plan
+                  </button>
+                  <button type="button" className="editor-canva-position-drawer__action-text" onClick={() => onBlockSendToBack?.(selected.id)}>
+                    Arrière-plan
+                  </button>
+                </div>
+              </div>
+
+              <div className="editor-canva-position-drawer__section">
+                <p className="editor-canva-position-drawer__section-label">Actions</p>
+                <div className="editor-canva-position-drawer__action-row" role="group" aria-label="Actions sur le bloc">
+                  <button
+                    type="button"
+                    title={locked ? 'Déverrouiller' : 'Verrouiller'}
+                    aria-label={locked ? 'Déverrouiller' : 'Verrouiller'}
+                    aria-pressed={locked}
+                    onClick={() => onToggleLock?.()}
+                  >
+                    {locked ? <HiLockClosed size={16} aria-hidden /> : <HiLockOpen size={16} aria-hidden />}
+                  </button>
+                  <button type="button" title="Dupliquer" aria-label="Dupliquer" onClick={() => onDuplicateSelected?.()}>
+                    <HiDocumentDuplicate size={16} aria-hidden />
+                  </button>
+                  <button
+                    type="button"
+                    className="editor-canva-position-drawer__btn-danger"
+                    title="Supprimer"
+                    aria-label="Supprimer"
+                    onClick={() => onDeleteSelected?.()}
+                  >
+                    <HiTrash size={16} aria-hidden />
+                  </button>
+                </div>
+              </div>
+
+              {canRename && (
+                <label className="editor-canva-position-drawer__rename">
+                  Nom du calque
                   <input
-                    type="number"
-                    step={key === 'z' ? 1 : 0.5}
-                    value={selected[key] ?? 0}
-                    onChange={(e) => onBlockPatch?.(selected.id, { [key]: parseFloat(e.target.value) || 0 })}
+                    type="text"
+                    maxLength={60}
+                    value={typeof selected.style?.layer_label === 'string' ? selected.style.layer_label : ''}
+                    placeholder={getBlockDisplayName({ type: selected.type })}
+                    onChange={(e) => handleRename(e.target.value)}
+                    disabled={locked}
                   />
                 </label>
-              ))}
-              <div className="editor-canva-position-drawer__z-actions">
-                <button type="button" onClick={() => onBlockBringToFront?.(selected.id)}>Premier plan</button>
-                <button type="button" onClick={() => onBlockSendToBack?.(selected.id)}>Arrière-plan</button>
-                <button type="button" onClick={() => onBlockZStep?.(selected.id, 1)}>+ plan</button>
-                <button type="button" onClick={() => onBlockZStep?.(selected.id, -1)}>− plan</button>
-              </div>
-            </div>
+              )}
+
+              <details
+                className="editor-canva-position-drawer__advanced"
+                open={advancedOpen}
+                onToggle={(e) => setAdvancedOpen(e.currentTarget.open)}
+              >
+                <summary>Avancé</summary>
+                <div className="editor-canva-position-drawer__geom">
+                  {['x', 'y', 'w', 'h', 'z'].map((key) => (
+                    <label key={key}>
+                      {key.toUpperCase()}
+                      <input
+                        type="number"
+                        step={key === 'z' ? 1 : 0.5}
+                        value={selected[key] ?? 0}
+                        disabled={locked && key !== 'z'}
+                        onChange={(e) => onBlockPatch?.(selected.id, { [key]: parseFloat(e.target.value) || 0 })}
+                      />
+                    </label>
+                  ))}
+                  <div className="editor-canva-position-drawer__z-actions">
+                    <button type="button" onClick={() => onBlockZStep?.(selected.id, 1)}>+ plan</button>
+                    <button type="button" onClick={() => onBlockZStep?.(selected.id, -1)}>− plan</button>
+                  </div>
+                </div>
+              </details>
+            </>
           )}
         </div>
       )}
@@ -168,8 +321,8 @@ export default function EditorCanvaPositionDrawer({
                   }
                   onClick={() => onSelectBlock?.(b.id)}
                 >
-                  <span className="editor-canva-position-drawer__layer-z">z{b.z ?? 0}</span>
-                  <span>{getBlockTypeLabel(b.type)}</span>
+                  {b.locked ? <HiLockClosed size={12} aria-hidden className="editor-canva-position-drawer__layer-lock" /> : null}
+                  <span className="editor-canva-position-drawer__layer-name">{getBlockDisplayName(b)}</span>
                 </button>
               </li>
             ))}

--- a/frontend/src/components/editor/EditorCanvaPositionDrawer.jsx
+++ b/frontend/src/components/editor/EditorCanvaPositionDrawer.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   HiBars3BottomLeft,
   HiBars3,
@@ -18,6 +18,14 @@ import { isNonSemanticBlockType, listAllBlocks } from '../../lib/cvLayoutModelV3
 import '../../styles/EditorCanvaPositionDrawer.css';
 
 const LAYER_DRAG_MIME = 'application/x-cv-canvas-layer';
+const TAB_POSITION_ID = 'editor-canva-position-tab';
+const TAB_LAYERS_ID = 'editor-canva-layers-tab';
+const PANEL_POSITION_ID = 'editor-canva-position-panel';
+const PANEL_LAYERS_ID = 'editor-canva-layers-panel';
+
+function layerLabelFromBlock(block) {
+  return typeof block?.style?.layer_label === 'string' ? block.style.layer_label : '';
+}
 
 /**
  * Panneau Position / calques (drawer sidebar) — actions simples d'abord (AXE-34).
@@ -41,6 +49,7 @@ export default function EditorCanvaPositionDrawer({
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [dragLayerId, setDragLayerId] = useState(null);
   const [dragOverId, setDragOverId] = useState(null);
+  const [renameDraft, setRenameDraft] = useState('');
 
   const blocks = useMemo(
     () => listAllBlocks(layout).slice().sort((a, b) => (b.z || 0) - (a.z || 0)),
@@ -48,9 +57,24 @@ export default function EditorCanvaPositionDrawer({
   );
   const selected = blocks.find((b) => b.id === selectedBlockId);
   const multiIds = selectedBlockIds?.length ? selectedBlockIds : (selectedBlockId ? [selectedBlockId] : []);
+  const selectedIdSet = useMemo(() => new Set(multiIds), [multiIds]);
   const canDistribute = multiIds.length >= 3;
   const canRename = selected && isNonSemanticBlockType(selected.type);
   const locked = Boolean(selected?.locked);
+  const lockedInSelection = multiIds.filter((id) => blocks.find((b) => b.id === id)?.locked).length;
+  const showLockedAlignHint = multiIds.length > 1 && lockedInSelection > 0 && lockedInSelection < multiIds.length;
+
+  useEffect(() => {
+    setRenameDraft(layerLabelFromBlock(selected));
+  }, [selectedBlockId, selected?.style?.layer_label]);
+
+  const commitRename = useCallback(() => {
+    if (!selected || !canRename || locked) return;
+    const current = layerLabelFromBlock(selected);
+    if (renameDraft === current) return;
+    const patch = computeLayerLabelPatch(selected, renameDraft);
+    if (patch) onBlockPatch?.(selected.id, patch);
+  }, [canRename, locked, onBlockPatch, renameDraft, selected]);
 
   const applyAlign = useCallback((align) => {
     const targets = multiIds.length ? multiIds : (selectedBlockId ? [selectedBlockId] : []);
@@ -83,12 +107,6 @@ export default function EditorCanvaPositionDrawer({
     }
     patches.forEach(({ id, x }) => onBlockPatch?.(id, { x }));
   }, [blocks, canDistribute, multiIds, onBlockPatch, onBlocksPatch]);
-
-  const handleRename = useCallback((value) => {
-    if (!selected || !canRename) return;
-    const patch = computeLayerLabelPatch(selected, value);
-    if (patch) onBlockPatch?.(selected.id, patch);
-  }, [canRename, onBlockPatch, selected]);
 
   const handleLayerDragStart = useCallback((blockId, event) => {
     setDragLayerId(blockId);
@@ -137,8 +155,11 @@ export default function EditorCanvaPositionDrawer({
       <div className="editor-canva-position-drawer__tabs" role="tablist" aria-label="Position ou calques">
         <button
           type="button"
+          id={TAB_POSITION_ID}
           role="tab"
+          aria-controls={PANEL_POSITION_ID}
           aria-selected={activeTab === 'position'}
+          tabIndex={activeTab === 'position' ? 0 : -1}
           className={
             activeTab === 'position'
               ? 'editor-canva-position-drawer__tab editor-canva-position-drawer__tab--active'
@@ -150,8 +171,11 @@ export default function EditorCanvaPositionDrawer({
         </button>
         <button
           type="button"
+          id={TAB_LAYERS_ID}
           role="tab"
+          aria-controls={PANEL_LAYERS_ID}
           aria-selected={activeTab === 'layers'}
+          tabIndex={activeTab === 'layers' ? 0 : -1}
           className={
             activeTab === 'layers'
               ? 'editor-canva-position-drawer__tab editor-canva-position-drawer__tab--active'
@@ -164,7 +188,11 @@ export default function EditorCanvaPositionDrawer({
       </div>
 
       {activeTab === 'position' && (
-        <div role="tabpanel">
+        <div
+          id={PANEL_POSITION_ID}
+          role="tabpanel"
+          aria-labelledby={TAB_POSITION_ID}
+        >
           {!selected && (
             <p className="editor-canva-position-drawer__empty">
               Sélectionnez un élément sur le canevas pour ajuster sa position.
@@ -200,6 +228,11 @@ export default function EditorCanvaPositionDrawer({
                     Distribuer
                   </button>
                 </div>
+                {showLockedAlignHint && (
+                  <p className="editor-canva-position-drawer__hint">
+                    Les éléments verrouillés restent en place.
+                  </p>
+                )}
               </div>
 
               <div className="editor-canva-position-drawer__section">
@@ -247,9 +280,16 @@ export default function EditorCanvaPositionDrawer({
                   <input
                     type="text"
                     maxLength={60}
-                    value={typeof selected.style?.layer_label === 'string' ? selected.style.layer_label : ''}
+                    value={renameDraft}
                     placeholder={getBlockDisplayName({ type: selected.type })}
-                    onChange={(e) => handleRename(e.target.value)}
+                    onChange={(e) => setRenameDraft(e.target.value)}
+                    onBlur={commitRename}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        e.currentTarget.blur();
+                      }
+                    }}
                     disabled={locked}
                   />
                 </label>
@@ -286,7 +326,11 @@ export default function EditorCanvaPositionDrawer({
       )}
 
       {activeTab === 'layers' && (
-        <div role="tabpanel">
+        <div
+          id={PANEL_LAYERS_ID}
+          role="tabpanel"
+          aria-labelledby={TAB_LAYERS_ID}
+        >
           <p className="editor-canva-position-drawer__layers-hint">
             Glissez les calques pour changer l&apos;ordre d&apos;empilement.
           </p>
@@ -315,10 +359,11 @@ export default function EditorCanvaPositionDrawer({
                 <button
                   type="button"
                   className={
-                    b.id === selectedBlockId
+                    selectedIdSet.has(b.id)
                       ? 'editor-canva-position-drawer__layer editor-canva-position-drawer__layer--active'
                       : 'editor-canva-position-drawer__layer'
                   }
+                  aria-pressed={selectedIdSet.has(b.id)}
                   onClick={() => onSelectBlock?.(b.id)}
                 >
                   {b.locked ? <HiLockClosed size={12} aria-hidden className="editor-canva-position-drawer__layer-lock" /> : null}

--- a/frontend/src/components/editor/EditorCanvaSidebar.jsx
+++ b/frontend/src/components/editor/EditorCanvaSidebar.jsx
@@ -197,6 +197,7 @@ export default function EditorCanvaSidebar({
   layout = null,
   fontFamilies = null,
   selectedBlockId = null,
+  selectedBlockIds = [],
   selectedBlock = null,
   onBlockStylePatch,
   showGrid = false,
@@ -207,10 +208,14 @@ export default function EditorCanvaSidebar({
   onCancelPlacement,
   onSelectBlock,
   onBlockPatch,
+  onBlocksPatch,
   onBlockBringToFront,
   onBlockSendToBack,
   onBlockZStep,
   onReorderLayers,
+  onDeleteSelected,
+  onDuplicateSelected,
+  onToggleLock,
   onPickBlank,
   onApplyCanvasTemplate,
   onLoadProposal,
@@ -675,12 +680,17 @@ export default function EditorCanvaSidebar({
             <EditorCanvaPositionDrawer
               layout={layout}
               selectedBlockId={selectedBlockId}
+              selectedBlockIds={selectedBlockIds}
               onSelectBlock={onSelectBlock}
               onBlockPatch={onBlockPatch}
+              onBlocksPatch={onBlocksPatch}
               onBlockBringToFront={onBlockBringToFront}
               onBlockSendToBack={onBlockSendToBack}
               onBlockZStep={onBlockZStep}
               onReorderLayers={onReorderLayers}
+              onDeleteSelected={onDeleteSelected}
+              onDuplicateSelected={onDuplicateSelected}
+              onToggleLock={onToggleLock}
             />
           )}
         </div>

--- a/frontend/src/lib/blockInspectorSchema.js
+++ b/frontend/src/lib/blockInspectorSchema.js
@@ -9,7 +9,7 @@ const TYPE_LABELS = Object.freeze({
   identity: 'Identité',
   photo: 'Photo',
   contact: 'Contact',
-  resume: 'Résumé',
+  resume: 'Profil',
   experiences: 'Expériences',
   formations: 'Formations',
   certifications: 'Certifications',
@@ -18,14 +18,40 @@ const TYPE_LABELS = Object.freeze({
   languages: 'Langues',
   text: 'Texte libre',
   title: 'Titre',
+  image: 'Image',
   'shape:line': 'Trait',
-  'shape:rect': 'Bandeau',
+  'shape:rect': 'Rectangle',
+  'shape:frame': 'Cadre',
+  'shape:circle': 'Cercle',
+  'shape:ellipse': 'Ellipse',
+  'shape:triangle': 'Triangle',
+  'shape:diamond': 'Losange',
+  'shape:star': 'Étoile',
+  'shape:hexagon': 'Hexagone',
+  'shape:arrow-right': 'Flèche',
+  'shape:arrow-left': 'Flèche',
+  'shape:arrow-up': 'Flèche',
+  'shape:arrow-down': 'Flèche',
+  'shape:cross': 'Croix',
+  'shape:heart': 'Cœur',
   icon: 'Icône',
   qrcode: 'QR code',
 });
 
 export function getBlockTypeLabel(type) {
   return TYPE_LABELS[type] || type || 'Bloc';
+}
+
+/**
+ * Nom affiché dans le panneau calques (label custom ou type).
+ * @param {object|null|undefined} block
+ * @returns {string}
+ */
+export function getBlockDisplayName(block) {
+  if (!block || typeof block !== 'object') return 'Bloc';
+  const custom = block.style?.layer_label;
+  if (typeof custom === 'string' && custom.trim()) return custom.trim();
+  return getBlockTypeLabel(block.type);
 }
 
 /** Champs position / taille (tous les blocs). */

--- a/frontend/src/lib/canvasEditorUtils.js
+++ b/frontend/src/lib/canvasEditorUtils.js
@@ -4,6 +4,7 @@
  */
 
 import { isCanvasInlineEditableType } from './canvasInlineEdit.js';
+import { PAGE_MARGIN_MM, PAGE_WIDTH_MM } from './cvLayoutModelV3.js';
 
 const INVALID_FILENAME_CHARS = /[<>:"/\\|?*]/g;
 
@@ -98,4 +99,87 @@ export function sameLayout(a, b) {
   } catch {
     return false;
   }
+}
+
+/**
+ * Alignement horizontal d'un bloc sur la page A4 (AXE-34).
+ * @param {object|null|undefined} block
+ * @param {'left'|'center'|'right'} align
+ * @returns {{ x: number } | null}
+ */
+export function computeBlockHorizontalAlign(block, align) {
+  if (!block || typeof block !== 'object') return null;
+  const w = Number(block.w);
+  const width = Number.isFinite(w) && w > 0 ? w : 0;
+  if (align === 'left') {
+    return { x: PAGE_MARGIN_MM };
+  }
+  if (align === 'center') {
+    return { x: Math.max(0, (PAGE_WIDTH_MM - width) / 2) };
+  }
+  if (align === 'right') {
+    return { x: Math.max(0, PAGE_WIDTH_MM - PAGE_MARGIN_MM - width) };
+  }
+  return null;
+}
+
+/**
+ * Répartition horizontale égale entre le bloc le plus à gauche et le plus à droite.
+ * Nécessite au moins 3 blocs. Retourne des patches `{ id, x }` (les extrémités inchangées).
+ * @param {Array<object|null|undefined>} blocks
+ * @returns {Array<{ id: string, x: number }>}
+ */
+export function computeHorizontalDistribute(blocks) {
+  const list = (Array.isArray(blocks) ? blocks : [])
+    .filter((b) => b && typeof b === 'object' && typeof b.id === 'string' && !b.locked)
+    .map((b) => ({
+      id: b.id,
+      x: Number(b.x) || 0,
+      w: Number.isFinite(Number(b.w)) && Number(b.w) > 0 ? Number(b.w) : 0,
+    }))
+    .sort((a, b) => a.x - b.x || a.id.localeCompare(b.id));
+
+  if (list.length < 3) return [];
+
+  const first = list[0];
+  const last = list[list.length - 1];
+  const spanStart = first.x;
+  const spanEnd = last.x + last.w;
+  const totalW = list.reduce((sum, b) => sum + b.w, 0);
+  const gap = (spanEnd - spanStart - totalW) / (list.length - 1);
+  if (!Number.isFinite(gap)) return [];
+
+  const patches = [];
+  let cursor = spanStart;
+  list.forEach((b, index) => {
+    if (index === 0) {
+      cursor = b.x + b.w + gap;
+      return;
+    }
+    if (index === list.length - 1) return;
+    const nextX = cursor;
+    if (Math.abs(nextX - b.x) > 0.01) {
+      patches.push({ id: b.id, x: Math.max(0, nextX) });
+    }
+    cursor = nextX + b.w + gap;
+  });
+  return patches;
+}
+
+/**
+ * Patch style.layer_label pour renommer un calque décoratif.
+ * @param {object|null|undefined} block
+ * @param {string} name
+ * @returns {{ style: object } | null}
+ */
+export function computeLayerLabelPatch(block, name) {
+  if (!block || typeof block !== 'object') return null;
+  const label = String(name || '').trim().slice(0, 60);
+  const style = { ...(block.style && typeof block.style === 'object' ? block.style : {}) };
+  if (!label) {
+    delete style.layer_label;
+  } else {
+    style.layer_label = label;
+  }
+  return { style };
 }

--- a/frontend/src/styles/EditorCanvaPositionDrawer.css
+++ b/frontend/src/styles/EditorCanvaPositionDrawer.css
@@ -30,11 +30,16 @@
 }
 
 .editor-canva-position-drawer__empty,
-.editor-canva-position-drawer__layers-hint {
+.editor-canva-position-drawer__layers-hint,
+.editor-canva-position-drawer__hint {
   margin: 0 0 10px;
   font-size: 0.72rem;
   line-height: 1.45;
   color: var(--color-muted, #93939f);
+}
+
+.editor-canva-position-drawer__hint {
+  margin: 6px 0 0;
 }
 
 .editor-canva-position-drawer__selection-name {

--- a/frontend/src/styles/EditorCanvaPositionDrawer.css
+++ b/frontend/src/styles/EditorCanvaPositionDrawer.css
@@ -27,7 +27,6 @@
 .editor-canva-position-drawer__tab--active {
   background: var(--color-canvas, #fff);
   color: var(--color-ink, #212121);
-  box-shadow: 0 1px 2px rgba(23, 23, 28, 0.06);
 }
 
 .editor-canva-position-drawer__empty,
@@ -36,6 +35,131 @@
   font-size: 0.72rem;
   line-height: 1.45;
   color: var(--color-muted, #93939f);
+}
+
+.editor-canva-position-drawer__selection-name {
+  margin: 0 0 12px;
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--color-ink, #212121);
+  line-height: 1.3;
+}
+
+.editor-canva-position-drawer__section {
+  margin-bottom: 14px;
+}
+
+.editor-canva-position-drawer__section-label {
+  margin: 0 0 6px;
+  font-family: CohereMono, Arial, ui-sans-serif, system-ui, sans-serif;
+  font-size: 0.65rem;
+  font-weight: 400;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-muted, #93939f);
+}
+
+.editor-canva-position-drawer__action-row {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 6px;
+  align-items: stretch;
+}
+
+.editor-canva-position-drawer__action-row--wrap {
+  flex-wrap: wrap;
+}
+
+.editor-canva-position-drawer__action-row > button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 34px;
+  min-height: 34px;
+  padding: 6px 8px;
+  border: 1px solid var(--color-hairline, #d9d9dd);
+  border-radius: 8px;
+  background: var(--color-canvas, #fff);
+  color: var(--color-ink, #212121);
+  cursor: pointer;
+}
+
+.editor-canva-position-drawer__action-row > button:hover:not(:disabled) {
+  background: var(--color-soft-stone, #eeece7);
+}
+
+.editor-canva-position-drawer__action-row > button:focus-visible {
+  outline: 2px solid var(--color-focus-blue, #4c6ee6);
+  outline-offset: 1px;
+}
+
+.editor-canva-position-drawer__action-row > button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.editor-canva-position-drawer__action-text {
+  flex: 1 1 auto;
+  font-size: 0.72rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.editor-canva-position-drawer__btn-danger {
+  color: var(--color-error, #b30000);
+}
+
+.editor-canva-position-drawer__rename {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 14px;
+  font-size: 0.72rem;
+  color: var(--color-body-muted, #616161);
+}
+
+.editor-canva-position-drawer__rename input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 8px 10px;
+  border: 1px solid var(--color-hairline, #d9d9dd);
+  border-radius: 8px;
+  font-size: 0.78rem;
+  color: var(--color-ink, #212121);
+  background: var(--color-canvas, #fff);
+}
+
+.editor-canva-position-drawer__rename input:focus-visible {
+  outline: none;
+  border-color: var(--color-form-focus, #9b60aa);
+}
+
+.editor-canva-position-drawer__advanced {
+  margin-top: 4px;
+  border-top: 1px solid var(--color-card-border, #f2f2f2);
+  padding-top: 10px;
+}
+
+.editor-canva-position-drawer__advanced > summary {
+  cursor: pointer;
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--color-body-muted, #616161);
+  list-style: none;
+  margin-bottom: 10px;
+}
+
+.editor-canva-position-drawer__advanced > summary::-webkit-details-marker {
+  display: none;
+}
+
+.editor-canva-position-drawer__advanced > summary::before {
+  content: '▸ ';
+  color: var(--color-muted, #93939f);
+}
+
+.editor-canva-position-drawer__advanced[open] > summary::before {
+  content: '▾ ';
 }
 
 .editor-canva-position-drawer__geom {
@@ -70,6 +194,11 @@
 .editor-canva-position-drawer__geom input:focus-visible {
   outline: none;
   border-color: var(--color-form-focus, #9b60aa);
+}
+
+.editor-canva-position-drawer__geom input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .editor-canva-position-drawer__z-actions {
@@ -152,6 +281,7 @@
   text-align: left;
   font-size: 0.78rem;
   cursor: pointer;
+  color: var(--color-ink, #212121);
 }
 
 .editor-canva-position-drawer__layer:hover {
@@ -161,4 +291,15 @@
 .editor-canva-position-drawer__layer--active {
   background: var(--color-pale-green, #edfce9);
   color: var(--color-primary, #17171c);
+}
+
+.editor-canva-position-drawer__layer-lock {
+  flex-shrink: 0;
+  color: var(--color-muted, #93939f);
+}
+
+.editor-canva-position-drawer__layer-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/frontend/tests/unit/blockInspectorSchema.test.js
+++ b/frontend/tests/unit/blockInspectorSchema.test.js
@@ -5,6 +5,7 @@ import {
   blockHasEditableContent,
   blockIsSemanticBound,
   getBlockContentFields,
+  getBlockDisplayName,
   getBlockStyleFields,
   getBlockTypeLabel,
 } from '../../src/lib/blockInspectorSchema.js';
@@ -12,6 +13,15 @@ import {
 test('getBlockTypeLabel', () => {
   assert.equal(getBlockTypeLabel('experiences'), 'Expériences');
   assert.equal(getBlockTypeLabel('text'), 'Texte libre');
+  assert.equal(getBlockTypeLabel('shape:rect'), 'Rectangle');
+});
+
+test('getBlockDisplayName : custom layer_label prioritaire', () => {
+  assert.equal(getBlockDisplayName({ type: 'text' }), 'Texte libre');
+  assert.equal(
+    getBlockDisplayName({ type: 'shape:rect', style: { layer_label: 'Bandeau vert' } }),
+    'Bandeau vert',
+  );
 });
 
 test('blockIsSemanticBound', () => {

--- a/frontend/tests/unit/canvasEditorUtils.test.js
+++ b/frontend/tests/unit/canvasEditorUtils.test.js
@@ -5,6 +5,9 @@ import {
   blockSupportsEditHint,
   editHintMessageForBlock,
   buildCanvasPdfFilename,
+  computeBlockHorizontalAlign,
+  computeHorizontalDistribute,
+  computeLayerLabelPatch,
   SEMANTIC_EDIT_NOTE_DISMISSED_KEY,
   dismissSemanticEditNote,
   isSemanticEditNoteDismissed,
@@ -49,4 +52,32 @@ test('buildCanvasPdfFilename : identité et titre', () => {
     buildCanvasPdfFilename({ prenom: 'Marie', nom: 'Dupont', titre_professionnel: 'Dev' }),
     'CV - Marie Dupont - Dev.pdf',
   );
+});
+
+test('computeBlockHorizontalAlign : left center right', () => {
+  const block = { w: 50 };
+  assert.deepEqual(computeBlockHorizontalAlign(block, 'left'), { x: 10 });
+  assert.deepEqual(computeBlockHorizontalAlign(block, 'center'), { x: 80 });
+  assert.deepEqual(computeBlockHorizontalAlign(block, 'right'), { x: 150 });
+  assert.equal(computeBlockHorizontalAlign(null, 'left'), null);
+});
+
+test('computeHorizontalDistribute : ≥3 blocs, extrémités fixes', () => {
+  const patches = computeHorizontalDistribute([
+    { id: 'a', x: 10, w: 20 },
+    { id: 'b', x: 40, w: 20 },
+    { id: 'c', x: 100, w: 20 },
+  ]);
+  assert.equal(patches.length, 1);
+  assert.equal(patches[0].id, 'b');
+  assert.equal(patches[0].x, 55);
+  assert.deepEqual(computeHorizontalDistribute([{ id: 'a', x: 0, w: 10 }]), []);
+});
+
+test('computeLayerLabelPatch : set et clear', () => {
+  const set = computeLayerLabelPatch({ style: { color: '#000' } }, 'Bandeau');
+  assert.equal(set.style.layer_label, 'Bandeau');
+  assert.equal(set.style.color, '#000');
+  const clear = computeLayerLabelPatch({ style: { layer_label: 'x' } }, '  ');
+  assert.equal(clear.style.layer_label, undefined);
 });


### PR DESCRIPTION
## Summary
- Panneau Position : aligner / centrer / distribuer, premier/arrière-plan, verrouiller / dupliquer / supprimer en premier
- Coordonnées `x/y/w/h/z` repliées sous **Avancé**
- Calques avec noms humains + renommage des blocs décoratifs (`style.layer_label`)

## Linear
Fixes AXE-34

## GitHub issue
Closes #63

## Test plan
- [ ] Sidebar → Position : actions nommées visibles sans ouvrir Avancé
- [ ] Aligner gauche / centrer / droite sur un bloc sélectionné
- [ ] Distribuer actif uniquement avec ≥ 3 éléments sélectionnés
- [ ] Verrouiller / dupliquer / supprimer depuis le panneau
- [ ] Renommer un trait / rectangle / texte libre ; le nom apparaît dans Calques
- [ ] Avancé : éditer x/y/w/h/z toujours possible
- [ ] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks` OK

Made with [Cursor](https://cursor.com)