### PR TITLE
Feat: Optimiser ATS — réorganisation spatiale + preview (AXE-37)

### DIFF
--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -27,7 +27,12 @@ import {
   readBlockContentFromRoot,
 } from '../../lib/canvasInlineEdit.js';
 import { resolveCanvasImageSrcForLayout } from '../../lib/uploadCanvasAsset.js';
-import { applyAtsLayoutOptimizations } from '../../lib/atsLayoutOptimize.js';
+import {
+  applyAtsLayoutOptimizations,
+  describeAtsOptimizationChanges,
+} from '../../lib/atsLayoutOptimize.js';
+import { fetchAtsScoreParsing } from '../../lib/atsScoreClient.js';
+import { formatAtsScoreImpact } from '../../lib/atsCoachFixes.js';
 import { saveLayoutProposal } from '../../lib/layoutProposalsStorage.js';
 import {
   BLANK_CANVAS_CONTEXT_KEY,
@@ -167,6 +172,9 @@ function CvEditorBeta({
   const [onboardingDismissed, setOnboardingDismissed] = useState(() => isEditorOnboardingDismissed());
   const [pdfExportError, setPdfExportError] = useState('');
   const [atsOptimizeMessage, setAtsOptimizeMessage] = useState('');
+  const [atsOptimizePreview, setAtsOptimizePreview] = useState(null);
+  const [atsOptimizePreviewLoading, setAtsOptimizePreviewLoading] = useState(false);
+  const [atsOptimizeCanUndo, setAtsOptimizeCanUndo] = useState(false);
   const autoHeightPendingRef = useRef(new Map());
   const autoHeightTimerRef = useRef(null);
   const suppressAutoHeightUntilRef = useRef(0);
@@ -1079,23 +1087,100 @@ function CvEditorBeta({
     clearDocumentTextSelection();
   }, [layout, cv, commitLayout, handleCvChange]);
 
-  const handleOptimizeAtsLayout = useCallback(() => {
-    if (!layout) return;
+  const handleOptimizeAtsLayout = useCallback(async () => {
+    if (!layout || atsOptimizePreviewLoading) return;
     const next = applyAtsLayoutOptimizations(layout);
     if (sameLayout(layout, next)) {
-      setAtsOptimizeMessage('Layout deja optimise pour la lecture ATS.');
+      setAtsOptimizeMessage('Layout déjà optimisé pour la lecture ATS.');
+      setAtsOptimizePreview(null);
       return;
     }
-    commitLayout(next, { groupKey: 'ats:optimize' });
-    setAtsOptimizeMessage('Optimisation appliquee : contenu devant, bandeaux derriere. Ctrl+Z pour annuler.');
+    const changes = describeAtsOptimizationChanges(layout, next);
+    setAtsOptimizePreviewLoading(true);
+    setAtsOptimizeMessage('');
+    setAtsOptimizePreview({
+      beforeLayout: layout,
+      afterLayout: next,
+      changes,
+      beforeScore: null,
+      afterScore: null,
+      error: '',
+    });
+    try {
+      const [beforeScored, afterScored] = await Promise.all([
+        fetchAtsScoreParsing({ layout, cv, templateId }),
+        fetchAtsScoreParsing({ layout: next, cv, templateId }),
+      ]);
+      setAtsOptimizePreview((prev) => (
+        prev
+          ? {
+            ...prev,
+            beforeScore: beforeScored.score,
+            afterScore: afterScored.score,
+            error: '',
+          }
+          : prev
+      ));
+    } catch (err) {
+      setAtsOptimizePreview((prev) => (
+        prev
+          ? {
+            ...prev,
+            error: err?.message || 'Impossible de calculer l’impact ATS',
+          }
+          : prev
+      ));
+    } finally {
+      setAtsOptimizePreviewLoading(false);
+    }
+  }, [layout, cv, templateId, atsOptimizePreviewLoading]);
+
+  const handleCancelAtsOptimizePreview = useCallback(() => {
+    setAtsOptimizePreview(null);
+    setAtsOptimizePreviewLoading(false);
+  }, []);
+
+  const handleApplyAtsOptimizePreview = useCallback(() => {
+    if (!atsOptimizePreview?.afterLayout) return;
+    const next = atsOptimizePreview.afterLayout;
+    if (sameLayout(layout, next)) {
+      setAtsOptimizePreview(null);
+      setAtsOptimizeMessage('Layout déjà optimisé pour la lecture ATS.');
+      return;
+    }
+    commitLayout(next, { groupKey: 'ats:optimize-spatial' });
+    setAtsOptimizeCanUndo(true);
+    const impact = formatAtsScoreImpact(
+      atsOptimizePreview.beforeScore,
+      atsOptimizePreview.afterScore,
+    );
+    setAtsOptimizeMessage(`Réorganisation spatiale ATS appliquée. ${impact}`);
+    setAtsOptimizePreview(null);
     if (cv) autoSave.schedule(cv);
-  }, [layout, commitLayout, cv, autoSave]);
+  }, [atsOptimizePreview, layout, commitLayout, cv, autoSave]);
+
+  const handleUndoAtsOptimize = useCallback(() => {
+    if (!canUndoLayout) {
+      setAtsOptimizeCanUndo(false);
+      return;
+    }
+    undoLayout();
+    setAtsOptimizeCanUndo(false);
+    setAtsOptimizeMessage('Optimisation ATS annulée.');
+    if (cv) autoSave.schedule(cv);
+  }, [canUndoLayout, undoLayout, cv, autoSave]);
 
   useEffect(() => {
     if (!atsOptimizeMessage) return undefined;
-    const id = setTimeout(() => setAtsOptimizeMessage(''), 4500);
+    const id = setTimeout(() => setAtsOptimizeMessage(''), 6500);
     return () => clearTimeout(id);
   }, [atsOptimizeMessage]);
+
+  useEffect(() => {
+    if (!atsOptimizeCanUndo) return undefined;
+    if (!canUndoLayout) setAtsOptimizeCanUndo(false);
+    return undefined;
+  }, [atsOptimizeCanUndo, canUndoLayout]);
 
   const handleExportLayoutPdf = useCallback(async () => {
     if (!cv || !layout || pdfExporting) return;
@@ -1379,10 +1464,10 @@ function CvEditorBeta({
             type="button"
             className="cv-editor-beta-history-btn"
             onClick={handleOptimizeAtsLayout}
-            disabled={loading || !layout}
-            title="Réordonner les blocs pour la lecture ATS"
+            disabled={loading || !layout || atsOptimizePreviewLoading}
+            title="Réorganiser spatialement les blocs pour la lecture ATS (aperçu avant application)"
           >
-            Optimiser ATS
+            {atsOptimizePreviewLoading ? 'Analyse ATS…' : 'Optimiser ATS'}
           </button>
           <button
             type="button"
@@ -1413,9 +1498,72 @@ function CvEditorBeta({
           Survole le badge « PDF » sur le canvas pour le détail.
         </div>
       )}
+      {atsOptimizePreview && (
+        <div className="cv-editor-beta-ats-preview" role="dialog" aria-label="Aperçu optimisation ATS">
+          <div className="cv-editor-beta-ats-preview__header">
+            <strong>Aperçu — réorganisation spatiale ATS</strong>
+            <button
+              type="button"
+              className="cv-editor-beta-ats-preview__close"
+              onClick={handleCancelAtsOptimizePreview}
+              aria-label="Fermer l’aperçu"
+            >
+              ✕
+            </button>
+          </div>
+          <p className="cv-editor-beta-ats-preview__impact" role="status">
+            {atsOptimizePreviewLoading && 'Calcul de l’impact score…'}
+            {!atsOptimizePreviewLoading && atsOptimizePreview.error && atsOptimizePreview.error}
+            {!atsOptimizePreviewLoading && !atsOptimizePreview.error && (
+              formatAtsScoreImpact(
+                atsOptimizePreview.beforeScore,
+                atsOptimizePreview.afterScore,
+              )
+            )}
+          </p>
+          {atsOptimizePreview.changes?.length > 0 ? (
+            <ul className="cv-editor-beta-ats-preview__changes">
+              {atsOptimizePreview.changes.slice(0, 8).map((change) => (
+                <li key={change.id}>{change.label}</li>
+              ))}
+              {atsOptimizePreview.changes.length > 8 && (
+                <li>+ {atsOptimizePreview.changes.length - 8} autre(s) déplacement(s)</li>
+              )}
+            </ul>
+          ) : (
+            <p className="cv-editor-beta-ats-preview__empty">Aucun déplacement détecté.</p>
+          )}
+          <div className="cv-editor-beta-ats-preview__actions">
+            <button
+              type="button"
+              className="cv-editor-beta-ats-preview__btn"
+              onClick={handleCancelAtsOptimizePreview}
+            >
+              Annuler
+            </button>
+            <button
+              type="button"
+              className="cv-editor-beta-ats-preview__btn cv-editor-beta-ats-preview__btn--primary"
+              onClick={handleApplyAtsOptimizePreview}
+              disabled={atsOptimizePreviewLoading}
+            >
+              Appliquer
+            </button>
+          </div>
+        </div>
+      )}
       {atsOptimizeMessage && (
-        <div className="cv-editor-beta-info" role="status">
-          {atsOptimizeMessage}
+        <div className="cv-editor-beta-info cv-editor-beta-ats-toast" role="status">
+          <span>{atsOptimizeMessage}</span>
+          {atsOptimizeCanUndo && (
+            <button
+              type="button"
+              className="cv-editor-beta-ats-toast__undo"
+              onClick={handleUndoAtsOptimize}
+            >
+              Annuler
+            </button>
+          )}
         </div>
       )}
 

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -174,7 +174,9 @@ function CvEditorBeta({
   const [atsOptimizeMessage, setAtsOptimizeMessage] = useState('');
   const [atsOptimizePreview, setAtsOptimizePreview] = useState(null);
   const [atsOptimizePreviewLoading, setAtsOptimizePreviewLoading] = useState(false);
-  const [atsOptimizeCanUndo, setAtsOptimizeCanUndo] = useState(false);
+  /** Layout post-apply : Annuler n'est visible que tant que le canvas === ce snapshot. */
+  const [atsOptimizeUndoAfter, setAtsOptimizeUndoAfter] = useState(null);
+  const atsOptimizePreviewReqRef = useRef(0);
   const autoHeightPendingRef = useRef(new Map());
   const autoHeightTimerRef = useRef(null);
   const suppressAutoHeightUntilRef = useRef(0);
@@ -1096,8 +1098,11 @@ function CvEditorBeta({
       return;
     }
     const changes = describeAtsOptimizationChanges(layout, next);
+    const reqId = atsOptimizePreviewReqRef.current + 1;
+    atsOptimizePreviewReqRef.current = reqId;
     setAtsOptimizePreviewLoading(true);
     setAtsOptimizeMessage('');
+    setAtsOptimizeUndoAfter(null);
     setAtsOptimizePreview({
       beforeLayout: layout,
       afterLayout: next,
@@ -1111,6 +1116,7 @@ function CvEditorBeta({
         fetchAtsScoreParsing({ layout, cv, templateId }),
         fetchAtsScoreParsing({ layout: next, cv, templateId }),
       ]);
+      if (atsOptimizePreviewReqRef.current !== reqId) return;
       setAtsOptimizePreview((prev) => (
         prev
           ? {
@@ -1122,6 +1128,7 @@ function CvEditorBeta({
           : prev
       ));
     } catch (err) {
+      if (atsOptimizePreviewReqRef.current !== reqId) return;
       setAtsOptimizePreview((prev) => (
         prev
           ? {
@@ -1131,17 +1138,25 @@ function CvEditorBeta({
           : prev
       ));
     } finally {
-      setAtsOptimizePreviewLoading(false);
+      if (atsOptimizePreviewReqRef.current === reqId) {
+        setAtsOptimizePreviewLoading(false);
+      }
     }
   }, [layout, cv, templateId, atsOptimizePreviewLoading]);
 
   const handleCancelAtsOptimizePreview = useCallback(() => {
+    atsOptimizePreviewReqRef.current += 1;
     setAtsOptimizePreview(null);
     setAtsOptimizePreviewLoading(false);
   }, []);
 
   const handleApplyAtsOptimizePreview = useCallback(() => {
-    if (!atsOptimizePreview?.afterLayout) return;
+    if (!atsOptimizePreview?.afterLayout || !atsOptimizePreview?.beforeLayout) return;
+    if (!sameLayout(layout, atsOptimizePreview.beforeLayout)) {
+      setAtsOptimizeMessage('Le canvas a changé depuis l’aperçu — relance Optimiser ATS.');
+      setAtsOptimizePreview(null);
+      return;
+    }
     const next = atsOptimizePreview.afterLayout;
     if (sameLayout(layout, next)) {
       setAtsOptimizePreview(null);
@@ -1149,7 +1164,7 @@ function CvEditorBeta({
       return;
     }
     commitLayout(next, { groupKey: 'ats:optimize-spatial' });
-    setAtsOptimizeCanUndo(true);
+    setAtsOptimizeUndoAfter(next);
     const impact = formatAtsScoreImpact(
       atsOptimizePreview.beforeScore,
       atsOptimizePreview.afterScore,
@@ -1160,27 +1175,36 @@ function CvEditorBeta({
   }, [atsOptimizePreview, layout, commitLayout, cv, autoSave]);
 
   const handleUndoAtsOptimize = useCallback(() => {
+    if (!atsOptimizeUndoAfter || !sameLayout(layout, atsOptimizeUndoAfter)) {
+      setAtsOptimizeUndoAfter(null);
+      return;
+    }
     if (!canUndoLayout) {
-      setAtsOptimizeCanUndo(false);
+      setAtsOptimizeUndoAfter(null);
       return;
     }
     undoLayout();
-    setAtsOptimizeCanUndo(false);
+    setAtsOptimizeUndoAfter(null);
     setAtsOptimizeMessage('Optimisation ATS annulée.');
     if (cv) autoSave.schedule(cv);
-  }, [canUndoLayout, undoLayout, cv, autoSave]);
+  }, [atsOptimizeUndoAfter, layout, canUndoLayout, undoLayout, cv, autoSave]);
+
+  const atsOptimizeUndoVisible = Boolean(
+    atsOptimizeUndoAfter && layout && sameLayout(layout, atsOptimizeUndoAfter),
+  );
 
   useEffect(() => {
-    if (!atsOptimizeMessage) return undefined;
+    if (!atsOptimizeMessage || atsOptimizeUndoVisible) return undefined;
     const id = setTimeout(() => setAtsOptimizeMessage(''), 6500);
     return () => clearTimeout(id);
-  }, [atsOptimizeMessage]);
+  }, [atsOptimizeMessage, atsOptimizeUndoVisible]);
 
   useEffect(() => {
-    if (!atsOptimizeCanUndo) return undefined;
-    if (!canUndoLayout) setAtsOptimizeCanUndo(false);
-    return undefined;
-  }, [atsOptimizeCanUndo, canUndoLayout]);
+    if (!atsOptimizeUndoAfter) return;
+    if (!layout || !sameLayout(layout, atsOptimizeUndoAfter)) {
+      setAtsOptimizeUndoAfter(null);
+    }
+  }, [layout, atsOptimizeUndoAfter]);
 
   const handleExportLayoutPdf = useCallback(async () => {
     if (!cv || !layout || pdfExporting) return;
@@ -1552,10 +1576,10 @@ function CvEditorBeta({
           </div>
         </div>
       )}
-      {atsOptimizeMessage && (
+      {(atsOptimizeMessage || atsOptimizeUndoVisible) && (
         <div className="cv-editor-beta-info cv-editor-beta-ats-toast" role="status">
-          <span>{atsOptimizeMessage}</span>
-          {atsOptimizeCanUndo && (
+          <span>{atsOptimizeMessage || 'Réorganisation spatiale ATS appliquée.'}</span>
+          {atsOptimizeUndoVisible && (
             <button
               type="button"
               className="cv-editor-beta-ats-toast__undo"

--- a/frontend/src/lib/atsCoachFixes.js
+++ b/frontend/src/lib/atsCoachFixes.js
@@ -4,7 +4,7 @@
 
 import {
   optimizeContactVerticalPosition,
-  optimizeLayoutReadingOrder,
+  optimizeLayoutSpatialOrder,
 } from './atsLayoutOptimize.js';
 import { getAtsCoachAdvice } from './atsCoachAdvice.js';
 
@@ -21,7 +21,7 @@ export function applyAtsCoachFix(layout, ruleId) {
     return optimizeContactVerticalPosition(layout);
   }
   if (fixKind === 'reading-order') {
-    return optimizeLayoutReadingOrder(layout);
+    return optimizeLayoutSpatialOrder(layout);
   }
   return layout;
 }

--- a/frontend/src/lib/atsLayoutOptimize.js
+++ b/frontend/src/lib/atsLayoutOptimize.js
@@ -1,12 +1,19 @@
 /**
- * Optimisations ATS 1-clic sur layout v3 (P4.4).
+ * Optimisations ATS 1-clic sur layout v3 (AXE-37).
+ *
+ * Important : le score free_canvas lit l'ordre **spatial** (y puis x).
+ * Un simple tri z-index ne suffit pas — on repositionne les blocs de contenu.
  */
 
-import { listAllBlocks } from './cvLayoutModelV3.js';
+import {
+  listAllBlocks,
+  PAGE_HEIGHT_MM,
+  PAGE_MARGIN_MM,
+} from './cvLayoutModelV3.js';
 import { isVectorShapeType } from './canvasShapePresets.js';
 
 /** Ordre de lecture sémantique recommandé (haut → bas, même page). */
-const SEMANTIC_READ_ORDER = [
+export const SEMANTIC_READ_ORDER = [
   'identity',
   'photo',
   'contact',
@@ -19,6 +26,9 @@ const SEMANTIC_READ_ORDER = [
   'projets',
 ];
 
+const CONTENT_GAP_MM = 6;
+const CONTACT_TOP_Y_MM = 40;
+
 function semanticRank(type) {
   const i = SEMANTIC_READ_ORDER.indexOf(type);
   return i >= 0 ? i : 50;
@@ -30,13 +40,27 @@ function visualLayerRank(type) {
   return 2;
 }
 
+function asNumber(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+/** Blocs dont la position y impacte la lecture ATS. */
+export function isAtsReadingContentBlock(block) {
+  if (!block || typeof block !== 'object') return false;
+  const type = block.type;
+  if (typeof type !== 'string') return false;
+  if (SEMANTIC_READ_ORDER.includes(type)) return true;
+  return type === 'title' || type === 'text';
+}
+
+function isDecorativeBlock(block) {
+  return !isAtsReadingContentBlock(block);
+}
+
 /**
- * Réordonne les blocs par page : identité/contact en tête, puis ordre canonique.
- * Conserve x/y/w/h ; ajuste z pour l empilement visuel.
- *
- * Important : les formes décoratives doivent rester derrière le contenu.
- * Sinon le bouton "Optimiser ATS" peut passer un bandeau au premier plan
- * et masquer les textes, ce qui est l inverse de l intention utilisateur.
+ * Réordonne les calques (z) : décor derrière, contenu devant, ordre sémantique.
+ * Ne touche pas x/y/w/h.
  */
 export function optimizeLayoutReadingOrder(layout) {
   if (!layout?.pages?.length) return layout;
@@ -49,7 +73,7 @@ export function optimizeLayoutReadingOrder(layout) {
       const ra = semanticRank(a.type);
       const rb = semanticRank(b.type);
       if (ra !== rb) return ra - rb;
-      return (a.y || 0) - (b.y || 0);
+      return asNumber(a.y) - asNumber(b.y);
     });
     let z = 1;
     const nextBlocks = sorted.map((b) => ({ ...b, z: z++ }));
@@ -59,15 +83,16 @@ export function optimizeLayoutReadingOrder(layout) {
 }
 
 /**
- * Remonte le bloc contact sous 25 % de la hauteur de page si trop bas.
+ * Remonte le bloc contact sous ~13 % de la hauteur A4 si trop bas.
  */
 export function optimizeContactVerticalPosition(layout) {
   if (!layout?.pages?.length) return layout;
+  const threshold = PAGE_HEIGHT_MM * 0.3;
   const pages = layout.pages.map((page) => {
     const blocks = (page.blocks || []).map((b) => {
       if (b.type !== 'contact') return b;
-      if ((b.y || 0) > 297 * 0.3) {
-        return { ...b, y: Math.min(b.y, 40) };
+      if (asNumber(b.y) > threshold) {
+        return { ...b, y: Math.min(asNumber(b.y), CONTACT_TOP_Y_MM) };
       }
       return b;
     });
@@ -76,30 +101,103 @@ export function optimizeContactVerticalPosition(layout) {
   return { ...layout, pages };
 }
 
-/** Applique toutes les optimisations ATS disponibles côté client. */
+/**
+ * Vraie réorganisation spatiale : empile le contenu en ordre ATS (y croissant).
+ * Conserve x/w/h ; laisse les formes décoratives à leur place.
+ */
+export function optimizeLayoutSpatialOrder(layout) {
+  if (!layout?.pages?.length) return layout;
+  const pages = layout.pages.map((page) => {
+    const blocks = Array.isArray(page.blocks) ? page.blocks : [];
+    const content = blocks.filter(isAtsReadingContentBlock);
+    const decor = blocks.filter(isDecorativeBlock);
+    if (content.length === 0) {
+      return { ...page, blocks: [...blocks] };
+    }
+
+    const sorted = [...content].sort((a, b) => {
+      const ra = semanticRank(a.type);
+      const rb = semanticRank(b.type);
+      if (ra !== rb) return ra - rb;
+      return asNumber(a.y) - asNumber(b.y);
+    });
+
+    let cursorY = PAGE_MARGIN_MM;
+    const relocated = sorted.map((block) => {
+      const h = Math.max(asNumber(block.h, 10), 3);
+      const next = { ...block, y: cursorY };
+      cursorY += h + CONTENT_GAP_MM;
+      return next;
+    });
+
+    return { ...page, blocks: [...decor, ...relocated] };
+  });
+  return { ...layout, pages };
+}
+
+/** Applique spatial + contact + calques (pipeline ATS 1-clic). */
 export function applyAtsLayoutOptimizations(layout) {
   let next = layout;
-  next = optimizeLayoutReadingOrder(next);
+  next = optimizeLayoutSpatialOrder(next);
   next = optimizeContactVerticalPosition(next);
+  next = optimizeLayoutReadingOrder(next);
   return next;
 }
 
-/** Liste d actions proposées pour l UI (P4.4). */
+/**
+ * Décrit les déplacements de blocs (pour le panneau avant/après).
+ * @returns {Array<{ id: string, type: string, label: string, fromY: number, toY: number }>}
+ */
+export function describeAtsOptimizationChanges(beforeLayout, afterLayout) {
+  if (!beforeLayout || !afterLayout) return [];
+  const beforeById = new Map(
+    listAllBlocks(beforeLayout).map((b) => [b.id, b]),
+  );
+  const changes = [];
+  for (const after of listAllBlocks(afterLayout)) {
+    if (!after?.id) continue;
+    const before = beforeById.get(after.id);
+    if (!before) continue;
+    const fromY = Math.round(asNumber(before.y) * 10) / 10;
+    const toY = Math.round(asNumber(after.y) * 10) / 10;
+    const fromZ = asNumber(before.z, 1);
+    const toZ = asNumber(after.z, 1);
+    if (fromY === toY && fromZ === toZ) continue;
+    const typeLabel = typeof after.type === 'string' ? after.type : 'bloc';
+    let label = `${typeLabel} : ${fromY} → ${toY} mm`;
+    if (fromY === toY && fromZ !== toZ) {
+      label = `${typeLabel} : calque ${fromZ} → ${toZ}`;
+    }
+    changes.push({
+      id: after.id,
+      type: typeLabel,
+      label,
+      fromY,
+      toY,
+    });
+  }
+  return changes;
+}
+
+/** Liste d actions proposées pour l UI (coach / legacy). */
 export function listAtsLayoutOptimizationActions(layout) {
   if (!layout) return [];
   const blocks = listAllBlocks(layout);
   const actions = [];
   const identity = blocks.find((b) => b.type === 'identity');
-  const first = blocks[0];
-  if (identity && first && first.id !== identity.id) {
+  const sortedByY = [...blocks]
+    .filter(isAtsReadingContentBlock)
+    .sort((a, b) => asNumber(a.y) - asNumber(b.y));
+  const firstContent = sortedByY[0];
+  if (identity && firstContent && firstContent.id !== identity.id) {
     actions.push({
       id: 'reading-order',
-      label: 'Réordonner pour la lecture ATS',
-      description: 'Identité et sections clés en tête de page.',
+      label: 'Réorganiser spatialement pour la lecture ATS',
+      description: 'Identité et sections clés empilées de haut en bas.',
     });
   }
   const contact = blocks.find((b) => b.type === 'contact');
-  if (contact && (contact.y || 0) > 297 * 0.3) {
+  if (contact && asNumber(contact.y) > PAGE_HEIGHT_MM * 0.3) {
     actions.push({
       id: 'contact-up',
       label: 'Remonter le contact',
@@ -109,8 +207,8 @@ export function listAtsLayoutOptimizationActions(layout) {
   if (actions.length === 0) {
     actions.push({
       id: 'reading-order',
-      label: 'Réordonner pour la lecture ATS',
-      description: 'Aligner l ordre des blocs sur les bonnes pratiques ATS.',
+      label: 'Réorganiser spatialement pour la lecture ATS',
+      description: 'Empiler les blocs selon l’ordre de lecture machine.',
     });
   }
   return actions;

--- a/frontend/src/lib/atsLayoutOptimize.js
+++ b/frontend/src/lib/atsLayoutOptimize.js
@@ -12,17 +12,17 @@ import {
 } from './cvLayoutModelV3.js';
 import { isVectorShapeType } from './canvasShapePresets.js';
 
-/** Ordre de lecture sémantique recommandé (haut → bas, même page). */
+/** Ordre aligné sur `free_canvas._CANONICAL_READ_ORDER` (scorer ATS). */
 export const SEMANTIC_READ_ORDER = [
   'identity',
-  'photo',
   'contact',
+  'photo',
   'resume',
   'experiences',
   'formations',
+  'certifications',
   'skills',
   'languages',
-  'certifications',
   'projets',
 ];
 
@@ -135,11 +135,15 @@ export function optimizeLayoutSpatialOrder(layout) {
   return { ...layout, pages };
 }
 
-/** Applique spatial + contact + calques (pipeline ATS 1-clic). */
+/** Applique spatial + calques (pipeline ATS 1-clic).
+ *
+ * Pas de `optimizeContactVerticalPosition` ici : le stack spatial place déjà
+ * le contact juste sous l'identité. Un yank à y=40 après coup chevaucherait
+ * identity/photo et casserait l'ordre que le scorer attend.
+ */
 export function applyAtsLayoutOptimizations(layout) {
   let next = layout;
   next = optimizeLayoutSpatialOrder(next);
-  next = optimizeContactVerticalPosition(next);
   next = optimizeLayoutReadingOrder(next);
   return next;
 }

--- a/frontend/src/styles/CvEditorBeta.css
+++ b/frontend/src/styles/CvEditorBeta.css
@@ -301,6 +301,101 @@
   font-weight: 500;
 }
 
+.cv-editor-beta-ats-toast {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.cv-editor-beta-ats-toast__undo {
+  border: none;
+  background: transparent;
+  color: var(--color-action-blue);
+  font-weight: 500;
+  font-size: 0.82rem;
+  text-decoration: underline;
+  cursor: pointer;
+  font-family: inherit;
+  padding: 0;
+  flex-shrink: 0;
+}
+
+.cv-editor-beta-ats-preview {
+  border-bottom: 1px solid var(--color-hairline);
+  background: var(--color-canvas);
+  padding: 0.75rem 1rem 0.85rem;
+}
+
+.cv-editor-beta-ats-preview__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+.cv-editor-beta-ats-preview__close {
+  border: none;
+  background: transparent;
+  color: var(--color-slate);
+  cursor: pointer;
+  font-size: 0.9rem;
+  line-height: 1;
+  padding: 0.1rem 0.25rem;
+}
+
+.cv-editor-beta-ats-preview__impact {
+  margin: 0 0 0.45rem;
+  font-size: 0.82rem;
+  color: var(--color-deep-green);
+  font-weight: 500;
+}
+
+.cv-editor-beta-ats-preview__changes {
+  margin: 0 0 0.65rem;
+  padding-left: 1.1rem;
+  font-size: 0.78rem;
+  color: var(--color-body-muted);
+  line-height: 1.4;
+  max-height: 7.5rem;
+  overflow-y: auto;
+}
+
+.cv-editor-beta-ats-preview__empty {
+  margin: 0 0 0.65rem;
+  font-size: 0.78rem;
+  color: var(--color-muted);
+}
+
+.cv-editor-beta-ats-preview__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.cv-editor-beta-ats-preview__btn {
+  border: 1px solid var(--color-primary);
+  background: transparent;
+  color: var(--color-primary);
+  border-radius: 30px;
+  padding: 0.35rem 0.9rem;
+  font-size: 0.78rem;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.cv-editor-beta-ats-preview__btn--primary {
+  background: var(--color-primary);
+  color: var(--color-on-dark);
+}
+
+.cv-editor-beta-ats-preview__btn:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
+
 .cv-editor-beta-pdf-fidelity {
   background: var(--color-soft-stone);
   color: var(--color-body-muted);

--- a/frontend/tests/unit/atsLayoutOptimize.test.js
+++ b/frontend/tests/unit/atsLayoutOptimize.test.js
@@ -1,9 +1,13 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createStarterLayoutV3 } from '../../src/lib/cvLayoutModelV3.js';
-import { applyAtsLayoutOptimizations } from '../../src/lib/atsLayoutOptimize.js';
+import {
+  applyAtsLayoutOptimizations,
+  describeAtsOptimizationChanges,
+  optimizeLayoutSpatialOrder,
+} from '../../src/lib/atsLayoutOptimize.js';
 
-test('reordonne les blocs semantiques par type', () => {
+test('reordonne les blocs semantiques par type (z)', () => {
   const layout = createStarterLayoutV3();
   const page = layout.pages[0];
   const blocks = page.blocks;
@@ -46,4 +50,68 @@ test('garde les bandeaux decoratifs derriere le contenu', () => {
 
   assert.ok(banner.z < title.z);
   assert.ok(banner.z < resume.z);
+});
+
+test('optimisation spatiale empile identity avant experiences (y)', () => {
+  const layout = {
+    version: 3,
+    format: 'A4',
+    grid: 'free',
+    unit: 'mm',
+    theme: {},
+    pages: [{
+      id: 'page-1',
+      blocks: [
+        { id: 'exp', type: 'experiences', x: 10, y: 10, w: 180, h: 40, z: 2, style: {} },
+        { id: 'id', type: 'identity', x: 10, y: 80, w: 180, h: 20, z: 1, style: {} },
+        { id: 'banner', type: 'shape:rect', x: 0, y: 0, w: 210, h: 12, z: 99, style: {} },
+      ],
+    }],
+  };
+  const next = optimizeLayoutSpatialOrder(layout);
+  const identity = next.pages[0].blocks.find((b) => b.id === 'id');
+  const experiences = next.pages[0].blocks.find((b) => b.id === 'exp');
+  const banner = next.pages[0].blocks.find((b) => b.id === 'banner');
+  assert.ok(identity.y < experiences.y);
+  assert.equal(banner.y, 0);
+});
+
+test('applyAtsLayoutOptimizations remonte contact + ordre spatial', () => {
+  const layout = {
+    version: 3,
+    format: 'A4',
+    grid: 'free',
+    unit: 'mm',
+    theme: {},
+    pages: [{
+      id: 'page-1',
+      blocks: [
+        { id: 'exp', type: 'experiences', x: 10, y: 20, w: 180, h: 50, z: 1, style: {} },
+        { id: 'contact', type: 'contact', x: 10, y: 200, w: 180, h: 10, z: 2, style: {} },
+        { id: 'id', type: 'identity', x: 10, y: 120, w: 180, h: 20, z: 3, style: {} },
+      ],
+    }],
+  };
+  const next = applyAtsLayoutOptimizations(layout);
+  const byType = Object.fromEntries(next.pages[0].blocks.map((b) => [b.type, b]));
+  assert.ok(byType.identity.y < byType.contact.y);
+  assert.ok(byType.contact.y < byType.experiences.y);
+});
+
+test('describeAtsOptimizationChanges liste les deplacements y', () => {
+  const before = {
+    version: 3,
+    grid: 'free',
+    pages: [{
+      id: 'p1',
+      blocks: [
+        { id: 'a', type: 'identity', x: 10, y: 80, w: 100, h: 20, z: 1 },
+        { id: 'b', type: 'contact', x: 10, y: 10, w: 100, h: 10, z: 2 },
+      ],
+    }],
+  };
+  const after = optimizeLayoutSpatialOrder(before);
+  const changes = describeAtsOptimizationChanges(before, after);
+  assert.ok(changes.length >= 1);
+  assert.ok(changes.some((c) => c.id === 'a' || c.id === 'b'));
 });

--- a/frontend/tests/unit/atsLayoutOptimize.test.js
+++ b/frontend/tests/unit/atsLayoutOptimize.test.js
@@ -98,6 +98,57 @@ test('applyAtsLayoutOptimizations remonte contact + ordre spatial', () => {
   assert.ok(byType.contact.y < byType.experiences.y);
 });
 
+test('ordre spatial aligne scorer free_canvas (contact avant photo, certif avant skills)', () => {
+  const layout = {
+    version: 3,
+    format: 'A4',
+    grid: 'free',
+    unit: 'mm',
+    theme: {},
+    pages: [{
+      id: 'page-1',
+      blocks: [
+        { id: 'skills', type: 'skills', x: 10, y: 10, w: 180, h: 20, z: 1, style: {} },
+        { id: 'photo', type: 'photo', x: 10, y: 40, w: 40, h: 40, z: 2, style: {} },
+        { id: 'cert', type: 'certifications', x: 10, y: 90, w: 180, h: 20, z: 3, style: {} },
+        { id: 'contact', type: 'contact', x: 10, y: 120, w: 180, h: 10, z: 4, style: {} },
+        { id: 'id', type: 'identity', x: 10, y: 150, w: 180, h: 20, z: 5, style: {} },
+      ],
+    }],
+  };
+  const next = applyAtsLayoutOptimizations(layout);
+  const byType = Object.fromEntries(
+    next.pages[0].blocks.filter((b) => b.type !== 'shape:rect').map((b) => [b.type, b]),
+  );
+  assert.ok(byType.identity.y < byType.contact.y);
+  assert.ok(byType.contact.y < byType.photo.y);
+  assert.ok(byType.certifications.y < byType.skills.y);
+});
+
+test('applyAtsLayoutOptimizations ne yank pas le contact hors du stack', () => {
+  const layout = {
+    version: 3,
+    format: 'A4',
+    grid: 'free',
+    unit: 'mm',
+    theme: {},
+    pages: [{
+      id: 'page-1',
+      blocks: [
+        { id: 'id', type: 'identity', x: 10, y: 200, w: 180, h: 40, z: 1, style: {} },
+        { id: 'photo', type: 'photo', x: 10, y: 10, w: 40, h: 50, z: 2, style: {} },
+        { id: 'contact', type: 'contact', x: 10, y: 250, w: 180, h: 10, z: 3, style: {} },
+      ],
+    }],
+  };
+  const next = applyAtsLayoutOptimizations(layout);
+  const byType = Object.fromEntries(next.pages[0].blocks.map((b) => [b.type, b]));
+  // identity (h=40) + gap 6 → contact à y≈56, pas yanké à 40 par-dessus identity
+  assert.ok(byType.contact.y >= byType.identity.y + byType.identity.h);
+  assert.ok(byType.identity.y < byType.contact.y);
+  assert.ok(byType.contact.y < byType.photo.y);
+});
+
 test('describeAtsOptimizationChanges liste les deplacements y', () => {
   const before = {
     version: 3,

--- a/tests/test_ats_score_rules_free_canvas.py
+++ b/tests/test_ats_score_rules_free_canvas.py
@@ -123,5 +123,45 @@ class TestContactFarFromTop(unittest.TestCase):
         self.assertIsNone(fc_rules.rule_contact_far_from_top(cv, layout))
 
 
+class TestSpatialReorganizationImprovesScore(unittest.TestCase):
+    """AXE-37 : une réorganisation spatiale (y) doit lever les malus free_canvas."""
+
+    def test_score_increases_after_canonical_y_stack(self):
+        from backend.services.ats_score import score_parsing
+
+        cv = {
+            "prenom": "Alice",
+            "nom": "Martin",
+            "email": "alice@example.com",
+            "telephone": "0600000000",
+            "resume": "Profil",
+            "experiences": [{"poste": "Dev", "debut": "2020", "fin": "2024"}],
+        }
+        before = _free_layout(
+            [
+                {"id": "exp", "type": "experiences", "x": 10, "y": 10, "w": 180, "h": 40},
+                {"id": "contact", "type": "contact", "x": 10, "y": 160, "w": 180, "h": 10},
+                {"id": "resume", "type": "resume", "x": 10, "y": 60, "w": 180, "h": 20},
+                {"id": "id", "type": "identity", "x": 10, "y": 100, "w": 180, "h": 20},
+            ]
+        )
+        # Miroir de optimizeLayoutSpatialOrder (front) : empilement haut → bas.
+        after = _free_layout(
+            [
+                {"id": "id", "type": "identity", "x": 10, "y": 10, "w": 180, "h": 20},
+                {"id": "contact", "type": "contact", "x": 10, "y": 36, "w": 180, "h": 10},
+                {"id": "resume", "type": "resume", "x": 10, "y": 52, "w": 180, "h": 20},
+                {"id": "exp", "type": "experiences", "x": 10, "y": 78, "w": 180, "h": 40},
+            ]
+        )
+        before_score = score_parsing(cv, before).total
+        after_score = score_parsing(cv, after).total
+        self.assertGreater(after_score, before_score)
+        self.assertIsNone(fc_rules.rule_free_canvas_reading_order({}, after))
+        self.assertIsNone(fc_rules.rule_identity_not_first_in_reading({}, after))
+        self.assertIsNone(fc_rules.rule_experiences_before_resume({}, after))
+        self.assertIsNone(fc_rules.rule_contact_far_from_top(cv, after))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Vraie réorganisation spatiale (empilement y) alignée sur les règles free_canvas
- Preview avant/après avec impact score + liste des déplacements
- Annulation en un clic après application ; libellé/tooltip honnêtes

Fixes AXE-37
Closes #72

## Test plan
- [ ] Éditeur Beta : désordonner identity/contact/experiences
- [ ] Cliquer « Optimiser ATS » → aperçu score + changements
- [ ] Appliquer → blocs empilés ; toast avec Annuler
- [ ] Annuler restaure le layout précédent
- [ ] Coach « Corriger » ordre de lecture utilise aussi le spatial


Made with [Cursor](https://cursor.com)