### PR TITLE
feat(ats): verify-pdf (score JSON vs réel) + snapshots HTML/PDF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,14 @@ jobs:
         with:
           python-version: "3.12"
 
+      # WeasyPrint (verify-pdf / snapshots HTML→PDF, AXE-39)
+      - name: Install WeasyPrint system libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 \
+            libffi-dev shared-mime-info fonts-dejavu-core
+
       - name: Create virtualenv and install dependencies
         run: |
           python -m venv .venv
@@ -58,6 +66,8 @@ jobs:
           pytest tests -v --tb=short \
             --cov=backend.services.cv_render_helpers \
             --cov=backend.cv_html_render \
+            --cov=backend.services.ats_parsing_check \
+            --cov=backend.api_ats \
             --cov-report=term-missing \
             --cov-fail-under=62
 

--- a/backend/api_ats.py
+++ b/backend/api_ats.py
@@ -6,7 +6,7 @@ Module isole de ``backend/main.py`` pour conserver une separation claire
 
 1. valider le payload (Pydantic) ;
 2. resoudre un layout depuis ``template_id`` si necessaire ;
-3. appeler ``score_parsing`` ;
+3. appeler ``score_parsing`` / ``verify-pdf`` ;
 4. serialiser la reponse via ``serialization.score_result_to_dict``.
 
 Ce decoupage permet de tester :
@@ -28,6 +28,11 @@ from fastapi import HTTPException
 from pydantic import BaseModel, Field
 
 from backend.path_safety import is_safe_id_segment, resolve_under_base
+from backend.services.ats_parsing_check import (
+    adjust_score_with_ground_truth,
+    rules_diff,
+    verify_parsing_quality,
+)
 from backend.services.ats_score import score_parsing
 from backend.services.ats_score.serialization import score_result_to_dict
 from backend.services.ats_score.template_layout import template_meta_to_layout
@@ -37,6 +42,10 @@ from backend.services.ats_score.template_layout import template_meta_to_layout
 # les tests.
 _DEFAULT_TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
 _templates_dir: Path = _DEFAULT_TEMPLATES_DIR
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Ecart score JSON vs PDF au-dela duquel un test de non-regression echoue.
+VERIFY_PDF_SCORE_DELTA_THRESHOLD: int = 25
 
 
 def set_templates_dir(path: Path) -> None:
@@ -66,6 +75,16 @@ class ScoreParsingBody(BaseModel):
     cv: dict[str, Any] | None = None
     layout: dict[str, Any] | None = None
     template_id: str | None = Field(default=None, max_length=64)
+
+
+class VerifyPdfBody(ScoreParsingBody):
+    """Payload de ``POST /api/ats/verify-pdf``.
+
+    Meme forme que score-parsing. Optionnellement ``pdf_base64`` permet de
+    rejouer une verification sur un PDF deja genere (debug / CI).
+    """
+
+    pdf_base64: str | None = Field(default=None, max_length=12_000_000)
 
 
 def _load_template_meta(template_id: str) -> dict[str, Any]:
@@ -131,3 +150,102 @@ def handle_score_parsing(body: ScoreParsingBody) -> dict[str, Any]:
     cv = body.cv if isinstance(body.cv, dict) else {}
     result = score_parsing(cv, layout)
     return score_result_to_dict(result)
+
+
+def _layout_has_pages(layout: dict[str, Any]) -> bool:
+    pages = layout.get("pages")
+    return isinstance(pages, list) and bool(pages)
+
+
+def render_verify_pdf_bytes(
+    cv: dict[str, Any],
+    layout: dict[str, Any],
+    template_id: str | None,
+) -> bytes:
+    """Genere les octets PDF a verifier (layout free-canvas ou template HTML)."""
+    from backend.services.generator import generer_pdf_bytes, generer_pdf_bytes_from_html
+
+    if _layout_has_pages(layout):
+        from backend.services.layout_renderer import render_html
+
+        html = render_html(cv, layout, for_preview=False)
+        pdf_bytes, _ = generer_pdf_bytes_from_html(
+            html,
+            _REPO_ROOT,
+            cv,
+            {},
+            template_id=template_id,
+        )
+        return pdf_bytes
+
+    tid = (template_id or "").strip() or str(layout.get("template_id") or "").strip()
+    if not tid:
+        raise HTTPException(
+            status_code=400,
+            detail="Pour verify-pdf sans layout.pages, template_id est requis.",
+        )
+    pdf_bytes, _ = generer_pdf_bytes(
+        cv,
+        {},
+        base_dir=_REPO_ROOT,
+        template_id=tid,
+    )
+    return pdf_bytes
+
+
+def _decode_optional_pdf_base64(raw: str | None) -> bytes | None:
+    if not raw or not str(raw).strip():
+        return None
+    import base64
+
+    try:
+        data = base64.b64decode(str(raw).strip(), validate=False)
+    except Exception as err:
+        raise HTTPException(status_code=400, detail="pdf_base64 invalide") from err
+    if not data.startswith(b"%PDF"):
+        raise HTTPException(status_code=400, detail="pdf_base64 n'est pas un PDF")
+    return data
+
+
+def handle_verify_pdf(body: VerifyPdfBody) -> dict[str, Any]:
+    """Compare le score ATS JSON au score ajuste apres extraction du PDF reel.
+
+    Pipeline :
+
+    1. score JSON via ``score_parsing`` ;
+    2. PDF fourni (``pdf_base64``) ou genere depuis layout/template ;
+    3. metriques ground truth ;
+    4. score PDF = score JSON + penalites ground truth ;
+    5. diff de regles + blocs divergents.
+    """
+    layout = resolve_layout_for_scoring(body.layout, body.template_id)
+    cv = body.cv if isinstance(body.cv, dict) else {}
+    score_json = score_parsing(cv, layout)
+
+    pdf_bytes = _decode_optional_pdf_base64(body.pdf_base64)
+    if pdf_bytes is None:
+        try:
+            pdf_bytes = render_verify_pdf_bytes(cv, layout, body.template_id)
+        except HTTPException:
+            raise
+        except Exception as err:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Impossible de generer le PDF pour verify-pdf : {err}",
+            ) from err
+
+    gt = verify_parsing_quality(pdf_bytes, cv, layout=layout)
+    score_pdf = adjust_score_with_ground_truth(score_json, gt)
+    diff = rules_diff(score_json, score_pdf)
+    delta_total = int(score_pdf.total) - int(score_json.total)
+
+    return {
+        "score_json": score_result_to_dict(score_json),
+        "score_pdf": score_result_to_dict(score_pdf),
+        "delta_total": delta_total,
+        "within_threshold": abs(delta_total) <= VERIFY_PDF_SCORE_DELTA_THRESHOLD,
+        "threshold": VERIFY_PDF_SCORE_DELTA_THRESHOLD,
+        "rules_diff": diff,
+        "ground_truth": gt,
+        "block_ids_divergent": list(gt.get("block_ids_divergent") or []),
+    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -1714,7 +1714,9 @@ def api_render_html(request: Request, body: RenderHtmlBody):
 
 
 from backend.api_ats import ScoreParsingBody as _AtsScoreParsingBody
+from backend.api_ats import VerifyPdfBody as _AtsVerifyPdfBody
 from backend.api_ats import handle_score_parsing as _ats_handle_score_parsing
+from backend.api_ats import handle_verify_pdf as _ats_handle_verify_pdf
 
 
 @app.post("/api/ats/score-parsing")
@@ -1728,6 +1730,18 @@ def api_ats_score_parsing(request: Request, body: _AtsScoreParsingBody):
     user_id = _get_user_id(request)
     check_rate_limit(user_id, 60, scope="ats_score")
     return _ats_handle_score_parsing(body)
+
+
+@app.post("/api/ats/verify-pdf")
+def api_ats_verify_pdf(request: Request, body: _AtsVerifyPdfBody):
+    """Ground truth ATS : score JSON vs score apres extraction du PDF reel.
+
+    Genere le PDF (layout free-canvas ou template) sauf si ``pdf_base64`` est
+    fourni, puis compare les scores et retourne l'ecart / blocs divergents.
+    """
+    user_id = _get_user_id(request)
+    check_rate_limit(user_id, 20, scope="ats_verify_pdf")
+    return _ats_handle_verify_pdf(body)
 
 
 FREE_ADAPTATIONS_LIMIT = 3

--- a/backend/services/ats_parsing_check.py
+++ b/backend/services/ats_parsing_check.py
@@ -1,0 +1,488 @@
+"""Ground truth ATS : extraction PDF reel vs CV semantique attendu.
+
+Complete le Score Parsing JSON (``ats_score.score_parsing``) avec des
+metriques mesurables sur les octets PDF (pdfplumber + PyMuPDF). Voir
+``docs/editor-vision.md`` §9.4 et §10.2.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections.abc import Iterable
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from io import BytesIO
+from typing import Any
+
+from backend.services.ats_score.scoring import SCORE_MAX, SCORE_MIN
+from backend.services.ats_score.types import Rule, RuleSeverity, ScoreResult
+
+
+def _clamp_score(value: int) -> int:
+    if value < SCORE_MIN:
+        return SCORE_MIN
+    if value > SCORE_MAX:
+        return SCORE_MAX
+    return value
+
+
+# Seuils aligns sur la vision produit (§9.4 / §9.2.1).
+COVERAGE_WARN: float = 0.85
+COVERAGE_ERROR: float = 0.70
+SECTION_ORDER_WARN: float = 0.85
+PARSER_DISAGREE_WARN: float = 0.15
+RASTER_MAX_CHARS: int = 20
+
+DELTA_RASTER: int = -40
+DELTA_PARSER_DISAGREE: int = -5
+DELTA_COVERAGE_WARN: int = -8
+DELTA_COVERAGE_ERROR: int = -15
+DELTA_SECTION_ORDER: int = -10
+DELTA_CRITICAL_FIELD: int = -10
+
+
+@dataclass(frozen=True)
+class CriticalFieldHit:
+    """Presence d'un champ critique dans le texte extrait."""
+
+    field: str
+    expected: str
+    present: bool
+    block_ids: tuple[str, ...] = ()
+
+
+def extract_text_pdfplumber(pdf_bytes: bytes) -> str:
+    """Extrait le texte via pdfplumber (lecture type ATS simple)."""
+    import pdfplumber
+
+    pages: list[str] = []
+    with pdfplumber.open(BytesIO(pdf_bytes)) as pdf:
+        for page in pdf.pages:
+            text = page.extract_text()
+            if text:
+                pages.append(text)
+    return "\n\n".join(pages)
+
+
+def extract_text_pymupdf(pdf_bytes: bytes) -> str:
+    """Extrait le texte via PyMuPDF (second parser pour desaccord)."""
+    import fitz
+
+    doc = fitz.open(stream=pdf_bytes, filetype="pdf")
+    try:
+        parts = [page.get_text() or "" for page in doc]
+    finally:
+        doc.close()
+    return "\n\n".join(p for p in parts if p.strip())
+
+
+def _normalize_text(value: str) -> str:
+    """Normalise pour comparaisons (casse, accents, espaces)."""
+    if not value:
+        return ""
+    folded = unicodedata.normalize("NFKD", value)
+    ascii_ish = "".join(ch for ch in folded if not unicodedata.combining(ch))
+    ascii_ish = ascii_ish.lower()
+    ascii_ish = re.sub(r"[^\w\s@.+-]", " ", ascii_ish, flags=re.UNICODE)
+    return re.sub(r"\s+", " ", ascii_ish).strip()
+
+
+def _tokens(value: str) -> list[str]:
+    norm = _normalize_text(value)
+    return [t for t in norm.split(" ") if t]
+
+
+def linearize_cv(cv: dict[str, Any] | None) -> str:
+    """Produit une lecture lineaire attendue du CV (ordre ATS classique)."""
+    cv = cv if isinstance(cv, dict) else {}
+    chunks: list[str] = []
+
+    name = " ".join(
+        str(cv.get(k) or "").strip() for k in ("prenom", "nom") if str(cv.get(k) or "").strip()
+    )
+    if name:
+        chunks.append(name)
+    for key in ("titre_professionnel", "email", "telephone", "ville", "linkedin", "resume"):
+        val = str(cv.get(key) or "").strip()
+        if val:
+            chunks.append(val)
+
+    for exp in cv.get("experiences") or []:
+        if not isinstance(exp, dict):
+            continue
+        for key in ("poste", "entreprise", "date_debut", "date_fin"):
+            val = str(exp.get(key) or "").strip()
+            if val:
+                chunks.append(val)
+        for bullet in exp.get("bullet_points") or []:
+            b = str(bullet or "").strip()
+            if b:
+                chunks.append(b)
+
+    for form in cv.get("formations") or []:
+        if not isinstance(form, dict):
+            continue
+        for key in ("diplome", "etablissement", "date"):
+            val = str(form.get(key) or "").strip()
+            if val:
+                chunks.append(val)
+
+    comps = cv.get("competences") if isinstance(cv.get("competences"), dict) else {}
+    for key in ("techniques", "logiciels", "autres"):
+        for item in comps.get(key) or []:
+            val = str(item or "").strip()
+            if val:
+                chunks.append(val)
+    for lang in comps.get("langues") or []:
+        if isinstance(lang, dict):
+            label = " ".join(
+                str(lang.get(k) or "").strip() for k in ("langue", "niveau") if lang.get(k)
+            )
+            if label:
+                chunks.append(label)
+        else:
+            val = str(lang or "").strip()
+            if val:
+                chunks.append(val)
+
+    return "\n".join(chunks)
+
+
+def _coverage_ratio(extracted: str, expected_linear: str) -> float:
+    expected_tokens = _tokens(expected_linear)
+    if not expected_tokens:
+        return 1.0
+    hay = set(_tokens(extracted))
+    hits = sum(1 for tok in expected_tokens if tok in hay)
+    return hits / len(expected_tokens)
+
+
+def _lcs_ratio(extracted: str, expected_linear: str) -> float:
+    a = _tokens(extracted)
+    b = _tokens(expected_linear)
+    if not b:
+        return 1.0
+    if not a:
+        return 0.0
+    return SequenceMatcher(None, a, b).ratio()
+
+
+def _normalized_diff(left: str, right: str) -> float:
+    a = _normalize_text(left)
+    b = _normalize_text(right)
+    if not a and not b:
+        return 0.0
+    return 1.0 - SequenceMatcher(None, a, b).ratio()
+
+
+def _count_bullets(text: str) -> int:
+    if not text:
+        return 0
+    count = 0
+    for line in text.splitlines():
+        s = line.strip()
+        if re.match(r"^([•\-\*]|\d+[.)])\s+\S", s):
+            count += 1
+    return count
+
+
+def _count_expected_bullets(cv: dict[str, Any] | None) -> int:
+    cv = cv if isinstance(cv, dict) else {}
+    total = 0
+    for exp in cv.get("experiences") or []:
+        if isinstance(exp, dict):
+            total += sum(1 for b in (exp.get("bullet_points") or []) if str(b or "").strip())
+    return total
+
+
+def _field_block_ids(layout: dict[str, Any] | None, field: str) -> tuple[str, ...]:
+    """Associe un champ CV aux block_ids du layout free-canvas si possible."""
+    if not isinstance(layout, dict):
+        return ()
+    identity_fields = {"prenom", "nom", "titre_professionnel"}
+    found: list[str] = []
+    for page in layout.get("pages") or []:
+        if not isinstance(page, dict):
+            continue
+        for block in page.get("blocks") or []:
+            if not isinstance(block, dict):
+                continue
+            bid = str(block.get("id") or "").strip()
+            if not bid:
+                continue
+            binding = block.get("bind")
+            binds: list[str] = []
+            if isinstance(binding, str):
+                binds = [binding]
+            elif isinstance(binding, list):
+                binds = [str(x) for x in binding]
+            btype = str(block.get("type") or "")
+            if (
+                field in binds
+                or field in identity_fields
+                and btype == "identity"
+                or field in {"email", "telephone", "linkedin", "ville"}
+                and btype == "contact"
+            ):
+                found.append(bid)
+    seen: set[str] = set()
+    out: list[str] = []
+    for bid in found:
+        if bid not in seen:
+            seen.add(bid)
+            out.append(bid)
+    return tuple(out)
+
+
+def _critical_field_hits(
+    extracted: str,
+    cv: dict[str, Any] | None,
+    layout: dict[str, Any] | None = None,
+) -> list[CriticalFieldHit]:
+    cv = cv if isinstance(cv, dict) else {}
+    hay = _normalize_text(extracted)
+    hits: list[CriticalFieldHit] = []
+
+    name_parts = [str(cv.get(k) or "").strip() for k in ("prenom", "nom")]
+    name = " ".join(p for p in name_parts if p)
+    if name:
+        present = _normalize_text(name) in hay or all(
+            _normalize_text(p) in hay for p in name_parts if p
+        )
+        hits.append(
+            CriticalFieldHit(
+                field="name",
+                expected=name,
+                present=present,
+                block_ids=_field_block_ids(layout, "prenom")
+                or _field_block_ids(layout, "nom")
+                or _field_block_ids(layout, "titre_professionnel"),
+            )
+        )
+
+    for field in ("email", "telephone"):
+        expected = str(cv.get(field) or "").strip()
+        if not expected:
+            continue
+        needle = _normalize_text(expected)
+        present = bool(needle) and needle in hay
+        if field == "telephone" and not present:
+            digits_exp = re.sub(r"\D", "", expected)
+            digits_hay = re.sub(r"\D", "", extracted)
+            present = bool(digits_exp) and digits_exp in digits_hay
+        hits.append(
+            CriticalFieldHit(
+                field=field,
+                expected=expected,
+                present=present,
+                block_ids=_field_block_ids(layout, field),
+            )
+        )
+    return hits
+
+
+def verify_parsing_quality(
+    pdf_bytes: bytes,
+    expected_cv: dict[str, Any] | None,
+    *,
+    layout: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Parse le PDF avec deux extracteurs et compare au CV attendu."""
+    expected_cv = expected_cv if isinstance(expected_cv, dict) else {}
+    text_plumber = extract_text_pdfplumber(pdf_bytes)
+    try:
+        text_pymupdf = extract_text_pymupdf(pdf_bytes)
+    except Exception:
+        text_pymupdf = ""
+
+    expected_linear = linearize_cv(expected_cv)
+    coverage = _coverage_ratio(text_plumber, expected_linear)
+    section_order = _lcs_ratio(text_plumber, expected_linear)
+    disagreement = _normalized_diff(text_plumber, text_pymupdf)
+    bullets_ok = _count_bullets(text_plumber) == _count_expected_bullets(expected_cv)
+    critical = _critical_field_hits(text_plumber, expected_cv, layout)
+    all_critical = all(h.present for h in critical) if critical else True
+    raster = (
+        len(_normalize_text(text_plumber)) <= RASTER_MAX_CHARS
+        and len(_normalize_text(text_pymupdf)) <= RASTER_MAX_CHARS
+    )
+
+    missing = [h.field for h in critical if not h.present]
+    divergent_blocks: list[str] = []
+    for hit in critical:
+        if not hit.present:
+            divergent_blocks.extend(hit.block_ids)
+
+    preview = text_plumber.strip()
+    if len(preview) > 500:
+        preview = preview[:500] + "…"
+
+    return {
+        "all_critical_fields_present": all_critical,
+        "critical_fields": [
+            {
+                "field": h.field,
+                "expected": h.expected,
+                "present": h.present,
+                "block_ids": list(h.block_ids),
+            }
+            for h in critical
+        ],
+        "missing_critical_fields": missing,
+        "section_order_correct": round(section_order, 4),
+        "bullets_parsed_as_list": bullets_ok,
+        "no_text_loss_coverage": round(coverage, 4),
+        "parser_disagreement": round(disagreement, 4),
+        "likely_raster_pdf": raster,
+        "block_ids_divergent": list(dict.fromkeys(divergent_blocks)),
+        "text_preview": preview,
+        "text_chars_pdfplumber": len(text_plumber),
+        "text_chars_pymupdf": len(text_pymupdf),
+    }
+
+
+def adjust_score_with_ground_truth(
+    score: ScoreResult,
+    gt: dict[str, Any] | None,
+) -> ScoreResult:
+    """Applique les penalites ground-truth au score JSON (nouvelles regles)."""
+    gt = gt if isinstance(gt, dict) else {}
+    extra: list[Rule] = []
+
+    if gt.get("likely_raster_pdf"):
+        extra.append(
+            Rule(
+                id="gt_raster_pdf",
+                label="PDF probablement rasterise (peu ou pas de texte extractible)",
+                delta=DELTA_RASTER,
+                severity=RuleSeverity.ERROR,
+                advice="Exporter du texte selectionnable, pas une image plate.",
+            )
+        )
+
+    disagreement = float(gt.get("parser_disagreement") or 0.0)
+    if disagreement > PARSER_DISAGREE_WARN:
+        extra.append(
+            Rule(
+                id="gt_parser_disagreement",
+                label="Desaccord entre extracteurs PDF (design ambigu)",
+                delta=DELTA_PARSER_DISAGREE,
+                severity=RuleSeverity.WARNING,
+                advice="Simplifier colonnes / formes qui brouillent la lecture machine.",
+            )
+        )
+
+    coverage = float(gt.get("no_text_loss_coverage") or 1.0)
+    if coverage < COVERAGE_ERROR:
+        extra.append(
+            Rule(
+                id="gt_text_loss",
+                label="Perte de texte importante a l'extraction PDF",
+                delta=DELTA_COVERAGE_ERROR,
+                severity=RuleSeverity.ERROR,
+                block_ids=tuple(gt.get("block_ids_divergent") or ()),
+                advice="Verifier que le contenu critique apparait bien dans le PDF.",
+            )
+        )
+    elif coverage < COVERAGE_WARN:
+        extra.append(
+            Rule(
+                id="gt_text_loss",
+                label="Perte de texte partielle a l'extraction PDF",
+                delta=DELTA_COVERAGE_WARN,
+                severity=RuleSeverity.WARNING,
+                block_ids=tuple(gt.get("block_ids_divergent") or ()),
+                advice="Certains mots du CV ne sont pas retrouves dans le PDF.",
+            )
+        )
+
+    section_order = float(gt.get("section_order_correct") or 1.0)
+    if section_order < SECTION_ORDER_WARN:
+        extra.append(
+            Rule(
+                id="gt_section_order",
+                label="Ordre de lecture PDF eloigne de l'ordre semantique",
+                delta=DELTA_SECTION_ORDER,
+                severity=RuleSeverity.WARNING,
+                advice="Eviter les colonnes / empilements qui melangent l'ordre ATS.",
+            )
+        )
+
+    missing = gt.get("missing_critical_fields") or []
+    if isinstance(missing, list) and missing:
+        block_ids = tuple(gt.get("block_ids_divergent") or ())
+        extra.append(
+            Rule(
+                id="gt_critical_fields_missing",
+                label=f"Champs critiques absents du PDF : {', '.join(missing)}",
+                delta=DELTA_CRITICAL_FIELD * len(missing),
+                severity=RuleSeverity.ERROR,
+                block_ids=block_ids,
+                advice="Nom, email et telephone doivent etre extractibles.",
+            )
+        )
+
+    if not extra:
+        return score
+
+    rules = (*score.rules, *extra)
+    total = _clamp_score(score.total + sum(r.delta for r in extra))
+    return ScoreResult(
+        kind=score.kind,
+        total=total,
+        version=score.version,
+        rules=rules,
+    )
+
+
+def rules_diff(
+    score_json: ScoreResult,
+    score_pdf: ScoreResult,
+) -> dict[str, Any]:
+    """Compare les regles JSON vs PDF (ids manquants / deltas changes)."""
+    left = {r.id: r for r in score_json.rules}
+    right = {r.id: r for r in score_pdf.rules}
+    only_json = sorted(set(left) - set(right))
+    only_pdf = sorted(set(right) - set(left))
+    changed = sorted(
+        rid
+        for rid in set(left) & set(right)
+        if left[rid].delta != right[rid].delta or left[rid].label != right[rid].label
+    )
+    return {
+        "only_json": only_json,
+        "only_pdf": only_pdf,
+        "changed": changed,
+    }
+
+
+def expected_text_chunks(cv: dict[str, Any] | None, *, limit: int = 12) -> list[str]:
+    """Morceaux de texte stables pour les snapshots PDF de non-regression."""
+    linear = linearize_cv(cv)
+    chunks: list[str] = []
+    for line in linear.splitlines():
+        s = line.strip()
+        if len(s) < 3:
+            continue
+        chunks.append(s)
+        if len(chunks) >= limit:
+            break
+    return chunks
+
+
+def assert_chunks_in_text(extracted: str, chunks: Iterable[str]) -> list[str]:
+    """Retourne la liste des chunks absents (vide = OK)."""
+    import html as html_lib
+
+    plain = html_lib.unescape(extracted or "")
+    hay = _normalize_text(plain)
+    missing: list[str] = []
+    for chunk in chunks:
+        if _normalize_text(chunk) not in hay:
+            # telephone : comparer aussi les chiffres seuls
+            digits = re.sub(r"\D", "", chunk)
+            if digits and len(digits) >= 8 and digits in re.sub(r"\D", "", plain):
+                continue
+            missing.append(chunk)
+    return missing

--- a/tests/test_api_ats_verify_pdf.py
+++ b/tests/test_api_ats_verify_pdf.py
@@ -1,0 +1,182 @@
+"""Contrat du handler ``handle_verify_pdf`` (AXE-39)."""
+
+from __future__ import annotations
+
+import base64
+import json
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastapi import HTTPException
+
+from backend import main
+from backend.api_ats import VerifyPdfBody, handle_verify_pdf
+
+
+def _text_pdf(text: str) -> bytes:
+    import fitz
+
+    doc = fitz.open()
+    page = doc.new_page(width=595, height=842)
+    page.insert_text((40, 72), text, fontsize=11)
+    out = doc.tobytes()
+    doc.close()
+    return out
+
+
+def _starter_layout() -> dict:
+    return {
+        "version": 3,
+        "theme": {"color_accent": "#1e3a5f"},
+        "pages": [
+            {
+                "id": "p1",
+                "blocks": [
+                    {
+                        "id": "b-identity",
+                        "type": "identity",
+                        "bind": ["prenom", "nom", "titre_professionnel"],
+                        "x": 10,
+                        "y": 10,
+                        "w": 190,
+                        "h": 22,
+                        "z": 1,
+                    },
+                    {
+                        "id": "b-contact",
+                        "type": "contact",
+                        "x": 10,
+                        "y": 35,
+                        "w": 190,
+                        "h": 14,
+                        "z": 1,
+                    },
+                    {
+                        "id": "b-resume",
+                        "type": "resume",
+                        "bind": "resume",
+                        "x": 10,
+                        "y": 52,
+                        "w": 190,
+                        "h": 24,
+                        "z": 1,
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def _cv() -> dict:
+    path = Path(__file__).resolve().parent / "fixtures" / "ats_score" / "cv_standard.json"
+    cv = json.loads(path.read_text(encoding="utf-8"))
+    cv["photo_url"] = ""
+    return cv
+
+
+class _FakeRequest:
+    def __init__(self) -> None:
+        self.headers = {}
+        self.state = SimpleNamespace()
+
+
+class TestHandleVerifyPdf(unittest.TestCase):
+    def test_pdf_base64_returns_scores_and_delta(self):
+        cv = _cv()
+        text = (
+            f"{cv['prenom']} {cv['nom']}\n{cv['titre_professionnel']}\n"
+            f"{cv['email']}\n{cv['telephone']}\n{cv['resume']}"
+        )
+        body = VerifyPdfBody(
+            cv=cv,
+            layout=_starter_layout(),
+            pdf_base64=base64.b64encode(_text_pdf(text)).decode("ascii"),
+        )
+        payload = handle_verify_pdf(body)
+        self.assertIn("score_json", payload)
+        self.assertIn("score_pdf", payload)
+        self.assertIn("delta_total", payload)
+        self.assertIn("rules_diff", payload)
+        self.assertIn("ground_truth", payload)
+        self.assertIn("block_ids_divergent", payload)
+        self.assertEqual(payload["score_json"]["kind"], "parsing")
+        self.assertTrue(payload["within_threshold"])
+        self.assertTrue(payload["ground_truth"]["all_critical_fields_present"])
+
+    def test_raster_pdf_lowers_score_pdf(self):
+        import fitz
+
+        doc = fitz.open()
+        doc.new_page()
+        blank = doc.tobytes()
+        doc.close()
+        body = VerifyPdfBody(
+            cv=_cv(),
+            layout=_starter_layout(),
+            pdf_base64=base64.b64encode(blank).decode("ascii"),
+        )
+        payload = handle_verify_pdf(body)
+        self.assertLess(payload["score_pdf"]["total"], payload["score_json"]["total"])
+        self.assertLess(payload["delta_total"], 0)
+        self.assertIn("gt_raster_pdf", payload["rules_diff"]["only_pdf"])
+
+    def test_invalid_pdf_base64_raises_400(self):
+        body = VerifyPdfBody(layout=_starter_layout(), pdf_base64="not-a-pdf")
+        with self.assertRaises(HTTPException) as ctx:
+            handle_verify_pdf(body)
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_requires_layout_or_template(self):
+        with self.assertRaises(HTTPException) as ctx:
+            handle_verify_pdf(VerifyPdfBody())
+        self.assertEqual(ctx.exception.status_code, 400)
+
+
+class TestHandleVerifyPdfGenerate(unittest.TestCase):
+    def test_generates_pdf_from_free_canvas_layout(self):
+        try:
+            import weasyprint  # noqa: F401
+        except ImportError:
+            self.skipTest("WeasyPrint indisponible")
+        body = VerifyPdfBody(cv=_cv(), layout=_starter_layout())
+        payload = handle_verify_pdf(body)
+        self.assertTrue(payload["within_threshold"])
+        self.assertGreater(payload["ground_truth"]["text_chars_pdfplumber"], 20)
+        self.assertTrue(payload["ground_truth"]["all_critical_fields_present"])
+
+
+class TestTemplateDirIsolation(unittest.TestCase):
+    def test_layout_without_pages_requires_template_id(self):
+        body = VerifyPdfBody(
+            cv=_cv(),
+            layout={"grid": "single-or-sidebar", "sidebar_ratio": 0.0},
+        )
+        with self.assertRaises(HTTPException) as ctx:
+            handle_verify_pdf(body)
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("template_id", ctx.exception.detail)
+
+
+class TestRouteVerifyPdf(unittest.TestCase):
+    def test_route_wires_rate_limit_and_payload(self):
+        cv = _cv()
+        text = f"{cv['prenom']} {cv['nom']}\n{cv['email']}\n{cv['telephone']}"
+        body = VerifyPdfBody(
+            cv=cv,
+            layout=_starter_layout(),
+            pdf_base64=base64.b64encode(_text_pdf(text)).decode("ascii"),
+        )
+        with (
+            patch.object(main, "_get_user_id", return_value="user_verify"),
+            patch.object(main, "check_rate_limit") as rl_mock,
+        ):
+            payload = main.api_ats_verify_pdf(_FakeRequest(), body)
+        rl_mock.assert_called_once_with("user_verify", 20, scope="ats_verify_pdf")
+        self.assertIn("score_json", payload)
+        self.assertIn("delta_total", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ats_parsing_check.py
+++ b/tests/test_ats_parsing_check.py
@@ -1,0 +1,190 @@
+"""Tests ground truth ``ats_parsing_check`` (AXE-39)."""
+
+from __future__ import annotations
+
+import unittest
+
+from backend.services.ats_parsing_check import (
+    DELTA_RASTER,
+    adjust_score_with_ground_truth,
+    assert_chunks_in_text,
+    expected_text_chunks,
+    extract_text_pdfplumber,
+    linearize_cv,
+    rules_diff,
+    verify_parsing_quality,
+)
+from backend.services.ats_score.types import Rule, RuleSeverity, ScoreResult
+from backend.services.ats_score.version import SCORING_VERSION
+
+
+def _make_text_pdf(text: str) -> bytes:
+    import fitz
+
+    doc = fitz.open()
+    page = doc.new_page(width=595, height=842)
+    page.insert_text((40, 72), text, fontsize=11)
+    pdf_bytes = doc.tobytes()
+    doc.close()
+    return pdf_bytes
+
+
+def _make_blank_pdf() -> bytes:
+    import fitz
+
+    doc = fitz.open()
+    doc.new_page(width=595, height=842)
+    pdf_bytes = doc.tobytes()
+    doc.close()
+    return pdf_bytes
+
+
+def _sample_cv() -> dict:
+    return {
+        "prenom": "Alice",
+        "nom": "Martin",
+        "email": "alice.martin@example.fr",
+        "telephone": "+33 6 12 34 56 78",
+        "titre_professionnel": "Data Analyst",
+        "resume": "Analyste business confirmee.",
+        "experiences": [
+            {
+                "poste": "Data Analyst",
+                "entreprise": "Acme",
+                "date_debut": "01/2022",
+                "date_fin": "Aujourd'hui",
+                "bullet_points": ["Migration Tableau."],
+            }
+        ],
+    }
+
+
+class TestLinearizeAndChunks(unittest.TestCase):
+    def test_linearize_includes_identity_and_bullets(self):
+        linear = linearize_cv(_sample_cv())
+        self.assertIn("Alice Martin", linear)
+        self.assertIn("alice.martin@example.fr", linear)
+        self.assertIn("Migration Tableau.", linear)
+
+    def test_expected_chunks_subset(self):
+        chunks = expected_text_chunks(_sample_cv(), limit=5)
+        self.assertGreaterEqual(len(chunks), 3)
+        self.assertTrue(any("Alice" in c for c in chunks))
+
+
+class TestVerifyParsingQuality(unittest.TestCase):
+    def test_good_pdf_has_critical_fields_and_coverage(self):
+        cv = _sample_cv()
+        text = "\n".join(
+            [
+                "Alice Martin",
+                "Data Analyst",
+                "alice.martin@example.fr",
+                "+33 6 12 34 56 78",
+                "Analyste business confirmee.",
+                "Data Analyst",
+                "Acme",
+                "01/2022",
+                "Aujourd'hui",
+                "• Migration Tableau.",
+            ]
+        )
+        pdf = _make_text_pdf(text)
+        layout = {
+            "pages": [
+                {
+                    "id": "p1",
+                    "blocks": [
+                        {"id": "b-identity", "type": "identity"},
+                        {"id": "b-contact", "type": "contact"},
+                    ],
+                }
+            ]
+        }
+        gt = verify_parsing_quality(pdf, cv, layout=layout)
+        self.assertTrue(gt["all_critical_fields_present"])
+        self.assertGreaterEqual(gt["no_text_loss_coverage"], 0.7)
+        self.assertFalse(gt["likely_raster_pdf"])
+        self.assertEqual(gt["block_ids_divergent"], [])
+
+    def test_raster_pdf_has_zero_coverage(self):
+        cv = _sample_cv()
+        gt = verify_parsing_quality(_make_blank_pdf(), cv)
+        self.assertTrue(gt["likely_raster_pdf"])
+        self.assertEqual(gt["no_text_loss_coverage"], 0.0)
+        self.assertFalse(gt["all_critical_fields_present"])
+        self.assertIn("name", gt["missing_critical_fields"])
+
+    def test_missing_email_maps_contact_block(self):
+        cv = _sample_cv()
+        pdf = _make_text_pdf("Alice Martin\nData Analyst\n+33 6 12 34 56 78")
+        layout = {
+            "pages": [
+                {
+                    "id": "p1",
+                    "blocks": [
+                        {"id": "b-identity", "type": "identity"},
+                        {"id": "b-contact", "type": "contact"},
+                    ],
+                }
+            ]
+        }
+        gt = verify_parsing_quality(pdf, cv, layout=layout)
+        self.assertIn("email", gt["missing_critical_fields"])
+        self.assertIn("b-contact", gt["block_ids_divergent"])
+
+
+class TestAdjustScore(unittest.TestCase):
+    def _base_score(self) -> ScoreResult:
+        return ScoreResult(
+            kind="parsing",
+            total=90,
+            version=SCORING_VERSION,
+            rules=(
+                Rule(
+                    id="bonus_mono_column",
+                    label="Mono-colonne",
+                    delta=10,
+                    severity=RuleSeverity.INFO,
+                ),
+            ),
+        )
+
+    def test_raster_applies_penalty(self):
+        gt = verify_parsing_quality(_make_blank_pdf(), _sample_cv())
+        adjusted = adjust_score_with_ground_truth(self._base_score(), gt)
+        self.assertTrue(any(r.id == "gt_raster_pdf" for r in adjusted.rules))
+        self.assertLess(adjusted.total, 90)
+        # Au minimum la penalite raster ; d'autres gt_* peuvent s'empiler.
+        self.assertLessEqual(adjusted.total, max(0, 90 + DELTA_RASTER))
+
+    def test_good_pdf_keeps_score(self):
+        cv = _sample_cv()
+        text = linearize_cv(cv) + "\n• Migration Tableau."
+        gt = verify_parsing_quality(_make_text_pdf(text), cv)
+        adjusted = adjust_score_with_ground_truth(self._base_score(), gt)
+        self.assertEqual(adjusted.total, 90)
+        self.assertFalse(any(r.id.startswith("gt_") for r in adjusted.rules))
+
+    def test_rules_diff_lists_only_pdf(self):
+        base = self._base_score()
+        gt = {"likely_raster_pdf": True, "parser_disagreement": 0.0, "no_text_loss_coverage": 1.0}
+        pdf_score = adjust_score_with_ground_truth(base, gt)
+        diff = rules_diff(base, pdf_score)
+        self.assertIn("gt_raster_pdf", diff["only_pdf"])
+        self.assertEqual(diff["only_json"], [])
+
+
+class TestExtractHelpers(unittest.TestCase):
+    def test_pdfplumber_roundtrip(self):
+        pdf = _make_text_pdf("Hello ATS world")
+        text = extract_text_pdfplumber(pdf)
+        self.assertIn("Hello ATS world", text)
+
+    def test_assert_chunks_in_text(self):
+        missing = assert_chunks_in_text("Alice Martin Data Analyst", ["Alice Martin", "Ghost"])
+        self.assertEqual(missing, ["Ghost"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pdf_layout_snapshot.py
+++ b/tests/test_pdf_layout_snapshot.py
@@ -1,0 +1,178 @@
+"""Snapshots HTML/PDF de non-regression (AXE-39).
+
+- HTML : le layout free-canvas contient les chunks attendus du CV.
+- PDF  : WeasyPrint + pdfplumber retrouvent les memes chunks.
+- Score : |score_pdf - score_json| reste sous le seuil produit.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from backend.api_ats import VERIFY_PDF_SCORE_DELTA_THRESHOLD, VerifyPdfBody, handle_verify_pdf
+from backend.services.ats_parsing_check import (
+    assert_chunks_in_text,
+    extract_text_pdfplumber,
+)
+from backend.services.ats_score import score_parsing
+from backend.services.ats_score.template_layout import template_meta_to_layout
+from backend.services.layout_renderer import render_html
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "ats_score"
+TEMPLATES_DIR = REPO_ROOT / "templates"
+TEMPLATE_IDS = ("minimal", "classic", "modern", "bold", "creative", "elegant", "executive")
+
+
+def _load_cv() -> dict:
+    cv = json.loads((FIXTURES_DIR / "cv_standard.json").read_text(encoding="utf-8"))
+    cv["photo_url"] = ""
+    return cv
+
+
+def _snapshot_chunks(cv: dict) -> list[str]:
+    """Chunks presentes dans le layout free-canvas de ce fichier (pas la ville seule)."""
+    return [
+        f"{cv['prenom']} {cv['nom']}",
+        cv["titre_professionnel"],
+        cv["email"],
+        cv["telephone"],
+        cv["resume"],
+        cv["experiences"][0]["entreprise"],
+        cv["experiences"][0]["poste"],
+    ]
+
+
+def _free_canvas_layout() -> dict:
+    """Layout mono-colonne libre couvrant identite / contact / resume / xp."""
+    return {
+        "version": 3,
+        "theme": {
+            "color_accent": "#1e3a5f",
+            "font_heading": "Inter",
+            "font_body": "Inter",
+            "show_photo": False,
+        },
+        "pages": [
+            {
+                "id": "p1",
+                "blocks": [
+                    {
+                        "id": "b-identity",
+                        "type": "identity",
+                        "bind": ["prenom", "nom", "titre_professionnel"],
+                        "x": 10,
+                        "y": 10,
+                        "w": 190,
+                        "h": 22,
+                        "z": 1,
+                    },
+                    {
+                        "id": "b-contact",
+                        "type": "contact",
+                        "x": 10,
+                        "y": 34,
+                        "w": 190,
+                        "h": 12,
+                        "z": 1,
+                    },
+                    {
+                        "id": "b-resume",
+                        "type": "resume",
+                        "bind": "resume",
+                        "x": 10,
+                        "y": 50,
+                        "w": 190,
+                        "h": 22,
+                        "z": 1,
+                    },
+                    {
+                        "id": "b-xp",
+                        "type": "experiences",
+                        "x": 10,
+                        "y": 76,
+                        "w": 190,
+                        "h": 80,
+                        "z": 1,
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def _weasyprint_available() -> bool:
+    try:
+        import weasyprint  # noqa: F401
+
+        from backend.services.generator import generer_pdf_bytes_from_html
+
+        html = "<html><body><p>ping</p></body></html>"
+        generer_pdf_bytes_from_html(html, REPO_ROOT, {}, {})
+        return True
+    except Exception:
+        return False
+
+
+class TestHtmlLayoutSnapshot(unittest.TestCase):
+    def test_free_canvas_html_contains_expected_chunks(self):
+        cv = _load_cv()
+        layout = _free_canvas_layout()
+        html = render_html(cv, layout, for_preview=False)
+        missing = assert_chunks_in_text(html, _snapshot_chunks(cv))
+        self.assertEqual(missing, [], msg=f"Chunks absents du HTML : {missing}")
+
+
+class TestPdfLayoutSnapshot(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.weasy = _weasyprint_available()
+
+    def test_free_canvas_pdf_contains_expected_chunks(self):
+        if not self.weasy:
+            self.skipTest("WeasyPrint PDF indisponible dans cet environnement")
+        from backend.services.generator import generer_pdf_bytes_from_html
+
+        cv = _load_cv()
+        layout = _free_canvas_layout()
+        html = render_html(cv, layout, for_preview=False)
+        pdf_bytes, _ = generer_pdf_bytes_from_html(html, REPO_ROOT, cv, {})
+        extracted = extract_text_pdfplumber(pdf_bytes)
+        missing = assert_chunks_in_text(extracted, _snapshot_chunks(cv))
+        self.assertEqual(missing, [], msg=f"Chunks absents du PDF : {missing}")
+
+    def test_verify_pdf_delta_within_threshold_for_free_canvas(self):
+        if not self.weasy:
+            self.skipTest("WeasyPrint PDF indisponible dans cet environnement")
+        payload = handle_verify_pdf(VerifyPdfBody(cv=_load_cv(), layout=_free_canvas_layout()))
+        self.assertLessEqual(
+            abs(payload["delta_total"]),
+            VERIFY_PDF_SCORE_DELTA_THRESHOLD,
+            msg=f"delta_total={payload['delta_total']} gt={payload['ground_truth']}",
+        )
+        self.assertTrue(payload["within_threshold"])
+
+
+class TestTemplateScoreJsonStable(unittest.TestCase):
+    """Les templates livres restent scorables ; verify-pdf template demande un rendu HTML.
+
+    On ne force pas WeasyPrint sur les 7 templates ici (cout CI + deps systeme) :
+    on garde le contrat score JSON + un smoke verify-pdf sur free-canvas.
+    """
+
+    def test_template_meta_layouts_still_score(self):
+        cv = _load_cv()
+        for template_id in TEMPLATE_IDS:
+            meta = json.loads(
+                (TEMPLATES_DIR / template_id / "meta.json").read_text(encoding="utf-8")
+            )
+            layout = template_meta_to_layout(meta)
+            result = score_parsing(cv, layout)
+            self.assertGreaterEqual(result.total, 0)
+            self.assertLessEqual(result.total, 100)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Ajoute `POST /api/ats/verify-pdf` : génère (ou accepte) un PDF, extrait le texte (pdfplumber + PyMuPDF), compare le score JSON au score ajusté ground truth, retourne `delta_total`, `rules_diff` et `block_ids_divergent`.
- Nouveau module `backend/services/ats_parsing_check.py` (métriques coverage / ordre / champs critiques / raster).
- Tests non-régression HTML/PDF + CI WeasyPrint system libs (`Fixes AXE-39`, `Closes #76`).

## Test plan
- [x] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks`
- [ ] Vérifier CI verte (backend + frontend)
- [ ] Appeler `POST /api/ats/verify-pdf` avec un layout free-canvas et un CV standard → `within_threshold: true`
- [ ] Passer un PDF blank en `pdf_base64` → `gt_raster_pdf` et `delta_total < 0`


Made with [Cursor](https://cursor.com)