### PR TITLE
feat(AXE-35): accessibilité clavier + responsive dégradé du canvas

### DIFF
--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -120,6 +120,13 @@ import {
   listNonFaithfulBlocks,
   summarizeNonFaithfulBlocks,
 } from '../../lib/canvasPdfFidelity.js';
+import {
+  canvasNudgeDeltaFromKey,
+  CANVAS_DESKTOP_LAYOUT_MQ,
+  dismissCanvasDesktopHint,
+  isCanvasDesktopHintDismissed,
+  isCanvasTypingTarget,
+} from '../../lib/freeCanvasSelection.js';
 
 import '../../styles/CvEditorBeta.css';
 import '../../styles/EditorCanvaSidebar.css';
@@ -176,6 +183,8 @@ function CvEditorBeta({
   const [importToast, setImportToast] = useState('');
   const [editHintOpen, setEditHintOpen] = useState(false);
   const [semanticEditNoteOpen, setSemanticEditNoteOpen] = useState(false);
+  const [narrowViewport, setNarrowViewport] = useState(false);
+  const [desktopHintDismissed, setDesktopHintDismissed] = useState(() => isCanvasDesktopHintDismissed());
   const importCleanupRef = useRef(null);
   const blocksClipboardRef = useRef([]);
   const [profileLoadAttempt, setProfileLoadAttempt] = useState(0);
@@ -1177,9 +1186,7 @@ function CvEditorBeta({
 
   useEffect(() => {
     const onKeyDown = (e) => {
-      const tag = document.activeElement?.tagName?.toLowerCase();
-      if (tag === 'input' || tag === 'textarea' || tag === 'select') return;
-      if (document.activeElement?.isContentEditable) return;
+      if (isCanvasTypingTarget(document.activeElement) || isCanvasTypingTarget(e.target)) return;
       if (editingBlockId && (e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'a') {
         e.preventDefault();
         selectAllInEditableRoot();
@@ -1225,20 +1232,27 @@ function CvEditorBeta({
         setSelectedBlockIds([]);
         return;
       }
-      const step = e.shiftKey ? 5 : 1;
-      let dx = 0;
-      let dy = 0;
-      if (e.key === 'ArrowLeft') dx = -step;
-      else if (e.key === 'ArrowRight') dx = step;
-      else if (e.key === 'ArrowUp') dy = -step;
-      else if (e.key === 'ArrowDown') dy = step;
-      else return;
+      const delta = canvasNudgeDeltaFromKey(e.key, { shiftKey: e.shiftKey });
+      if (!delta) return;
       e.preventDefault();
-      handleNudgeSelectedBlock(dx, dy);
+      handleNudgeSelectedBlock(delta.dx, delta.dy);
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [selectedBlockIds, editingBlockId, handleDeleteSelectedBlock, handleNudgeSelectedBlock, handlePasteBlocks, layout]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return undefined;
+    const mq = window.matchMedia(CANVAS_DESKTOP_LAYOUT_MQ);
+    const sync = () => setNarrowViewport(Boolean(mq.matches));
+    sync();
+    if (typeof mq.addEventListener === 'function') {
+      mq.addEventListener('change', sync);
+      return () => mq.removeEventListener('change', sync);
+    }
+    mq.addListener(sync);
+    return () => mq.removeListener(sync);
+  }, []);
 
   if (loading) {
     return (
@@ -1276,8 +1290,24 @@ function CvEditorBeta({
 
   return (
     <div className="cv-editor-beta">
-      <header className="cv-editor-beta-topbar">
-        <div className="cv-editor-beta-topbar-left">
+      {narrowViewport && !desktopHintDismissed && (
+        <div className="cv-editor-beta-desktop-hint" role="status">
+          <p className="cv-editor-beta-desktop-hint__text">
+            Édition de mise en page recommandée sur un ordinateur. Sur mobile ou tablette, le canvas reste consultable mais moins confortable à éditer.
+          </p>
+          <button
+            type="button"
+            className="cv-editor-beta-desktop-hint__dismiss"
+            onClick={() => {
+              dismissCanvasDesktopHint();
+              setDesktopHintDismissed(true);
+            }}
+          >
+            Compris
+          </button>
+        </div>
+      )}
+      <header className="cv-editor-beta-topbar">        <div className="cv-editor-beta-topbar-left">
           <span className="cv-editor-beta-badge">Mode Beta</span>
           <div className="cv-editor-beta-history-btns">
             <button

--- a/frontend/src/components/editor/EditorCanvaSidebar.jsx
+++ b/frontend/src/components/editor/EditorCanvaSidebar.jsx
@@ -338,7 +338,7 @@ export default function EditorCanvaSidebar({
           </button>
         </div>
       )}
-      <nav className="editor-canva-rail" aria-label="Familles d’outils">
+      <nav className="editor-canva-rail" aria-label="Familles d’outils du canvas">
         {SECTIONS.map((section) => {
           const Icon = section.icon;
           const active = railActiveId === section.id;
@@ -346,7 +346,10 @@ export default function EditorCanvaSidebar({
             <button
               key={section.id}
               type="button"
-              aria-current={active ? 'true' : undefined}
+              aria-label={section.title || section.label}
+              aria-pressed={active}
+              aria-expanded={active}
+              aria-controls={active ? 'editor-canva-drawer' : undefined}
               className={active ? 'editor-canva-rail__btn editor-canva-rail__btn--active' : 'editor-canva-rail__btn'}
               title={section.title || section.label}
               onClick={() => toggleSection(section.id)}
@@ -359,10 +362,23 @@ export default function EditorCanvaSidebar({
       </nav>
       {openSection && (
         <div
+          id="editor-canva-drawer"
           className={[
             'editor-canva-drawer',
             openSection === 'fonts' ? 'editor-canva-drawer--fill' : '',
           ].filter(Boolean).join(' ')}
+          role="region"
+          aria-label={
+            openSection === 'sections'
+              ? 'Panneau Sections CV'
+              : openSection === 'design' || openSection === 'models'
+                ? 'Panneau Design'
+                : openSection === 'import'
+                  ? 'Panneau Importer'
+                  : openSection === 'position'
+                    ? 'Panneau Position et calques'
+                    : 'Panneau outils canvas'
+          }
         >
           {openSection === 'sections' && (
             <>

--- a/frontend/src/components/editor/FreeCanvas.jsx
+++ b/frontend/src/components/editor/FreeCanvas.jsx
@@ -849,6 +849,7 @@ export default function FreeCanvas({
                     onResizePointerMove={handleResizePointerMove}
                     onResizePointerUp={handleResizePointerUp}
                     onResizePointerCancel={handleResizePointerUp}
+                    onSelect={onSelectBlock}
                     onDoubleClickEdit={onStartBlockEdit}
                     onImageEdit={onImageEdit}
                     onInnerBlur={onCommitBlockEdit}

--- a/frontend/src/components/editor/FreeCanvasBlock.jsx
+++ b/frontend/src/components/editor/FreeCanvasBlock.jsx
@@ -28,6 +28,7 @@ import {
 import { blockHasTypographyOverride, blockStyleToCss } from '../../lib/canvasBlockToolbar.js';
 import { MM_TO_PX } from '../../lib/freeCanvasScale.js';
 import { isAutoHeightBlockType, isNonSemanticBlockType } from '../../lib/cvLayoutModelV3.js';
+import { getBlockDisplayName } from '../../lib/blockInspectorSchema.js';
 import { useCanvasBlockAutoHeight } from '../../lib/useCanvasBlockAutoHeight.js';
 import { isFloatingToolbarTarget, placeCaretAtPoint } from '../../lib/canvasCaret.js';
 import { RESIZE_HANDLES } from '../../lib/freeCanvasResize.js';
@@ -790,6 +791,7 @@ export default function FreeCanvasBlock({
   onInnerBlur,
   onBlockElementRef,
   onBlockAutoHeight,
+  onSelect,
   locked = false,
 }) {
   const innerRef = useRef(null);
@@ -884,6 +886,33 @@ export default function FreeCanvasBlock({
     onInnerBlur(block.id, innerRef.current);
   };
 
+  const handleFocus = () => {
+    if (!interactable || editing) return;
+    if (typeof onSelect === 'function') onSelect(block.id);
+  };
+
+  const handleKeyDown = (e) => {
+    if (!interactable || editing) return;
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      if ((type === 'image' || type === 'photo') && typeof onImageEdit === 'function') {
+        onImageEdit(block.id);
+        return;
+      }
+      if (canEdit && typeof onDoubleClickEdit === 'function') {
+        onDoubleClickEdit(block.id);
+      }
+    }
+  };
+
+  const a11yName = getBlockDisplayName(block);
+  const a11yLabel = [
+    a11yName,
+    selected ? 'sélectionné' : null,
+    locked ? 'verrouillé' : null,
+    'Flèches pour déplacer, Suppr pour supprimer, Entrée pour éditer.',
+  ].filter(Boolean).join('. ');
+
   return (
     <div
       ref={(el) => {
@@ -892,6 +921,9 @@ export default function FreeCanvasBlock({
       className={blockClassName({ selected, dragging, resizing, interactable, editing, locked })}
       data-block-id={id}
       data-block-type={type}
+      tabIndex={interactable && !editing ? 0 : undefined}
+      aria-label={interactable ? a11yLabel : undefined}
+      aria-disabled={interactable && locked ? true : undefined}
       style={{
         left: `${x}mm`,
         top: `${y}mm`,
@@ -904,9 +936,11 @@ export default function FreeCanvasBlock({
         editing
           ? 'Mode texte - Échap pour quitter'
           : interactable
-            ? `${type} - double-clic pour éditer`
+            ? `${a11yName} - double-clic ou Entrée pour éditer`
             : type
       }
+      onFocus={interactable && !editing ? handleFocus : undefined}
+      onKeyDown={interactable && !editing ? handleKeyDown : undefined}
       onPointerDown={interactable && !editing ? handlePointerDown : undefined}
       onPointerMove={interactable && !editing && onPointerMove ? onPointerMove : undefined}
       onPointerUp={interactable && !editing && onPointerUp ? onPointerUp : undefined}

--- a/frontend/src/lib/freeCanvasSelection.js
+++ b/frontend/src/lib/freeCanvasSelection.js
@@ -26,3 +26,61 @@ export function nextOverlappingBlockId(blocks, point, selectedBlockId) {
   if (selectedIndex < 0) return null;
   return hits[(selectedIndex + 1) % hits.length]?.id || null;
 }
+
+/** Pas fin (mm) pour flèches ; Shift = grand pas (AXE-35). */
+export const CANVAS_NUDGE_STEP_MM = 1;
+export const CANVAS_NUDGE_STEP_LARGE_MM = 5;
+
+/** Media query : tablette / mobile (desktop = ≥ 1024px). */
+export const CANVAS_DESKTOP_LAYOUT_MQ = '(max-width: 1023px)';
+
+export const CANVAS_DESKTOP_HINT_DISMISSED_KEY = 'cv_beta_canvas_desktop_hint_dismissed';
+
+/**
+ * Delta de déplacement clavier pour une touche fléchée.
+ * @param {string} key
+ * @param {{ shiftKey?: boolean }} [opts]
+ * @returns {{ dx: number, dy: number } | null}
+ */
+export function canvasNudgeDeltaFromKey(key, { shiftKey = false } = {}) {
+  const step = shiftKey ? CANVAS_NUDGE_STEP_LARGE_MM : CANVAS_NUDGE_STEP_MM;
+  if (key === 'ArrowLeft') return { dx: -step, dy: 0 };
+  if (key === 'ArrowRight') return { dx: step, dy: 0 };
+  if (key === 'ArrowUp') return { dx: 0, dy: -step };
+  if (key === 'ArrowDown') return { dx: 0, dy: step };
+  return null;
+}
+
+/**
+ * True si le focus est dans un champ où les flèches / Delete ne doivent pas
+ * piloter le canvas (inputs sidebar, édition inline, etc.).
+ * @param {Element|EventTarget|null|undefined} el
+ */
+export function isCanvasTypingTarget(el) {
+  if (!el || typeof el !== 'object') return false;
+  const node = /** @type {Element} */ (el);
+  if (typeof node.closest === 'function') {
+    if (node.closest('input, textarea, select, [contenteditable="true"]')) return true;
+  }
+  const tag = String(node.tagName || '').toLowerCase();
+  if (tag === 'input' || tag === 'textarea' || tag === 'select') return true;
+  // @ts-ignore isContentEditable sur HTMLElement
+  if (node.isContentEditable) return true;
+  return false;
+}
+
+export function isCanvasDesktopHintDismissed() {
+  try {
+    return localStorage.getItem(CANVAS_DESKTOP_HINT_DISMISSED_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function dismissCanvasDesktopHint() {
+  try {
+    localStorage.setItem(CANVAS_DESKTOP_HINT_DISMISSED_KEY, '1');
+  } catch {
+    /* ignore */
+  }
+}

--- a/frontend/src/styles/CvEditorBeta.css
+++ b/frontend/src/styles/CvEditorBeta.css
@@ -501,6 +501,45 @@
   border-color: var(--color-slate);
 }
 
+.cv-editor-beta-desktop-hint {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 16px;
+  background: var(--color-pale-blue, #f1f5ff);
+  border-bottom: 1px solid var(--color-hairline, #d9d9dd);
+  color: var(--color-ink, #212121);
+}
+
+.cv-editor-beta-desktop-hint__text {
+  margin: 0;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  color: var(--color-body-muted, #616161);
+}
+
+.cv-editor-beta-desktop-hint__dismiss {
+  flex-shrink: 0;
+  padding: 6px 12px;
+  border: 1px solid var(--color-primary, #17171c);
+  border-radius: 30px;
+  background: transparent;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-primary, #17171c);
+  cursor: pointer;
+}
+
+.cv-editor-beta-desktop-hint__dismiss:hover {
+  background: var(--color-canvas, #fff);
+}
+
+.cv-editor-beta-desktop-hint__dismiss:focus-visible {
+  outline: 2px solid var(--color-focus-blue, #4c6ee6);
+  outline-offset: 2px;
+}
+
 .cv-editor-beta-semantic-note {
   display: flex;
   align-items: center;

--- a/frontend/src/styles/FreeCanvas.css
+++ b/frontend/src/styles/FreeCanvas.css
@@ -421,6 +421,17 @@
   border-radius: 2px;
 }
 
+.free-canvas-block--interactive:focus {
+  outline: none;
+}
+
+.free-canvas-block--interactive:focus-visible::after {
+  inset: -1mm;
+  border: 2px solid var(--color-focus-blue, #4c6ee6);
+  border-radius: 2px;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-focus-blue, #4c6ee6) 35%, transparent);
+}
+
 .free-canvas-block--interactive.free-canvas-block--dragging::after {
   inset: -0.5mm;
   border-color: var(--color-focus-blue, #4c6ee6);

--- a/frontend/tests/unit/freeCanvasSelection.test.js
+++ b/frontend/tests/unit/freeCanvasSelection.test.js
@@ -4,6 +4,8 @@ import assert from 'node:assert/strict';
 import {
   nextOverlappingBlockId,
   selectableBlocksAtPoint,
+  canvasNudgeDeltaFromKey,
+  isCanvasTypingTarget,
 } from '../../src/lib/freeCanvasSelection.js';
 
 const blocks = [
@@ -33,4 +35,19 @@ test('nextOverlappingBlockId ignore les blocs verrouilles', () => {
 
 test('nextOverlappingBlockId ne change rien sans superposition', () => {
   assert.equal(nextOverlappingBlockId(blocks, { x: 12, y: 12 }, 'back'), null);
+});
+
+test('canvasNudgeDeltaFromKey : pas fin et Shift grand pas', () => {
+  assert.deepEqual(canvasNudgeDeltaFromKey('ArrowLeft'), { dx: -1, dy: 0 });
+  assert.deepEqual(canvasNudgeDeltaFromKey('ArrowRight', { shiftKey: true }), { dx: 5, dy: 0 });
+  assert.deepEqual(canvasNudgeDeltaFromKey('ArrowUp', { shiftKey: true }), { dx: 0, dy: -5 });
+  assert.deepEqual(canvasNudgeDeltaFromKey('ArrowDown'), { dx: 0, dy: 1 });
+  assert.equal(canvasNudgeDeltaFromKey('Enter'), null);
+});
+
+test('isCanvasTypingTarget : input et contenteditable', () => {
+  assert.equal(isCanvasTypingTarget(null), false);
+  assert.equal(isCanvasTypingTarget({ tagName: 'INPUT' }), true);
+  assert.equal(isCanvasTypingTarget({ tagName: 'DIV', isContentEditable: true }), true);
+  assert.equal(isCanvasTypingTarget({ tagName: 'DIV', isContentEditable: false, closest: () => null }), false);
 });


### PR DESCRIPTION
## Summary
- Blocs focusables (`tabIndex`, `aria-label`, Entrée pour éditer) + focus visible
- Flèches / Shift+flèches et Suppr/Backspace via helpers testés ; ignore les champs de saisie
- Labels ARIA renforcés sur le rail et le drawer
- Bandeau mobile/tablette : édition layout recommandée sur desktop (dismissible)

## Linear
Fixes AXE-35

## GitHub issue
Closes #65

## Test plan
- [ ] Tab vers un bloc → focus visible ; flèches déplacent ; Shift+flèches = pas 5 mm
- [ ] Suppr / Backspace supprime hors édition texte / hors input sidebar
- [ ] Entrée sur un bloc texte ouvre l’édition inline
- [ ] Rail : `aria-label` / `aria-expanded` ; drawer `role="region"`
- [ ] Viewport < 1024px : bandeau visible, « Compris » le masque
- [ ] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks` OK

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout de la navigation et de la sélection des blocs du canvas au clavier.
  * Déplacement précis des éléments avec les touches fléchées, notamment avec Shift.
  * Affichage d’un avertissement recommandant un ordinateur pour l’édition sur mobile ou tablette, avec mémorisation de sa fermeture.
  * Amélioration des indications et états d’accessibilité du rail de navigation et des blocs.

* **Corrections**
  * Les champs de saisie ne sont plus perturbés par les raccourcis clavier du canvas.

* **Accessibilité**
  * Renforcement de la visibilité du focus clavier sur les éléments interactifs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->