### PR TITLE
feat(import): 3 variantes layout à l'import (AXE-324)

### DIFF
--- a/docs/axe-41-import-pipeline-spike.md
+++ b/docs/axe-41-import-pipeline-spike.md
@@ -120,7 +120,7 @@ Créés sous le projet Éditeur / milestone P4, parent [AXE-41](https://linear.a
 
 | Ticket | Titre | Priorité |
 |--------|-------|----------|
-| [AXE-324](https://linear.app/axel-project/issue/AXE-324) | Feat: Générer 3 variantes layout à l'import (ATS-safe / structurel / mix) | High |
+| [AXE-324](https://linear.app/axel-project/issue/AXE-324) | Feat: Générer 3 variantes layout à l'import (ATS-safe / structurel / mix) | High — service FE `frontend/src/lib/importLayoutVariants.js` |
 | [AXE-325](https://linear.app/axel-project/issue/AXE-325) | Feat: Scorer les 3 sorties d'import (`ats_score` + delta) | High |
 | [AXE-326](https://linear.app/axel-project/issue/AXE-326) | Feat: UI chooser import Beta (preview + score + confirmation) | High |
 | [AXE-327](https://linear.app/axel-project/issue/AXE-327) | Improve: Durcir Word (tables/runs) + refus `.doc` explicite | Medium |

--- a/frontend/src/lib/importLayoutVariants.js
+++ b/frontend/src/lib/importLayoutVariants.js
@@ -14,8 +14,6 @@ import { applyAtsLayoutOptimizations } from './atsLayoutOptimize.js';
 import {
   buildAdaptedCanvasLayoutForCv,
   buildFullCanvasImportLayout,
-  buildStructuralImportLayout,
-  isStructuralLayout,
 } from './canvasCvImportAdapter.js';
 
 export const IMPORT_VARIANT_IDS = Object.freeze(['ats-safe', 'design', 'mix']);
@@ -37,18 +35,29 @@ function cloneLayout(layout) {
 }
 
 /**
- * Choisit le template ATS-safe (minimal / tags ats-safe|single-column).
+ * Choisit le template ATS-safe pour la variante import.
+ *
+ * Important : presque tous les templates livrés portent le tag `ats-safe`,
+ * donc on ne peut pas se fier au premier match par tag (sinon `bold` gagne
+ * alphabétiquement). Ordre :
+ *   1. id === `minimal`
+ *   2. single-column / no-sidebar (sans sidebar*)
+ *   3. stub minimal
+ *
  * @param {Array<object>} templatesList
  */
 export function pickAtsSafeTemplate(templatesList = []) {
   const list = Array.isArray(templatesList) ? templatesList : [];
-  const byTag = list.find(
-    (t) => Array.isArray(t?.tags)
-      && (t.tags.includes('ats-safe') || t.tags.includes('single-column')),
-  );
-  if (byTag) return byTag;
   const minimal = list.find((t) => t?.id === 'minimal');
   if (minimal) return minimal;
+
+  const singleColumn = list.find((t) => {
+    const tags = Array.isArray(t?.tags) ? t.tags : [];
+    if (tags.includes('sidebar') || tags.includes('sidebar-left')) return false;
+    return tags.includes('single-column') || tags.includes('no-sidebar');
+  });
+  if (singleColumn) return singleColumn;
+
   return { id: 'minimal', name: 'Minimal', tags: ['ats-safe', 'single-column', 'no-sidebar'] };
 }
 
@@ -103,23 +112,14 @@ export function buildImportLayoutVariants(cv, templatesList = [], options = {}) 
     visionMeta,
   });
 
-  let mixVariant;
-  if (isStructuralLayout(visionLayout)) {
-    const structural = buildStructuralImportLayout(cv, visionLayout, { templateId });
-    const mixLayout = applyAtsLayoutOptimizations(cloneLayout(structural.layout));
-    mixVariant = toVariant('mix', structural, {
-      layout: mixLayout,
-      importSource: 'mix',
-      blockCount: countBlocks(mixLayout),
-    });
-  } else {
-    const mixLayout = applyAtsLayoutOptimizations(cloneLayout(designResult.layout));
-    mixVariant = toVariant('mix', designResult, {
-      layout: mixLayout,
-      importSource: 'mix',
-      blockCount: countBlocks(mixLayout),
-    });
-  }
+  // Mix = clone du layout design (même source / hints), puis optimisations ATS.
+  // Évite de reconstruire un structurel sans layoutHints/visionMeta.
+  const mixLayout = applyAtsLayoutOptimizations(cloneLayout(designResult.layout));
+  const mixVariant = toVariant('mix', designResult, {
+    layout: mixLayout,
+    importSource: 'mix',
+    blockCount: countBlocks(mixLayout),
+  });
 
   return {
     variants: [

--- a/frontend/src/lib/importLayoutVariants.js
+++ b/frontend/src/lib/importLayoutVariants.js
@@ -15,6 +15,7 @@ import {
   buildAdaptedCanvasLayoutForCv,
   buildFullCanvasImportLayout,
 } from './canvasCvImportAdapter.js';
+import { applyLayoutPagination } from './layoutPagination.js';
 
 export const IMPORT_VARIANT_IDS = Object.freeze(['ats-safe', 'design', 'mix']);
 
@@ -112,9 +113,11 @@ export function buildImportLayoutVariants(cv, templatesList = [], options = {}) 
     visionMeta,
   });
 
-  // Mix = clone du layout design (même source / hints), puis optimisations ATS.
-  // Évite de reconstruire un structurel sans layoutHints/visionMeta.
-  const mixLayout = applyAtsLayoutOptimizations(cloneLayout(designResult.layout));
+  // Mix = clone du layout design (même source / hints), puis ATS + pagination.
+  // Le restack ATS empile avec un gap fixe et peut dépasser A4 ; sans spill
+  // les blocs clipperaient / se chevaucheraient au clamp UI.
+  let mixLayout = applyAtsLayoutOptimizations(cloneLayout(designResult.layout));
+  mixLayout = applyLayoutPagination(mixLayout);
   const mixVariant = toVariant('mix', designResult, {
     layout: mixLayout,
     importSource: 'mix',

--- a/frontend/src/lib/importLayoutVariants.js
+++ b/frontend/src/lib/importLayoutVariants.js
@@ -1,0 +1,134 @@
+/**
+ * AXE-324 — Trois variantes de layout à partir d'un import CV réussi.
+ *
+ * Entrée typique : réponse de POST /api/cv/import
+ *   `{ cv, layout_hints, layout (structurel), vision }`
+ *
+ * Sortie :
+ *   `{ variants: [{ id, label, layout, recommendedTemplateId, importSource, blockCount }] }`
+ *
+ * Pas d'UI (AXE-326) ni de scoring (AXE-325) ici.
+ */
+
+import { applyAtsLayoutOptimizations } from './atsLayoutOptimize.js';
+import {
+  buildAdaptedCanvasLayoutForCv,
+  buildFullCanvasImportLayout,
+  buildStructuralImportLayout,
+  isStructuralLayout,
+} from './canvasCvImportAdapter.js';
+
+export const IMPORT_VARIANT_IDS = Object.freeze(['ats-safe', 'design', 'mix']);
+
+export const IMPORT_VARIANT_LABELS = Object.freeze({
+  'ats-safe': 'ATS-safe',
+  design: 'Design proche',
+  mix: 'Mix design + ATS',
+});
+
+function countBlocks(layout) {
+  if (!layout?.pages?.length) return 0;
+  return layout.pages.reduce((n, page) => n + (page?.blocks?.length || 0), 0);
+}
+
+function cloneLayout(layout) {
+  if (!layout || typeof layout !== 'object') return layout;
+  return structuredClone(layout);
+}
+
+/**
+ * Choisit le template ATS-safe (minimal / tags ats-safe|single-column).
+ * @param {Array<object>} templatesList
+ */
+export function pickAtsSafeTemplate(templatesList = []) {
+  const list = Array.isArray(templatesList) ? templatesList : [];
+  const byTag = list.find(
+    (t) => Array.isArray(t?.tags)
+      && (t.tags.includes('ats-safe') || t.tags.includes('single-column')),
+  );
+  if (byTag) return byTag;
+  const minimal = list.find((t) => t?.id === 'minimal');
+  if (minimal) return minimal;
+  return { id: 'minimal', name: 'Minimal', tags: ['ats-safe', 'single-column', 'no-sidebar'] };
+}
+
+function toVariant(id, result, overrides = {}) {
+  const layout = overrides.layout ?? result?.layout ?? null;
+  return {
+    id,
+    label: IMPORT_VARIANT_LABELS[id] || id,
+    layout,
+    recommendedTemplateId:
+      overrides.recommendedTemplateId
+      ?? result?.recommendedTemplateId
+      ?? layout?.theme?.template_id
+      ?? '',
+    importSource: overrides.importSource ?? result?.importSource ?? 'preset',
+    blockCount: overrides.blockCount ?? result?.blockCount ?? countBlocks(layout),
+  };
+}
+
+/**
+ * Produit les 3 variantes layout pour un import.
+ *
+ * @param {object} cv
+ * @param {Array<object>} templatesList
+ * @param {object} [options]
+ * @param {string} [options.templateId]
+ * @param {object} [options.layoutHints]
+ * @param {object|null} [options.visionLayout] layout structurel ou vision (comme buildFullCanvasImportLayout)
+ * @param {object} [options.visionMeta]
+ */
+export function buildImportLayoutVariants(cv, templatesList = [], options = {}) {
+  const {
+    templateId = '',
+    layoutHints = {},
+    visionLayout = null,
+    visionMeta = {},
+  } = options;
+
+  const atsTemplate = pickAtsSafeTemplate(templatesList);
+  const atsSafeResult = buildAdaptedCanvasLayoutForCv(cv, atsTemplate, {
+    templatesList,
+    templateId: atsTemplate.id || 'minimal',
+    // Pas de hints vision : on force le chemin ATS-safe.
+    layoutHints: {},
+    forImport: true,
+  });
+
+  const designResult = buildFullCanvasImportLayout(cv, templatesList, {
+    templateId,
+    layoutHints,
+    visionLayout,
+    visionMeta,
+  });
+
+  let mixVariant;
+  if (isStructuralLayout(visionLayout)) {
+    const structural = buildStructuralImportLayout(cv, visionLayout, { templateId });
+    const mixLayout = applyAtsLayoutOptimizations(cloneLayout(structural.layout));
+    mixVariant = toVariant('mix', structural, {
+      layout: mixLayout,
+      importSource: 'mix',
+      blockCount: countBlocks(mixLayout),
+    });
+  } else {
+    const mixLayout = applyAtsLayoutOptimizations(cloneLayout(designResult.layout));
+    mixVariant = toVariant('mix', designResult, {
+      layout: mixLayout,
+      importSource: 'mix',
+      blockCount: countBlocks(mixLayout),
+    });
+  }
+
+  return {
+    variants: [
+      toVariant('ats-safe', atsSafeResult, {
+        recommendedTemplateId: atsTemplate.id || 'minimal',
+        importSource: 'ats-safe',
+      }),
+      toVariant('design', designResult),
+      mixVariant,
+    ],
+  };
+}

--- a/frontend/tests/unit/importLayoutVariants.test.js
+++ b/frontend/tests/unit/importLayoutVariants.test.js
@@ -7,6 +7,13 @@ import {
   pickAtsSafeTemplate,
 } from '../../src/lib/importLayoutVariants.js';
 import { isStructuralLayout } from '../../src/lib/canvasCvImportAdapter.js';
+import {
+  applyAtsLayoutOptimizations,
+} from '../../src/lib/atsLayoutOptimize.js';
+import {
+  applyLayoutPagination,
+  layoutHasPageOverflow,
+} from '../../src/lib/layoutPagination.js';
 
 const DENSE_CV = {
   prenom: 'Marie',
@@ -189,4 +196,34 @@ test('sans structurel : design tombe en preset, mix reste disponible', () => {
   assert.equal(design.importSource, 'preset');
   assert.equal(mix.importSource, 'mix');
   assert.ok(mix.layout?.pages?.length >= 1);
+});
+
+test('mix paginate après restack ATS (pas d overflow A4)', () => {
+  // Beaucoup de blocs texte hauts : le restack ATS dépasse 297 mm sans spill.
+  const denseBlocks = Array.from({ length: 12 }, (_, i) => ({
+    id: `t${i}`,
+    type: 'text',
+    content: `Bloc ${i}`,
+    x: 14,
+    y: 20 + i * 8,
+    w: 180,
+    h: 28,
+    z: 3,
+    style: { font_size: 10 },
+  }));
+  const tallStructural = {
+    ...STRUCTURAL_LAYOUT,
+    pages: [{ id: 'page_1', blocks: denseBlocks }],
+  };
+  const atsOnly = applyAtsLayoutOptimizations(structuredClone(tallStructural));
+  assert.equal(layoutHasPageOverflow(atsOnly), true);
+
+  const { variants } = buildImportLayoutVariants(DENSE_CV, TEMPLATES, {
+    visionLayout: tallStructural,
+  });
+  const mix = variants.find((v) => v.id === 'mix');
+  assert.equal(layoutHasPageOverflow(mix.layout), false);
+  assert.ok(mix.layout.pages.length >= 2);
+  // Contrôle : pagination seule suffit aussi (régression ordre ATS→paginate).
+  assert.equal(layoutHasPageOverflow(applyLayoutPagination(atsOnly)), false);
 });

--- a/frontend/tests/unit/importLayoutVariants.test.js
+++ b/frontend/tests/unit/importLayoutVariants.test.js
@@ -1,0 +1,172 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  IMPORT_VARIANT_IDS,
+  buildImportLayoutVariants,
+  pickAtsSafeTemplate,
+} from '../../src/lib/importLayoutVariants.js';
+import { isStructuralLayout } from '../../src/lib/canvasCvImportAdapter.js';
+
+const DENSE_CV = {
+  prenom: 'Marie',
+  nom: 'Martin',
+  titre_professionnel: 'Directrice Marketing',
+  email: 'marie@ex.com',
+  resume: 'Profil senior avec 12 ans d experience en growth et brand.',
+  experiences: [
+    { poste: 'Head of Growth', entreprise: 'ScaleUp', bullet_points: ['A', 'B', 'C'] },
+    { poste: 'CMO', entreprise: 'Agency', bullet_points: ['D'] },
+    { poste: 'Lead', entreprise: 'Corp', bullet_points: ['E', 'F'] },
+  ],
+  formations: [{ diplome: 'MBA', etablissement: 'HEC', date: '2015' }],
+  competences: {
+    techniques: ['SEO', 'SEA', 'Analytics'],
+    logiciels: ['HubSpot'],
+    langues: [{ langue: 'Anglais', niveau: 'C1' }],
+    autres: [],
+  },
+  certifications: [],
+  projets: [],
+};
+
+const TEMPLATES = [
+  { id: 'minimal', name: 'Minimal', tags: ['ats-safe', 'single-column', 'no-sidebar'] },
+  { id: 'classic', name: 'Classic', tags: ['sidebar', 'photo'] },
+  { id: 'executive', name: 'Executive', tags: ['sidebar'] },
+];
+
+const STRUCTURAL_LAYOUT = {
+  version: 3,
+  format: 'A4',
+  grid: 'free',
+  unit: 'mm',
+  source: 'pdf_structural',
+  pages: [
+    {
+      id: 'page_1',
+      blocks: [
+        {
+          id: 'sb',
+          type: 'shape:rect',
+          x: 0,
+          y: 0,
+          w: 63,
+          h: 297,
+          z: 0,
+          style: { color: '#1e3a5f' },
+        },
+        {
+          id: 't1',
+          type: 'text',
+          content: 'Marie Martin',
+          x: 14,
+          y: 21,
+          w: 80,
+          h: 8,
+          z: 3,
+          style: { font_size: 20, color: '#000000', bold: true },
+        },
+        {
+          id: 't2',
+          type: 'text',
+          content: 'Directrice Marketing',
+          x: 14,
+          y: 35,
+          w: 90,
+          h: 5,
+          z: 3,
+          style: { font_size: 11, color: '#333333' },
+        },
+        {
+          id: 't3',
+          type: 'text',
+          content: 'Experience',
+          x: 80,
+          y: 60,
+          w: 100,
+          h: 6,
+          z: 3,
+          style: { font_size: 12, bold: true },
+        },
+        {
+          id: 't4',
+          type: 'text',
+          content: 'Head of Growth — ScaleUp',
+          x: 80,
+          y: 90,
+          w: 110,
+          h: 5,
+          z: 3,
+          style: { font_size: 10 },
+        },
+      ],
+    },
+  ],
+  theme: { template_id: 'imported', color_body: '#1a1a1a' },
+};
+
+test('pickAtsSafeTemplate privilégie tags ats-safe / single-column', () => {
+  const picked = pickAtsSafeTemplate(TEMPLATES);
+  assert.equal(picked.id, 'minimal');
+});
+
+test('pickAtsSafeTemplate fallback minimal synthétique', () => {
+  const picked = pickAtsSafeTemplate([{ id: 'classic', tags: ['sidebar'] }]);
+  assert.equal(picked.id, 'minimal');
+  assert.ok(picked.tags.includes('ats-safe'));
+});
+
+test('buildImportLayoutVariants retourne les 3 ids attendus', () => {
+  const { variants } = buildImportLayoutVariants(DENSE_CV, TEMPLATES, {
+    visionLayout: STRUCTURAL_LAYOUT,
+  });
+  assert.deepEqual(variants.map((v) => v.id), [...IMPORT_VARIANT_IDS]);
+  for (const v of variants) {
+    assert.ok(v.label);
+    assert.ok(v.layout?.pages?.length >= 1);
+    assert.ok(v.blockCount > 0);
+  }
+});
+
+test('ats-safe force le template minimal', () => {
+  const { variants } = buildImportLayoutVariants(DENSE_CV, TEMPLATES, {
+    visionLayout: STRUCTURAL_LAYOUT,
+    layoutHints: { template_match: 'executive' },
+  });
+  const ats = variants.find((v) => v.id === 'ats-safe');
+  assert.equal(ats.recommendedTemplateId, 'minimal');
+  assert.equal(ats.importSource, 'ats-safe');
+});
+
+test('design privilégie le layout structurel', () => {
+  const { variants } = buildImportLayoutVariants(DENSE_CV, TEMPLATES, {
+    visionLayout: STRUCTURAL_LAYOUT,
+  });
+  const design = variants.find((v) => v.id === 'design');
+  assert.equal(design.importSource, 'structural');
+  assert.equal(isStructuralLayout(design.layout), true);
+});
+
+test('mix part du structurel et applique ATS (importSource mix)', () => {
+  const { variants } = buildImportLayoutVariants(DENSE_CV, TEMPLATES, {
+    visionLayout: STRUCTURAL_LAYOUT,
+  });
+  const design = variants.find((v) => v.id === 'design');
+  const mix = variants.find((v) => v.id === 'mix');
+  assert.equal(mix.importSource, 'mix');
+  assert.equal(mix.blockCount, design.blockCount);
+  // Les layouts restent indépendants (pas la même référence).
+  assert.notEqual(mix.layout, design.layout);
+});
+
+test('sans structurel : design tombe en preset, mix reste disponible', () => {
+  const { variants } = buildImportLayoutVariants(DENSE_CV, TEMPLATES, {
+    visionLayout: null,
+  });
+  const design = variants.find((v) => v.id === 'design');
+  const mix = variants.find((v) => v.id === 'mix');
+  assert.equal(design.importSource, 'preset');
+  assert.equal(mix.importSource, 'mix');
+  assert.ok(mix.layout?.pages?.length >= 1);
+});

--- a/frontend/tests/unit/importLayoutVariants.test.js
+++ b/frontend/tests/unit/importLayoutVariants.test.js
@@ -106,9 +106,29 @@ const STRUCTURAL_LAYOUT = {
   theme: { template_id: 'imported', color_body: '#1a1a1a' },
 };
 
-test('pickAtsSafeTemplate privilégie tags ats-safe / single-column', () => {
+test('pickAtsSafeTemplate privilégie id minimal', () => {
   const picked = pickAtsSafeTemplate(TEMPLATES);
   assert.equal(picked.id, 'minimal');
+});
+
+test('pickAtsSafeTemplate ignore le premier ats-safe alphabétique (bold)', () => {
+  // Tous les templates livrés portent `ats-safe` ; /api/templates liste
+  // alphabétiquement → bold en premier. On doit quand même forcer minimal.
+  const shippedLike = [
+    { id: 'bold', name: 'Bold', tags: ['ats-safe', 'sidebar', 'photo', 'bold'] },
+    { id: 'classic', name: 'Classic', tags: ['ats-safe', 'sidebar', 'photo'] },
+    { id: 'elegant', name: 'Elegant', tags: ['ats-safe', 'single-column', 'no-sidebar'] },
+    { id: 'minimal', name: 'Minimal', tags: ['ats-safe', 'single-column', 'no-sidebar', 'minimal'] },
+  ];
+  assert.equal(pickAtsSafeTemplate(shippedLike).id, 'minimal');
+});
+
+test('pickAtsSafeTemplate sans minimal : single-column / no-sidebar', () => {
+  const picked = pickAtsSafeTemplate([
+    { id: 'bold', tags: ['ats-safe', 'sidebar'] },
+    { id: 'elegant', tags: ['ats-safe', 'single-column', 'no-sidebar'] },
+  ]);
+  assert.equal(picked.id, 'elegant');
 });
 
 test('pickAtsSafeTemplate fallback minimal synthétique', () => {


### PR DESCRIPTION
## Summary
- Ajoute `frontend/src/lib/importLayoutVariants.js` : `buildImportLayoutVariants` → `{ variants: [ats-safe, design, mix] }`.
- ATS-safe force `minimal` / tags ats-safe ; design = chemin actuel (`buildFullCanvasImportLayout`) ; mix = structurel + `applyAtsLayoutOptimizations`.
- Tests unitaires (7) ; pas d'UI (AXE-326) ni scoring (AXE-325).
- `Fixes AXE-324` · `Closes #80`

## Test plan
- [x] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks`
- [x] `node --test frontend/tests/unit/importLayoutVariants.test.js`
- [ ] Smoke manuel : appeler `buildImportLayoutVariants` depuis la console après un import PDF structurel


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - Les imports de CV génèrent désormais trois variantes de mise en page : **compatible ATS**, **design** et **mixte**.
  - Chaque variante propose un modèle recommandé et conserve les informations issues de l’import.
  - La variante mixte combine une présentation structurée avec des optimisations destinées à faciliter la compatibilité ATS.

- **Améliorations**
  - Les mises en page générées restent indépendantes, permettant de les personnaliser séparément.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->