### PR TITLE
Feat: ATS coach — conseils, highlight, impact, modes (AXE-36)

### DIFF
--- a/backend/services/ats_score/rules/free_canvas.py
+++ b/backend/services/ats_score/rules/free_canvas.py
@@ -117,6 +117,10 @@ def rule_free_canvas_missing_profile_sections(
         label=f"Canvas libre : contenu du profil non affiche ({visible_missing}{suffix})",
         delta=delta,
         severity=RuleSeverity.ERROR if len(missing) >= 3 else RuleSeverity.WARNING,
+        advice=(
+            f"Des infos du profil ne sont pas sur le canvas ({visible_missing}{suffix}). "
+            "Ajoute les blocs manquants depuis la sidebar pour qu'ils soient scorés."
+        ),
     )
 
 
@@ -138,11 +142,20 @@ def rule_free_canvas_reading_order(cv: dict[str, Any], layout: dict[str, Any]) -
     if inversions == 0:
         return None
     delta = max(-9, -3 * inversions)
+    block_ids = tuple(
+        str(b["id"]) for b in ordered if isinstance(b.get("id"), str) and b["id"]
+    )
     return Rule(
         id="malus_free_canvas_reading_order",
         label=f"Canvas libre : ordre de lecture ambigu ({inversions} inversion(s))",
         delta=delta,
         severity=RuleSeverity.WARNING,
+        block_ids=block_ids[:6],
+        advice=(
+            "L'ordre de lecture machine (haut → bas) ne suit pas l'ordre "
+            "attendu des sections. Les parsers ATS peuvent mal enchaîner "
+            "identité, contact et expériences."
+        ),
     )
 
 
@@ -162,11 +175,22 @@ def rule_identity_not_first_in_reading(cv: dict[str, Any], layout: dict[str, Any
     first = min(blocks, key=_reading_position)
     if first.get("type") == "identity":
         return None
+    identity = identities[0]
+    ids: list[str] = []
+    for block in (identity, first):
+        bid = block.get("id")
+        if isinstance(bid, str) and bid and bid not in ids:
+            ids.append(bid)
     return Rule(
         id="malus_identity_not_first",
         label="Identite pas en tete de lecture (risque ATS)",
         delta=-5,
         severity=RuleSeverity.WARNING,
+        block_ids=tuple(ids),
+        advice=(
+            "Un autre bloc est lu avant l'identité. Place le nom / titre "
+            "en haut à gauche pour que les ATS le capturent en premier."
+        ),
     )
 
 
@@ -185,11 +209,21 @@ def rule_experiences_before_resume(cv: dict[str, Any], layout: dict[str, Any]) -
     resume_pos = min(_reading_position(b) for b in resume_blocks)
     exp_pos = min(_reading_position(b) for b in exp_blocks)
     if exp_pos < resume_pos:
+        ids: list[str] = []
+        for block in (*exp_blocks[:1], *resume_blocks[:1]):
+            bid = block.get("id")
+            if isinstance(bid, str) and bid and bid not in ids:
+                ids.append(bid)
         return Rule(
             id="malus_experiences_before_resume",
             label="Experiences placees avant le resume (ordre de lecture)",
             delta=-5,
             severity=RuleSeverity.WARNING,
+            block_ids=tuple(ids),
+            advice=(
+                "Les expériences sont placées avant le résumé. "
+                "Les ATS s'attendent souvent à une synthèse avant le détail."
+            ),
         )
     return None
 
@@ -214,10 +248,17 @@ def rule_contact_far_from_top(cv: dict[str, Any], layout: dict[str, Any]) -> Rul
         except (TypeError, ValueError):
             continue
         if y > threshold_mm:
+            bid = block.get("id")
+            block_ids = (str(bid),) if isinstance(bid, str) and bid else ()
             return Rule(
                 id="malus_contact_low_on_page",
                 label="Contact place trop bas sur la page",
                 delta=-3,
                 severity=RuleSeverity.WARNING,
+                block_ids=block_ids,
+                advice=(
+                    "Le contact est trop bas sur la page. Remonte-le dans "
+                    "le haut du CV pour qu'il soit lu par les parsers ATS."
+                ),
             )
     return None

--- a/backend/services/ats_score/rules/free_canvas.py
+++ b/backend/services/ats_score/rules/free_canvas.py
@@ -142,9 +142,7 @@ def rule_free_canvas_reading_order(cv: dict[str, Any], layout: dict[str, Any]) -
     if inversions == 0:
         return None
     delta = max(-9, -3 * inversions)
-    block_ids = tuple(
-        str(b["id"]) for b in ordered if isinstance(b.get("id"), str) and b["id"]
-    )
+    block_ids = tuple(str(b["id"]) for b in ordered if isinstance(b.get("id"), str) and b["id"])
     return Rule(
         id="malus_free_canvas_reading_order",
         label=f"Canvas libre : ordre de lecture ambigu ({inversions} inversion(s))",

--- a/backend/services/ats_score/serialization.py
+++ b/backend/services/ats_score/serialization.py
@@ -23,6 +23,8 @@ def rule_to_dict(rule: Rule) -> dict[str, Any]:
         "label": rule.label,
         "delta": rule.delta,
         "severity": rule.severity.value,
+        "block_ids": list(rule.block_ids),
+        "advice": rule.advice or rule.label,
     }
 
 

--- a/backend/services/ats_score/types.py
+++ b/backend/services/ats_score/types.py
@@ -45,12 +45,16 @@ class Rule:
         label: libelle affichable en UI (francais).
         delta: variation appliquee au score total (peut etre negative).
         severity: severite ; conditionne l'affichage front (couleur, icone).
+        block_ids: ids de blocs layout concernes (coach : highlight canvas).
+        advice: explication courte pour le coach (peut etre vide = label seul).
     """
 
     id: str
     label: str
     delta: int
     severity: RuleSeverity
+    block_ids: tuple[str, ...] = ()
+    advice: str = ""
 
 
 @dataclass(frozen=True)

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -1363,6 +1363,17 @@ function CvEditorBeta({
             layout={layout}
             cv={cv}
             paused={canvasBusy}
+            onSelectBlock={handleSelectBlock}
+            onApplyLayout={(nextLayout, meta = {}) => {
+              if (!nextLayout || !layout) return;
+              if (sameLayout(layout, nextLayout)) {
+                setAtsOptimizeMessage('Aucune correction applicable pour ce conseil.');
+                return;
+              }
+              commitLayout(nextLayout, { groupKey: meta.groupKey || 'ats:coach' });
+              setAtsOptimizeMessage('Correction ATS appliquée. Ctrl+Z pour annuler.');
+              if (cv) autoSave.schedule(cv);
+            }}
           />
           <button
             type="button"

--- a/frontend/src/components/editor/EditorAtsScoreBadge.jsx
+++ b/frontend/src/components/editor/EditorAtsScoreBadge.jsx
@@ -1,12 +1,52 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { scoreToneFor } from '../../lib/atsScoreClient.js';
+import { scoreToneFor, fetchAtsScoreParsing } from '../../lib/atsScoreClient.js';
 import { useAtsScoreFetching } from '../../lib/useAtsScoreFetching.js';
+import {
+  filterRulesForCoachMode,
+  getAtsCoachAdvice,
+  isAtsCoachRuleFixable,
+  summarizeAtsCoachStatus,
+} from '../../lib/atsCoachAdvice.js';
+import { applyAtsCoachFix, formatAtsScoreImpact } from '../../lib/atsCoachFixes.js';
+
+const IGNORED_STORAGE_KEY = 'axeljob.atsCoach.ignoredRules';
+
+function readIgnoredRuleIds() {
+  try {
+    const raw = sessionStorage.getItem(IGNORED_STORAGE_KEY);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((id) => typeof id === 'string'));
+  } catch {
+    return new Set();
+  }
+}
+
+function persistIgnoredRuleIds(ids) {
+  try {
+    sessionStorage.setItem(IGNORED_STORAGE_KEY, JSON.stringify([...ids]));
+  } catch {
+    /* ignore quota / private mode */
+  }
+}
+
+function scrollBlockIntoView(blockId) {
+  if (!blockId || typeof document === 'undefined') return;
+  const escaped = typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
+    ? CSS.escape(blockId)
+    : String(blockId).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const el = document.querySelector(`[data-block-id="${escaped}"]`);
+  el?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+}
 
 /**
- * Badge ATS avec debounce, retry et dernier score conserve pendant le chargement.
+ * Badge ATS + panneau coach (AXE-36) : conseils, highlight, corriger / ignorer, impact.
  *
  * @param {boolean} [paused] - true pendant drag/resize canvas (pas de rafale API).
+ * @param {(blockId: string|null, options?: object) => void} [onSelectBlock]
+ * @param {(layout: object, meta?: object) => void} [onApplyLayout]
  */
 export default function EditorAtsScoreBadge({
   templateId,
@@ -14,9 +54,17 @@ export default function EditorAtsScoreBadge({
   cv,
   paused = false,
   onScoreChange,
+  onSelectBlock,
+  onApplyLayout,
 }) {
   const wrapRef = useRef(null);
   const [panelOpen, setPanelOpen] = useState(false);
+  const [coachMode, setCoachMode] = useState('ats-safe');
+  const [ignoredIds, setIgnoredIds] = useState(() => readIgnoredRuleIds());
+  const [previewByRule, setPreviewByRule] = useState({});
+  const [previewLoadingId, setPreviewLoadingId] = useState(null);
+  const [actionError, setActionError] = useState('');
+
   const { status, data, error, stale, refreshNow } = useAtsScoreFetching({
     templateId,
     layout,
@@ -42,6 +90,77 @@ export default function EditorAtsScoreBadge({
     };
   }, [panelOpen]);
 
+  useEffect(() => {
+    setPreviewByRule({});
+    setActionError('');
+  }, [layout, data?.score, data?.version]);
+
+  const ignoreRule = useCallback((ruleId) => {
+    setIgnoredIds((prev) => {
+      const next = new Set(prev);
+      next.add(ruleId);
+      persistIgnoredRuleIds(next);
+      return next;
+    });
+  }, []);
+
+  const clearIgnored = useCallback(() => {
+    setIgnoredIds(new Set());
+    persistIgnoredRuleIds(new Set());
+  }, []);
+
+  const visibleRules = useMemo(() => {
+    const rules = Array.isArray(data?.rules) ? data.rules : [];
+    const filtered = filterRulesForCoachMode(rules, coachMode)
+      .filter((rule) => !ignoredIds.has(rule.id));
+    return [...filtered].sort((a, b) => {
+      const da = Number(a.delta) || 0;
+      const db = Number(b.delta) || 0;
+      return da - db;
+    });
+  }, [data?.rules, coachMode, ignoredIds]);
+
+  const handleSeeOnCanvas = useCallback((rule) => {
+    const ids = Array.isArray(rule.blockIds) ? rule.blockIds : [];
+    if (!ids.length || !onSelectBlock) return;
+    if (ids.length === 1) {
+      onSelectBlock(ids[0]);
+    } else {
+      onSelectBlock(null, { replaceIds: ids });
+    }
+    scrollBlockIntoView(ids[0]);
+  }, [onSelectBlock]);
+
+  const ensureImpactPreview = useCallback(async (rule) => {
+    if (!layout || !isAtsCoachRuleFixable(rule.id)) return null;
+    if (previewByRule[rule.id]) return previewByRule[rule.id];
+    const nextLayout = applyAtsCoachFix(layout, rule.id);
+    setPreviewLoadingId(rule.id);
+    setActionError('');
+    try {
+      const scored = await fetchAtsScoreParsing({ layout: nextLayout, cv, templateId });
+      const impact = {
+        before: data?.score ?? null,
+        after: scored.score,
+        nextLayout,
+      };
+      setPreviewByRule((prev) => ({ ...prev, [rule.id]: impact }));
+      return impact;
+    } catch (err) {
+      setActionError(err?.message || 'Impossible de prévisualiser l’impact ATS');
+      return null;
+    } finally {
+      setPreviewLoadingId(null);
+    }
+  }, [layout, cv, templateId, data?.score, previewByRule]);
+
+  const handleFix = useCallback(async (rule) => {
+    if (!onApplyLayout || !layout) return;
+    const impact = await ensureImpactPreview(rule);
+    const nextLayout = impact?.nextLayout || applyAtsCoachFix(layout, rule.id);
+    onApplyLayout(nextLayout, { groupKey: `ats:coach:${rule.id}` });
+  }, [onApplyLayout, layout, ensureImpactPreview]);
+
   if (status === 'idle') {
     return null;
   }
@@ -49,7 +168,10 @@ export default function EditorAtsScoreBadge({
   const showScore = data && (status === 'ok' || status === 'loading' || (status === 'error' && stale));
   const score = showScore ? (data.score ?? 0) : null;
   const tone = score !== null ? scoreToneFor(score) : 'unknown';
-  const rules = Array.isArray(data?.rules) ? data.rules : [];
+  const allRules = Array.isArray(data?.rules) ? data.rules : [];
+  const statusLine = showScore
+    ? summarizeAtsCoachStatus(score, allRules.filter((r) => !ignoredIds.has(r.id)))
+    : '';
 
   if (status === 'loading' && !showScore) {
     return (
@@ -87,11 +209,7 @@ export default function EditorAtsScoreBadge({
         onClick={() => setPanelOpen((o) => !o)}
         aria-expanded={panelOpen}
         aria-haspopup="dialog"
-        title={
-          status === 'error'
-            ? `${error} - score affiché : dernière valeur connue`
-            : 'Score ATS de parsing - clique pour voir les règles déclenchées'
-        }
+        title={statusLine || 'Coach ATS — conseils actionnables'}
       >
         ATS : {score}/100
         {(status === 'loading' || stale) && (
@@ -109,12 +227,12 @@ export default function EditorAtsScoreBadge({
         </button>
       )}
       {panelOpen && (
-        <div className="ats-badge-panel" role="dialog" aria-label="Détail du score ATS">
+        <div className="ats-badge-panel ats-coach-panel" role="dialog" aria-label="Coach ATS">
           <div className="ats-badge-panel-header">
-            <strong>
-              Score ATS Parsing : {score}/100
-              {status === 'error' ? ' (dernière valeur)' : ''}
-            </strong>
+            <div className="ats-coach-panel-heading">
+              <strong>Coach ATS · {score}/100</strong>
+              <p className="ats-coach-status">{statusLine}</p>
+            </div>
             <button
               type="button"
               className="ats-badge-panel-close"
@@ -124,6 +242,24 @@ export default function EditorAtsScoreBadge({
               ✕
             </button>
           </div>
+
+          <div className="ats-coach-mode" role="group" aria-label="Mode coach">
+            <button
+              type="button"
+              className={coachMode === 'ats-safe' ? 'ats-coach-mode-btn is-active' : 'ats-coach-mode-btn'}
+              onClick={() => setCoachMode('ats-safe')}
+            >
+              Version ATS-safe
+            </button>
+            <button
+              type="button"
+              className={coachMode === 'design' ? 'ats-coach-mode-btn is-active' : 'ats-coach-mode-btn'}
+              onClick={() => setCoachMode('design')}
+            >
+              Version design
+            </button>
+          </div>
+
           {status === 'error' && (
             <p className="ats-badge-panel-error" role="status">
               {error}
@@ -133,22 +269,103 @@ export default function EditorAtsScoreBadge({
               </button>
             </p>
           )}
-          {rules.length === 0 ? (
-            <p className="ats-badge-panel-empty">Aucune règle déclenchée. Layout optimal.</p>
+          {actionError && (
+            <p className="ats-badge-panel-error" role="status">{actionError}</p>
+          )}
+
+          {visibleRules.length === 0 ? (
+            <p className="ats-badge-panel-empty">
+              {ignoredIds.size > 0
+                ? 'Tous les conseils visibles sont ignorés.'
+                : coachMode === 'design'
+                  ? 'Aucun risque ATS affiché en mode design.'
+                  : 'Aucune règle déclenchée. Layout optimal.'}
+            </p>
           ) : (
-            <ul className="ats-badge-panel-list">
-              {rules.map((rule) => (
-                <li key={rule.id} className={`ats-badge-rule ats-badge-rule--${rule.severity}`}>
-                  <span className={`ats-badge-rule-delta ${rule.delta >= 0 ? 'ats-badge-rule-delta--positive' : 'ats-badge-rule-delta--negative'}`}>
-                    {rule.delta > 0 ? `+${rule.delta}` : rule.delta}
-                  </span>
-                  <span className="ats-badge-rule-label">{rule.label}</span>
-                </li>
-              ))}
+            <ul className="ats-badge-panel-list ats-coach-list">
+              {visibleRules.map((rule) => {
+                const advice = getAtsCoachAdvice(rule);
+                const canSee = Array.isArray(rule.blockIds) && rule.blockIds.length > 0 && onSelectBlock;
+                const canFix = isAtsCoachRuleFixable(rule.id) && onApplyLayout;
+                const preview = previewByRule[rule.id];
+                const soft = coachMode === 'design' && advice.designTradeoff;
+                return (
+                  <li
+                    key={rule.id}
+                    className={[
+                      'ats-badge-rule',
+                      'ats-coach-rule',
+                      `ats-badge-rule--${rule.severity}`,
+                      soft ? 'ats-coach-rule--tradeoff' : '',
+                    ].filter(Boolean).join(' ')}
+                  >
+                    <div className="ats-coach-rule-main">
+                      <span className={`ats-badge-rule-delta ${rule.delta >= 0 ? 'ats-badge-rule-delta--positive' : 'ats-badge-rule-delta--negative'}`}>
+                        {rule.delta > 0 ? `+${rule.delta}` : rule.delta}
+                      </span>
+                      <div className="ats-coach-rule-copy">
+                        <span className="ats-coach-rule-title">{advice.title}</span>
+                        <span className="ats-coach-rule-expl">{advice.explanation}</span>
+                        {soft && (
+                          <span className="ats-coach-rule-note">Choix design acceptable — impact ATS limité.</span>
+                        )}
+                        {preview && (
+                          <span className="ats-coach-impact" role="status">
+                            {formatAtsScoreImpact(preview.before, preview.after)}
+                          </span>
+                        )}
+                        {previewLoadingId === rule.id && !preview && (
+                          <span className="ats-coach-impact" role="status">Calcul de l’impact…</span>
+                        )}
+                      </div>
+                    </div>
+                    <div className="ats-coach-actions">
+                      {canSee && (
+                        <button
+                          type="button"
+                          className="ats-coach-action"
+                          onClick={() => handleSeeOnCanvas(rule)}
+                        >
+                          Voir sur le canvas
+                        </button>
+                      )}
+                      {canFix && (
+                        <button
+                          type="button"
+                          className="ats-coach-action ats-coach-action--primary"
+                          disabled={previewLoadingId === rule.id}
+                          onClick={async () => {
+                            if (!preview) {
+                              await ensureImpactPreview(rule);
+                              return;
+                            }
+                            await handleFix(rule);
+                          }}
+                        >
+                          {preview ? 'Corriger' : 'Voir l’impact'}
+                        </button>
+                      )}
+                      <button
+                        type="button"
+                        className="ats-coach-action"
+                        onClick={() => ignoreRule(rule.id)}
+                      >
+                        Ignorer
+                      </button>
+                    </div>
+                  </li>
+                );
+              })}
             </ul>
           )}
-          <div className="ats-badge-panel-footer">
-            Version : {data?.version || '?'}
+
+          <div className="ats-badge-panel-footer ats-coach-footer">
+            <span>Version : {data?.version || '?'}</span>
+            {ignoredIds.size > 0 && (
+              <button type="button" className="ats-coach-reset-ignored" onClick={clearIgnored}>
+                Réafficher {ignoredIds.size} ignoré(s)
+              </button>
+            )}
           </div>
         </div>
       )}

--- a/frontend/src/components/editor/EditorAtsScoreBadge.jsx
+++ b/frontend/src/components/editor/EditorAtsScoreBadge.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { scoreToneFor, fetchAtsScoreParsing } from '../../lib/atsScoreClient.js';
 import { useAtsScoreFetching } from '../../lib/useAtsScoreFetching.js';
@@ -95,32 +95,27 @@ export default function EditorAtsScoreBadge({
     setActionError('');
   }, [layout, data?.score, data?.version]);
 
-  const ignoreRule = useCallback((ruleId) => {
+  const ignoreRule = (ruleId) => {
     setIgnoredIds((prev) => {
       const next = new Set(prev);
       next.add(ruleId);
       persistIgnoredRuleIds(next);
       return next;
     });
-  }, []);
+  };
 
-  const clearIgnored = useCallback(() => {
+  const clearIgnored = () => {
     setIgnoredIds(new Set());
     persistIgnoredRuleIds(new Set());
-  }, []);
+  };
 
-  const visibleRules = useMemo(() => {
-    const rules = Array.isArray(data?.rules) ? data.rules : [];
-    const filtered = filterRulesForCoachMode(rules, coachMode)
-      .filter((rule) => !ignoredIds.has(rule.id));
-    return [...filtered].sort((a, b) => {
-      const da = Number(a.delta) || 0;
-      const db = Number(b.delta) || 0;
-      return da - db;
-    });
-  }, [data?.rules, coachMode, ignoredIds]);
+  const rules = Array.isArray(data?.rules) ? data.rules : [];
+  const visibleRules = filterRulesForCoachMode(rules, coachMode)
+    .filter((rule) => !ignoredIds.has(rule.id))
+    .slice()
+    .sort((a, b) => (Number(a.delta) || 0) - (Number(b.delta) || 0));
 
-  const handleSeeOnCanvas = useCallback((rule) => {
+  const handleSeeOnCanvas = (rule) => {
     const ids = Array.isArray(rule.blockIds) ? rule.blockIds : [];
     if (!ids.length || !onSelectBlock) return;
     if (ids.length === 1) {
@@ -129,9 +124,9 @@ export default function EditorAtsScoreBadge({
       onSelectBlock(null, { replaceIds: ids });
     }
     scrollBlockIntoView(ids[0]);
-  }, [onSelectBlock]);
+  };
 
-  const ensureImpactPreview = useCallback(async (rule) => {
+  const ensureImpactPreview = async (rule) => {
     if (!layout || !isAtsCoachRuleFixable(rule.id)) return null;
     if (previewByRule[rule.id]) return previewByRule[rule.id];
     const nextLayout = applyAtsCoachFix(layout, rule.id);
@@ -152,14 +147,14 @@ export default function EditorAtsScoreBadge({
     } finally {
       setPreviewLoadingId(null);
     }
-  }, [layout, cv, templateId, data?.score, previewByRule]);
+  };
 
-  const handleFix = useCallback(async (rule) => {
+  const handleFix = async (rule) => {
     if (!onApplyLayout || !layout) return;
     const impact = await ensureImpactPreview(rule);
     const nextLayout = impact?.nextLayout || applyAtsCoachFix(layout, rule.id);
     onApplyLayout(nextLayout, { groupKey: `ats:coach:${rule.id}` });
-  }, [onApplyLayout, layout, ensureImpactPreview]);
+  };
 
   if (status === 'idle') {
     return null;
@@ -168,9 +163,8 @@ export default function EditorAtsScoreBadge({
   const showScore = data && (status === 'ok' || status === 'loading' || (status === 'error' && stale));
   const score = showScore ? (data.score ?? 0) : null;
   const tone = score !== null ? scoreToneFor(score) : 'unknown';
-  const allRules = Array.isArray(data?.rules) ? data.rules : [];
   const statusLine = showScore
-    ? summarizeAtsCoachStatus(score, allRules.filter((r) => !ignoredIds.has(r.id)))
+    ? summarizeAtsCoachStatus(score, rules.filter((r) => !ignoredIds.has(r.id)))
     : '';
 
   if (status === 'loading' && !showScore) {

--- a/frontend/src/lib/atsCoachAdvice.js
+++ b/frontend/src/lib/atsCoachAdvice.js
@@ -1,0 +1,210 @@
+/**
+ * Mapping règle ATS → messages coach (AXE-36).
+ *
+ * Les `label` API restent la source courte ; ce module fournit le texte
+ * pédagogique stable (tests) + le type d'action « Corriger » possible.
+ */
+
+/** @typedef {'reading-order' | 'contact-up' | null} AtsCoachFixKind */
+
+/**
+ * @typedef {object} AtsCoachAdvice
+ * @property {string} title
+ * @property {string} explanation
+ * @property {AtsCoachFixKind} fixKind
+ * @property {boolean} designTradeoff - en mode design, conseil atténué
+ */
+
+/** @type {Record<string, AtsCoachAdvice>} */
+export const ATS_COACH_ADVICE = {
+  malus_contact_low_on_page: {
+    title: 'Le contact est trop bas',
+    explanation:
+      'Remonte le bloc contact dans le haut de la page pour qu’il soit lu par les parsers ATS.',
+    fixKind: 'contact-up',
+    designTradeoff: false,
+  },
+  malus_free_canvas_reading_order: {
+    title: 'L’ordre de lecture machine ne suit pas le visuel',
+    explanation:
+      'Les ATS lisent souvent de haut en bas. Réordonne identité → contact → résumé → expériences.',
+    fixKind: 'reading-order',
+    designTradeoff: false,
+  },
+  malus_identity_not_first: {
+    title: 'L’identité n’est pas en tête de lecture',
+    explanation:
+      'Place le nom / titre en haut à gauche pour que les ATS le capturent en premier.',
+    fixKind: 'reading-order',
+    designTradeoff: false,
+  },
+  malus_experiences_before_resume: {
+    title: 'Expériences avant le résumé',
+    explanation:
+      'Les expériences sont placées avant le résumé. Une synthèse avant le détail aide souvent le parsing.',
+    fixKind: 'reading-order',
+    designTradeoff: false,
+  },
+  malus_free_canvas_missing_profile_sections: {
+    title: 'Contenu du profil absent du canvas',
+    explanation:
+      'Des infos du profil ne sont pas affichées. Ajoute les blocs manquants depuis la sidebar.',
+    fixKind: null,
+    designTradeoff: false,
+  },
+  malus_free_canvas_text_blocks: {
+    title: 'Texte en positions libres',
+    explanation:
+      'Beaucoup de blocs texte en absolu : les ATS peuvent les lire dans un ordre inattendu.',
+    fixKind: 'reading-order',
+    designTradeoff: true,
+  },
+  malus_two_columns: {
+    title: 'Layout sur 2 colonnes',
+    explanation:
+      'Les colonnes perturbent souvent la lecture linéaire des ATS. Préfère une colonne pour une version ATS-safe.',
+    fixKind: null,
+    designTradeoff: true,
+  },
+  malus_three_or_more_columns: {
+    title: 'Trop de colonnes',
+    explanation:
+      'Plus de deux colonnes dégrade fortement la lecture machine. Simplifie la structure.',
+    fixKind: null,
+    designTradeoff: true,
+  },
+  malus_sidebar_present: {
+    title: 'Sidebar présente',
+    explanation:
+      'Une sidebar crée un ordre de lecture ambigu (gauche/droite). Utile en design, risqué pour les ATS.',
+    fixKind: null,
+    designTradeoff: true,
+  },
+  malus_table_layout: {
+    title: 'Mise en page par tableau',
+    explanation:
+      'Les tableaux sont souvent lus ligne par ligne et mélangent les colonnes pour les ATS.',
+    fixKind: null,
+    designTradeoff: false,
+  },
+  malus_photo_present: {
+    title: 'Photo sur le CV',
+    explanation:
+      'Une photo n’améliore pas le score ATS et peut être ignorée. Choix design acceptable.',
+    fixKind: null,
+    designTradeoff: true,
+  },
+  malus_exotic_font: {
+    title: 'Police atypique',
+    explanation:
+      'Certaines polices se transforment mal chez les ATS. Préfère Arial, Calibri, Helvetica…',
+    fixKind: null,
+    designTradeoff: true,
+  },
+  malus_body_font_size_out_of_range: {
+    title: 'Taille de corps hors plage',
+    explanation:
+      'Une taille trop petite ou trop grande nuit à l’extraction. Vise ~10–12 pt.',
+    fixKind: null,
+    designTradeoff: false,
+  },
+  malus_inconsistent_dates: {
+    title: 'Dates incohérentes',
+    explanation:
+      'Harmonise le format des dates (ex. MM/YYYY) pour faciliter le parsing.',
+    fixKind: null,
+    designTradeoff: false,
+  },
+  bonus_mono_column: {
+    title: 'Layout mono-colonne',
+    explanation: 'Bonne pratique : une seule colonne facilite la lecture ATS.',
+    fixKind: null,
+    designTradeoff: false,
+  },
+  bonus_standard_section_titles: {
+    title: 'Titres de sections standards',
+    explanation: 'Les titres classiques aident les parsers à reconnaître les sections.',
+    fixKind: null,
+    designTradeoff: false,
+  },
+  bonus_contact_top_of_page: {
+    title: 'Contact en haut de page',
+    explanation: 'Le contact est bien placé pour la lecture machine.',
+    fixKind: null,
+    designTradeoff: false,
+  },
+  bonus_dates_format_consistent: {
+    title: 'Dates cohérentes',
+    explanation: 'Le format des dates est homogène — bon signal pour les ATS.',
+    fixKind: null,
+    designTradeoff: false,
+  },
+};
+
+/**
+ * @param {{ id?: string, label?: string, advice?: string }} rule
+ * @returns {AtsCoachAdvice}
+ */
+export function getAtsCoachAdvice(rule) {
+  const id = typeof rule?.id === 'string' ? rule.id : '';
+  const mapped = ATS_COACH_ADVICE[id];
+  if (mapped) {
+    return {
+      ...mapped,
+      explanation: (typeof rule?.advice === 'string' && rule.advice.trim())
+        ? rule.advice.trim()
+        : mapped.explanation,
+    };
+  }
+  const label = typeof rule?.label === 'string' && rule.label.trim()
+    ? rule.label.trim()
+    : id || 'Conseil ATS';
+  const advice = typeof rule?.advice === 'string' && rule.advice.trim()
+    ? rule.advice.trim()
+    : label;
+  return {
+    title: label,
+    explanation: advice,
+    fixKind: null,
+    designTradeoff: false,
+  };
+}
+
+/**
+ * Résumé badge selon le score et le nombre de risques (malus).
+ * @param {number} score
+ * @param {Array<{ delta?: number }>} rules
+ */
+export function summarizeAtsCoachStatus(score, rules = []) {
+  const risks = rules.filter((r) => Number(r.delta) < 0).length;
+  if (!Number.isFinite(score)) return 'Score ATS indisponible';
+  if (risks === 0) return `Excellent pour ATS (${score}/100)`;
+  if (score >= 90) {
+    return risks === 1
+      ? `Bon pour ATS, 1 risque mineur`
+      : `Bon pour ATS, ${risks} risques mineurs`;
+  }
+  if (score >= 70) return `Correct pour ATS (${score}/100) — ${risks} point(s) d’attention`;
+  return `À améliorer pour les ATS (${score}/100)`;
+}
+
+/**
+ * Filtre les règles selon le mode coach.
+ * @param {Array<object>} rules
+ * @param {'ats-safe' | 'design'} mode
+ */
+export function filterRulesForCoachMode(rules, mode) {
+  const list = Array.isArray(rules) ? rules : [];
+  if (mode !== 'design') return list;
+  // Mode design : masquer les pure bonuses, garder malus + tradeoffs.
+  return list.filter((rule) => Number(rule?.delta) < 0);
+}
+
+/**
+ * @param {string} ruleId
+ * @returns {boolean}
+ */
+export function isAtsCoachRuleFixable(ruleId) {
+  const advice = ATS_COACH_ADVICE[ruleId];
+  return Boolean(advice?.fixKind);
+}

--- a/frontend/src/lib/atsCoachFixes.js
+++ b/frontend/src/lib/atsCoachFixes.js
@@ -1,0 +1,44 @@
+/**
+ * Corrections ATS par règle (AXE-36) — pures, réversibles via undo layout.
+ */
+
+import {
+  optimizeContactVerticalPosition,
+  optimizeLayoutReadingOrder,
+} from './atsLayoutOptimize.js';
+import { getAtsCoachAdvice } from './atsCoachAdvice.js';
+
+/**
+ * Applique la correction associée à une règle, ou retourne le layout inchangé.
+ * @param {object} layout
+ * @param {string} ruleId
+ * @returns {object}
+ */
+export function applyAtsCoachFix(layout, ruleId) {
+  if (!layout) return layout;
+  const { fixKind } = getAtsCoachAdvice({ id: ruleId });
+  if (fixKind === 'contact-up') {
+    return optimizeContactVerticalPosition(layout);
+  }
+  if (fixKind === 'reading-order') {
+    return optimizeLayoutReadingOrder(layout);
+  }
+  return layout;
+}
+
+/**
+ * Libellé court pour l’impact avant application.
+ * @param {number} before
+ * @param {number} after
+ * @returns {string}
+ */
+export function formatAtsScoreImpact(before, after) {
+  if (!Number.isFinite(before) || !Number.isFinite(after)) {
+    return 'Impact score : calcul…';
+  }
+  if (before === after) {
+    return `Impact score : aucun (${before}/100)`;
+  }
+  const arrow = after > before ? '↑' : '↓';
+  return `Impact score : ${before} → ${after} ${arrow}`;
+}

--- a/frontend/src/lib/atsScoreClient.js
+++ b/frontend/src/lib/atsScoreClient.js
@@ -105,11 +105,16 @@ function normalizeRule(rule) {
   if (!rule || typeof rule !== 'object') return null;
   const id = typeof rule.id === 'string' ? rule.id : null;
   if (!id) return null;
+  const blockIds = Array.isArray(rule.block_ids)
+    ? rule.block_ids.filter((bid) => typeof bid === 'string' && bid.trim())
+    : [];
   return {
     id,
     label: typeof rule.label === 'string' ? rule.label : id,
     delta: Number.isFinite(rule.delta) ? rule.delta : 0,
     severity: typeof rule.severity === 'string' ? rule.severity : 'info',
+    blockIds,
+    advice: typeof rule.advice === 'string' ? rule.advice : '',
   };
 }
 

--- a/frontend/src/styles/CvEditorBeta.css
+++ b/frontend/src/styles/CvEditorBeta.css
@@ -717,24 +717,154 @@
   position: absolute;
   top: calc(100% + 0.4rem);
   right: 0;
-  width: 320px;
+  width: 380px;
   max-width: calc(100vw - 2rem);
-  background: white;
-  border: 1px solid #e2e8f0;
-  border-radius: 0.5rem;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+  background: var(--color-canvas, #ffffff);
+  border: 1px solid var(--color-hairline, #d9d9dd);
+  border-radius: 8px;
   z-index: 50;
   padding: 0.75rem;
   font-size: 0.8rem;
-  color: #1e293b;
+  color: var(--color-ink, #212121);
+}
+
+.ats-coach-panel-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.ats-coach-status {
+  margin: 0;
+  font-size: 0.72rem;
+  color: var(--color-body-muted, #616161);
+  line-height: 1.35;
+}
+
+.ats-coach-mode {
+  display: flex;
+  gap: 0.35rem;
+  margin-bottom: 0.65rem;
+}
+
+.ats-coach-mode-btn {
+  flex: 1;
+  border: 1px solid var(--color-primary, #17171c);
+  background: transparent;
+  color: var(--color-primary, #17171c);
+  border-radius: 30px;
+  padding: 0.28rem 0.5rem;
+  font-size: 0.7rem;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.ats-coach-mode-btn.is-active {
+  background: var(--color-primary, #17171c);
+  color: var(--color-on-dark, #ffffff);
+}
+
+.ats-coach-list {
+  max-height: min(420px, 55vh);
+}
+
+.ats-coach-rule {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.45rem;
+  padding: 0.45rem 0.5rem;
+}
+
+.ats-coach-rule--tradeoff {
+  opacity: 0.92;
+  border: 1px dashed var(--color-hairline, #d9d9dd);
+}
+
+.ats-coach-rule-main {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+}
+
+.ats-coach-rule-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.ats-coach-rule-title {
+  font-weight: 500;
+  line-height: 1.3;
+}
+
+.ats-coach-rule-expl,
+.ats-coach-rule-note,
+.ats-coach-impact {
+  font-size: 0.72rem;
+  line-height: 1.35;
+  color: var(--color-body-muted, #616161);
+}
+
+.ats-coach-impact {
+  color: var(--color-deep-green, #003c33);
+  font-weight: 500;
+}
+
+.ats-coach-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.ats-coach-action {
+  border: none;
+  background: transparent;
+  color: var(--color-action-blue, #1863dc);
+  font-size: 0.7rem;
+  font-weight: 500;
+  padding: 0.15rem 0.25rem;
+  cursor: pointer;
+  font-family: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.ats-coach-action--primary {
+  color: var(--color-primary, #17171c);
+}
+
+.ats-coach-action:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
+
+.ats-coach-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.ats-coach-reset-ignored {
+  border: none;
+  background: none;
+  color: var(--color-action-blue, #1863dc);
+  font-size: 0.7rem;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+  font-family: inherit;
 }
 
 .ats-badge-panel-header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   padding-bottom: 0.5rem;
-  border-bottom: 1px solid #f1f5f9;
+  border-bottom: 1px solid var(--color-card-border, #f2f2f2);
   margin-bottom: 0.5rem;
 }
 

--- a/frontend/tests/unit/atsCoachAdvice.test.js
+++ b/frontend/tests/unit/atsCoachAdvice.test.js
@@ -1,0 +1,94 @@
+/**
+ * Tests mapping rule → messages coach (AXE-36).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  ATS_COACH_ADVICE,
+  filterRulesForCoachMode,
+  getAtsCoachAdvice,
+  isAtsCoachRuleFixable,
+  summarizeAtsCoachStatus,
+} from '../../src/lib/atsCoachAdvice.js';
+import { applyAtsCoachFix, formatAtsScoreImpact } from '../../src/lib/atsCoachFixes.js';
+
+test('chaque entrée ATS_COACH_ADVICE a title + explanation', () => {
+  for (const [id, advice] of Object.entries(ATS_COACH_ADVICE)) {
+    assert.ok(advice.title?.trim(), `title manquant pour ${id}`);
+    assert.ok(advice.explanation?.trim(), `explanation manquante pour ${id}`);
+  }
+});
+
+test('getAtsCoachAdvice mappe les règles clés en langage clair', () => {
+  assert.match(
+    getAtsCoachAdvice({ id: 'malus_contact_low_on_page' }).title,
+    /contact/i,
+  );
+  assert.match(
+    getAtsCoachAdvice({ id: 'malus_free_canvas_reading_order' }).explanation,
+    /haut|lecture|ATS/i,
+  );
+  assert.equal(
+    getAtsCoachAdvice({ id: 'malus_experiences_before_resume' }).fixKind,
+    'reading-order',
+  );
+});
+
+test('getAtsCoachAdvice préfère advice API si fourni', () => {
+  const advice = getAtsCoachAdvice({
+    id: 'malus_contact_low_on_page',
+    advice: 'Message backend prioritaire.',
+  });
+  assert.equal(advice.explanation, 'Message backend prioritaire.');
+});
+
+test('isAtsCoachRuleFixable pour contact et ordre', () => {
+  assert.equal(isAtsCoachRuleFixable('malus_contact_low_on_page'), true);
+  assert.equal(isAtsCoachRuleFixable('malus_identity_not_first'), true);
+  assert.equal(isAtsCoachRuleFixable('malus_photo_present'), false);
+});
+
+test('filterRulesForCoachMode masque les bonus en mode design', () => {
+  const rules = [
+    { id: 'bonus_mono_column', delta: 10 },
+    { id: 'malus_contact_low_on_page', delta: -3 },
+  ];
+  assert.deepEqual(
+    filterRulesForCoachMode(rules, 'design').map((r) => r.id),
+    ['malus_contact_low_on_page'],
+  );
+  assert.equal(filterRulesForCoachMode(rules, 'ats-safe').length, 2);
+});
+
+test('summarizeAtsCoachStatus distingue bon score et risques', () => {
+  assert.match(summarizeAtsCoachStatus(95, []), /Excellent/);
+  assert.match(
+    summarizeAtsCoachStatus(92, [{ delta: -3 }, { delta: -2 }]),
+    /2 risques/,
+  );
+});
+
+test('formatAtsScoreImpact affiche avant → après', () => {
+  assert.equal(formatAtsScoreImpact(86, 79), 'Impact score : 86 → 79 ↓');
+  assert.equal(formatAtsScoreImpact(70, 70), 'Impact score : aucun (70/100)');
+});
+
+test('applyAtsCoachFix remonte un contact trop bas', () => {
+  const layout = {
+    version: 3,
+    format: 'A4',
+    grid: 'free',
+    unit: 'mm',
+    theme: {},
+    pages: [{
+      id: 'page-1',
+      blocks: [
+        { id: 'c1', type: 'contact', x: 10, y: 120, w: 80, h: 20, z: 1, style: {} },
+      ],
+    }],
+  };
+  const next = applyAtsCoachFix(layout, 'malus_contact_low_on_page');
+  assert.ok(next.pages[0].blocks[0].y <= 40);
+});

--- a/tests/test_api_ats.py
+++ b/tests/test_api_ats.py
@@ -110,7 +110,12 @@ class TestHandleScoreParsing(unittest.TestCase):
         body = ScoreParsingBody(template_id="demo")
         payload = handle_score_parsing(body)
         for rule in payload["rules"]:
-            self.assertEqual(set(rule), {"id", "label", "delta", "severity"})
+            self.assertEqual(
+                set(rule),
+                {"id", "label", "delta", "severity", "block_ids", "advice"},
+            )
+            self.assertIsInstance(rule["block_ids"], list)
+            self.assertIsInstance(rule["advice"], str)
 
 
 if __name__ == "__main__":

--- a/tests/test_ats_score_serialization.py
+++ b/tests/test_ats_score_serialization.py
@@ -10,7 +10,30 @@ class TestRuleSerialization(unittest.TestCase):
     def test_rule_to_dict_has_expected_keys(self):
         rule = Rule(id="r1", label="L", delta=-3, severity=RuleSeverity.WARNING)
         payload = rule_to_dict(rule)
-        self.assertEqual(payload, {"id": "r1", "label": "L", "delta": -3, "severity": "warning"})
+        self.assertEqual(
+            payload,
+            {
+                "id": "r1",
+                "label": "L",
+                "delta": -3,
+                "severity": "warning",
+                "block_ids": [],
+                "advice": "L",
+            },
+        )
+
+    def test_rule_to_dict_includes_block_ids_and_advice(self):
+        rule = Rule(
+            id="malus_contact_low_on_page",
+            label="Contact bas",
+            delta=-3,
+            severity=RuleSeverity.WARNING,
+            block_ids=("b1",),
+            advice="Remonte le contact.",
+        )
+        payload = rule_to_dict(rule)
+        self.assertEqual(payload["block_ids"], ["b1"])
+        self.assertEqual(payload["advice"], "Remonte le contact.")
 
     def test_severity_is_serialized_as_lowercase_string(self):
         # Regression : si on serialise l'enum brute, le client front recoit


### PR DESCRIPTION
## Summary
- Panneau coach ATS depuis le badge : explications claires, Voir / Corriger / Ignorer
- Impact score avant/après avant correction ; modes ATS-safe vs design
- API règles enrichie (`block_ids`, `advice`) + mapping rule→message testé

Fixes AXE-36
Closes #70

## Test plan
- [ ] Ouvrir éditeur Beta, cliquer le badge ATS
- [ ] Vérifier conseils malus + « Voir sur le canvas » sélectionne le bloc
- [ ] « Voir l’impact » puis « Corriger » (Ctrl+Z annule)
- [ ] « Ignorer » masque le conseil ; réafficher via le footer
- [ ] Basculer mode design (masque les bonus)


Made with [Cursor](https://cursor.com)