### PR TITLE
feat(import): scorer les 3 variantes (ats_score + delta) — AXE-325

### DIFF
--- a/backend/services/import_variant_scoring.py
+++ b/backend/services/import_variant_scoring.py
@@ -22,7 +22,7 @@ def attach_delta_vs_best(
     totals: list[int] = []
     for row in scored:
         total = row.get("score_json", {}).get("total")
-        totals.append(int(total) if isinstance(total, (int, float)) else 0)
+        totals.append(int(total) if isinstance(total, int | float) else 0)
     best = max(totals) if totals else 0
     out: list[dict[str, Any]] = []
     for row, total in zip(scored, totals, strict=True):

--- a/backend/services/import_variant_scoring.py
+++ b/backend/services/import_variant_scoring.py
@@ -1,0 +1,68 @@
+"""AXE-325 — Scorer plusieurs variantes layout d'import (score_parsing + delta).
+
+Service pur (pas de FastAPI) : utile pour les tests fixtures `import_samples`
+et un éventuel endpoint batch plus tard. Le chemin produit FE appelle
+``POST /api/ats/score-parsing`` en parallèle via ``scoreImportLayoutVariants.js``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from backend.services.ats_score.scoring import score_parsing
+from backend.services.ats_score.serialization import score_result_to_dict
+
+
+def attach_delta_vs_best(
+    scored: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Ajoute ``delta_vs_best`` (= total − meilleur). Le meilleur a 0."""
+    if not scored:
+        return []
+    totals: list[int] = []
+    for row in scored:
+        total = row.get("score_json", {}).get("total")
+        totals.append(int(total) if isinstance(total, (int, float)) else 0)
+    best = max(totals) if totals else 0
+    out: list[dict[str, Any]] = []
+    for row, total in zip(scored, totals, strict=True):
+        out.append({**row, "delta_vs_best": total - best})
+    return out
+
+
+def score_import_layout_variants(
+    cv: dict[str, Any] | None,
+    variants: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Score chaque variante ``{ id, layout }``.
+
+    Retour ::
+        {
+          "variants": [
+            { "id", "score_json", "delta_vs_best" },
+            ...
+          ],
+          "best_total": int,
+        }
+    """
+    profile = cv if isinstance(cv, dict) else {}
+    scored: list[dict[str, Any]] = []
+    for variant in variants:
+        if not isinstance(variant, dict):
+            raise ValueError("variant must be a dict")
+        vid = variant.get("id")
+        layout = variant.get("layout")
+        if not isinstance(vid, str) or not vid:
+            raise ValueError("variant.id required")
+        if not isinstance(layout, dict) or not layout:
+            raise ValueError(f"variant.layout required for {vid}")
+        result = score_parsing(profile, layout)
+        scored.append(
+            {
+                "id": vid,
+                "score_json": score_result_to_dict(result),
+            }
+        )
+    with_delta = attach_delta_vs_best(scored)
+    best_total = max((int(v["score_json"]["total"]) for v in with_delta), default=0)
+    return {"variants": with_delta, "best_total": best_total}

--- a/docs/axe-41-import-pipeline-spike.md
+++ b/docs/axe-41-import-pipeline-spike.md
@@ -121,7 +121,7 @@ Créés sous le projet Éditeur / milestone P4, parent [AXE-41](https://linear.a
 | Ticket | Titre | Priorité |
 |--------|-------|----------|
 | [AXE-324](https://linear.app/axel-project/issue/AXE-324) | Feat: Générer 3 variantes layout à l'import (ATS-safe / structurel / mix) | High — service FE `frontend/src/lib/importLayoutVariants.js` |
-| [AXE-325](https://linear.app/axel-project/issue/AXE-325) | Feat: Scorer les 3 sorties d'import (`ats_score` + delta) | High |
+| [AXE-325](https://linear.app/axel-project/issue/AXE-325) | Feat: Scorer les 3 sorties d'import (`ats_score` + delta) | High — FE `scoreImportLayoutVariants.js` + BE `import_variant_scoring.py` |
 | [AXE-326](https://linear.app/axel-project/issue/AXE-326) | Feat: UI chooser import Beta (preview + score + confirmation) | High |
 | [AXE-327](https://linear.app/axel-project/issue/AXE-327) | Improve: Durcir Word (tables/runs) + refus `.doc` explicite | Medium |
 | [AXE-328](https://linear.app/axel-project/issue/AXE-328) | Improve: Policy PDF scanné — message UX, pas d'OCR MVP | Medium |

--- a/frontend/src/lib/importLayoutVariants.js
+++ b/frontend/src/lib/importLayoutVariants.js
@@ -7,7 +7,7 @@
  * Sortie :
  *   `{ variants: [{ id, label, layout, recommendedTemplateId, importSource, blockCount }] }`
  *
- * Pas d'UI (AXE-326) ni de scoring (AXE-325) ici.
+ * Pas d'UI (AXE-326) ni de scoring inline — voir `scoreImportLayoutVariants.js` (AXE-325).
  */
 
 import { applyAtsLayoutOptimizations } from './atsLayoutOptimize.js';

--- a/frontend/src/lib/scoreImportLayoutVariants.js
+++ b/frontend/src/lib/scoreImportLayoutVariants.js
@@ -1,0 +1,133 @@
+/**
+ * AXE-325 — Scorer les 3 variantes d'import (score_parsing + delta_vs_best).
+ *
+ * Entrée : variantes produites par `buildImportLayoutVariants` (AXE-324).
+ * Sortie :
+ *   `{ variants: [{ id, label?, layout?, score_json, delta_vs_best, ... }] }`
+ *
+ * Le scoring reste API-only (`POST /api/ats/score-parsing`) via fetcher injectable.
+ * Pas d'UI (AXE-326). verify-pdf optionnel hors de ce module.
+ */
+
+import { fetchAtsScoreParsing } from './atsScoreClient.js';
+
+/**
+ * Reconstitue la shape API (`score_json`) depuis la réponse normalisée client.
+ * @param {{ score: number, version: string, kind: string, rules: Array }} normalized
+ */
+export function toScoreJson(normalized) {
+  if (!normalized || typeof normalized !== 'object') {
+    throw new Error('toScoreJson: normalized score required');
+  }
+  const rules = Array.isArray(normalized.rules) ? normalized.rules : [];
+  return {
+    kind: typeof normalized.kind === 'string' ? normalized.kind : 'parsing',
+    total: Number.isFinite(normalized.score) ? normalized.score : 0,
+    version: typeof normalized.version === 'string' ? normalized.version : '',
+    rules: rules.map((rule) => ({
+      id: rule.id,
+      label: rule.label,
+      delta: rule.delta,
+      severity: rule.severity,
+      block_ids: Array.isArray(rule.blockIds) ? [...rule.blockIds] : [],
+      advice: rule.advice || '',
+    })),
+  };
+}
+
+/**
+ * Attache `delta_vs_best` (score − meilleur total ; 0 pour le meilleur).
+ * @param {Array<{ id: string, score_json: { total: number } }>} scored
+ */
+export function attachDeltaVsBest(scored = []) {
+  const list = Array.isArray(scored) ? scored : [];
+  if (list.length === 0) return [];
+  const totals = list.map((v) => Number(v?.score_json?.total));
+  const finite = totals.filter((n) => Number.isFinite(n));
+  const best = finite.length ? Math.max(...finite) : 0;
+  return list.map((v, i) => {
+    const total = totals[i];
+    const delta = Number.isFinite(total) ? total - best : 0;
+    return { ...v, delta_vs_best: delta };
+  });
+}
+
+/**
+ * Règles présentes sur une variante mais pas sur la meilleure (ids).
+ * Utile pour expliquer le delta (AXE-326).
+ *
+ * @param {Array<{ id: string, score_json: { total: number, rules?: Array }, delta_vs_best: number }>} scoredWithDelta
+ */
+export function listDifferentialRuleIds(scoredWithDelta = []) {
+  const list = Array.isArray(scoredWithDelta) ? scoredWithDelta : [];
+  const best = list.find((v) => v?.delta_vs_best === 0) || list[0];
+  if (!best?.score_json) return {};
+  const bestIds = new Set(
+    (best.score_json.rules || []).map((r) => r?.id).filter(Boolean),
+  );
+  const out = {};
+  for (const v of list) {
+    if (!v?.id) continue;
+    const ids = (v.score_json?.rules || [])
+      .map((r) => r?.id)
+      .filter((id) => id && !bestIds.has(id));
+    out[v.id] = ids;
+  }
+  return out;
+}
+
+/**
+ * Score chaque variante en parallèle puis calcule `delta_vs_best`.
+ *
+ * @param {Array<{ id: string, layout?: object, label?: string, recommendedTemplateId?: string }>} variants
+ * @param {object} [cv]
+ * @param {object} [options]
+ * @param {(path: string, body: object) => Promise<object>} [options.fetcher]
+ * @param {boolean} [options.includeLayout=false] conserver layout dans la sortie
+ * @returns {Promise<{ variants: Array, best_total: number, differential_rule_ids: object }>}
+ */
+export async function scoreImportLayoutVariants(variants, cv = {}, options = {}) {
+  const list = Array.isArray(variants) ? variants : [];
+  if (list.length === 0) {
+    return { variants: [], best_total: 0, differential_rule_ids: {} };
+  }
+
+  const { fetcher, includeLayout = false } = options;
+
+  const scored = await Promise.all(
+    list.map(async (variant) => {
+      if (!variant?.id) {
+        throw new Error('scoreImportLayoutVariants: variant.id required');
+      }
+      if (!variant.layout || typeof variant.layout !== 'object') {
+        throw new Error(`scoreImportLayoutVariants: layout missing for ${variant.id}`);
+      }
+      const normalized = await fetchAtsScoreParsing(
+        { layout: variant.layout, cv },
+        fetcher ? { fetcher } : {},
+      );
+      const score_json = toScoreJson(normalized);
+      const row = {
+        id: variant.id,
+        label: variant.label || variant.id,
+        recommendedTemplateId: variant.recommendedTemplateId || '',
+        importSource: variant.importSource || '',
+        blockCount: variant.blockCount ?? 0,
+        score_json,
+      };
+      if (includeLayout) row.layout = variant.layout;
+      return row;
+    }),
+  );
+
+  const withDelta = attachDeltaVsBest(scored);
+  const best_total = withDelta.length
+    ? Math.max(...withDelta.map((v) => Number(v.score_json?.total) || 0))
+    : 0;
+
+  return {
+    variants: withDelta,
+    best_total,
+    differential_rule_ids: listDifferentialRuleIds(withDelta),
+  };
+}

--- a/frontend/tests/unit/scoreImportLayoutVariants.test.js
+++ b/frontend/tests/unit/scoreImportLayoutVariants.test.js
@@ -1,0 +1,169 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  attachDeltaVsBest,
+  listDifferentialRuleIds,
+  scoreImportLayoutVariants,
+  toScoreJson,
+} from '../../src/lib/scoreImportLayoutVariants.js';
+import { buildImportLayoutVariants } from '../../src/lib/importLayoutVariants.js';
+import { ATS_SCORE_PARSING_ENDPOINT } from '../../src/lib/atsScoreClient.js';
+
+const CV = {
+  prenom: 'Marie',
+  nom: 'Martin',
+  email: 'marie@ex.com',
+  titre_professionnel: 'Directrice Marketing',
+  experiences: [{ poste: 'CMO', entreprise: 'Corp', bullet_points: ['A'] }],
+  formations: [],
+  competences: { techniques: ['SEO'], logiciels: [], langues: [], autres: [] },
+};
+
+const TEMPLATES = [
+  { id: 'minimal', name: 'Minimal', tags: ['ats-safe', 'single-column', 'no-sidebar'] },
+  { id: 'classic', name: 'Classic', tags: ['ats-safe', 'sidebar'] },
+];
+
+const LAYOUT_A = {
+  version: 3,
+  format: 'A4',
+  grid: 'free',
+  pages: [{ id: 'p1', blocks: [{ id: 't1', type: 'text', x: 10, y: 10, w: 40, h: 8 }] }],
+};
+const LAYOUT_B = {
+  ...LAYOUT_A,
+  pages: [{
+    id: 'p1',
+    blocks: [
+      { id: 't1', type: 'text', x: 10, y: 10, w: 40, h: 8 },
+      { id: 't2', type: 'text', x: 10, y: 30, w: 40, h: 8 },
+    ],
+  }],
+};
+
+test('toScoreJson mappe la shape API (block_ids)', () => {
+  const json = toScoreJson({
+    score: 88,
+    version: '2026.05.2',
+    kind: 'parsing',
+    rules: [{
+      id: 'malus_sidebar_present',
+      label: 'Sidebar',
+      delta: -5,
+      severity: 'warning',
+      blockIds: ['sb'],
+      advice: 'Retirer',
+    }],
+  });
+  assert.equal(json.total, 88);
+  assert.deepEqual(json.rules[0].block_ids, ['sb']);
+  assert.equal('blockIds' in json.rules[0], false);
+});
+
+test('attachDeltaVsBest : meilleur à 0, autres négatifs', () => {
+  const out = attachDeltaVsBest([
+    { id: 'ats-safe', score_json: { total: 95 } },
+    { id: 'design', score_json: { total: 80 } },
+    { id: 'mix', score_json: { total: 90 } },
+  ]);
+  assert.equal(out.find((v) => v.id === 'ats-safe').delta_vs_best, 0);
+  assert.equal(out.find((v) => v.id === 'design').delta_vs_best, -15);
+  assert.equal(out.find((v) => v.id === 'mix').delta_vs_best, -5);
+});
+
+test('listDifferentialRuleIds isole les règles hors meilleure variante', () => {
+  const scored = attachDeltaVsBest([
+    {
+      id: 'ats-safe',
+      score_json: { total: 100, rules: [{ id: 'bonus_contact' }] },
+    },
+    {
+      id: 'design',
+      score_json: {
+        total: 85,
+        rules: [{ id: 'bonus_contact' }, { id: 'malus_sidebar_present' }],
+      },
+    },
+  ]);
+  const diff = listDifferentialRuleIds(scored);
+  assert.deepEqual(diff['ats-safe'], []);
+  assert.deepEqual(diff.design, ['malus_sidebar_present']);
+});
+
+test('scoreImportLayoutVariants appelle score-parsing en parallèle', async () => {
+  const calls = [];
+  const fetcher = async (path, body) => {
+    calls.push({ path, layoutBlocks: body.layout?.pages?.[0]?.blocks?.length || 0 });
+    assert.equal(path, ATS_SCORE_PARSING_ENDPOINT);
+    assert.equal(body.cv.email, CV.email);
+    const total = body.layout.pages[0].blocks.length === 1 ? 95 : 80;
+    return {
+      kind: 'parsing',
+      total,
+      version: '2026.05.2',
+      rules: total < 90
+        ? [{ id: 'malus_x', label: 'x', delta: -15, severity: 'warning', block_ids: [] }]
+        : [],
+    };
+  };
+
+  const { variants, best_total, differential_rule_ids } = await scoreImportLayoutVariants(
+    [
+      { id: 'ats-safe', label: 'ATS-safe', layout: LAYOUT_A },
+      { id: 'design', label: 'Design', layout: LAYOUT_B },
+    ],
+    CV,
+    { fetcher },
+  );
+
+  assert.equal(calls.length, 2);
+  assert.equal(best_total, 95);
+  assert.equal(variants.find((v) => v.id === 'ats-safe').delta_vs_best, 0);
+  assert.equal(variants.find((v) => v.id === 'design').delta_vs_best, -15);
+  assert.equal(variants.find((v) => v.id === 'design').score_json.total, 80);
+  assert.ok(differential_rule_ids.design.includes('malus_x'));
+});
+
+test('scoreImportLayoutVariants + buildImportLayoutVariants (pipeline AXE-324)', async () => {
+  const scoreByVariantId = {
+    'ats-safe': 98,
+    design: 72,
+    mix: 88,
+  };
+  const { variants: built } = buildImportLayoutVariants(CV, TEMPLATES, {
+    visionLayout: null,
+  });
+  assert.equal(built.length, 3);
+
+  const layoutToId = new WeakMap();
+  for (const v of built) {
+    layoutToId.set(v.layout, v.id);
+  }
+
+  const fetcher = async (_path, body) => {
+    const id = layoutToId.get(body.layout);
+    assert.ok(id, 'layout doit correspondre à une variante');
+    return { kind: 'parsing', total: scoreByVariantId[id], version: 't', rules: [] };
+  };
+
+  const { variants, best_total } = await scoreImportLayoutVariants(built, CV, { fetcher });
+  assert.equal(best_total, 98);
+  assert.deepEqual(
+    variants.map((v) => ({ id: v.id, delta: v.delta_vs_best, total: v.score_json.total })),
+    [
+      { id: 'ats-safe', delta: 0, total: 98 },
+      { id: 'design', delta: -26, total: 72 },
+      { id: 'mix', delta: -10, total: 88 },
+    ],
+  );
+});
+
+test('scoreImportLayoutVariants refuse layout manquant', async () => {
+  await assert.rejects(
+    () => scoreImportLayoutVariants([{ id: 'ats-safe' }], CV, {
+      fetcher: async () => ({ total: 1 }),
+    }),
+    /layout missing/,
+  );
+});

--- a/tests/test_import_variant_scoring.py
+++ b/tests/test_import_variant_scoring.py
@@ -1,0 +1,114 @@
+"""AXE-325 — scoring multi-variantes sur fixtures import_samples."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from backend.api_ats import resolve_layout_for_scoring
+from backend.services.import_variant_scoring import (
+    attach_delta_vs_best,
+    score_import_layout_variants,
+)
+from backend.services.pdf_structural_extract import extract_layout_from_pdf
+
+SAMPLES = Path(__file__).resolve().parent / "fixtures" / "import_samples"
+
+# CV minimal cohérent avec les samples anonymisés (email présent dans les PDF).
+SAMPLE_CV = {
+    "prenom": "Alex",
+    "nom": "Martin",
+    "email": "alex.martin@example.com",
+    "titre_professionnel": "Product Manager",
+    "resume": "Profil product avec 8 ans d experience.",
+    "experiences": [
+        {
+            "poste": "Product Manager",
+            "entreprise": "Example Corp",
+            "bullet_points": ["Livraison roadmap", "Discovery utilisateurs"],
+        }
+    ],
+    "formations": [{"diplome": "Master", "etablissement": "Univ", "date": "2015"}],
+    "competences": {
+        "techniques": ["Agile", "SQL"],
+        "logiciels": [],
+        "langues": [],
+        "autres": [],
+    },
+}
+
+
+class TestAttachDeltaVsBest(unittest.TestCase):
+    def test_best_is_zero_others_negative(self) -> None:
+        scored = [
+            {"id": "ats-safe", "score_json": {"total": 100}},
+            {"id": "design", "score_json": {"total": 80}},
+            {"id": "mix", "score_json": {"total": 90}},
+        ]
+        out = attach_delta_vs_best(scored)
+        by_id = {row["id"]: row["delta_vs_best"] for row in out}
+        self.assertEqual(by_id["ats-safe"], 0)
+        self.assertEqual(by_id["design"], -20)
+        self.assertEqual(by_id["mix"], -10)
+
+
+class TestScoreImportVariantsOnFixtures(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        pdf_path = SAMPLES / "01_single_column.pdf"
+        if not pdf_path.is_file():
+            raise unittest.SkipTest(f"Fixture manquante : {pdf_path}")
+        cls.structural = extract_layout_from_pdf(pdf_path.read_bytes())
+        if not cls.structural:
+            raise unittest.SkipTest("extract_layout_from_pdf a échoué sur 01_single_column")
+
+    def test_three_variants_have_score_json_and_delta(self) -> None:
+        ats_safe = resolve_layout_for_scoring(None, "minimal")
+        # « mix » proxy : même base structurelle (FE applique ATS + pagination).
+        variants = [
+            {"id": "ats-safe", "layout": ats_safe},
+            {"id": "design", "layout": self.structural},
+            {"id": "mix", "layout": self.structural},
+        ]
+        result = score_import_layout_variants(SAMPLE_CV, variants)
+        self.assertEqual(len(result["variants"]), 3)
+        self.assertIn("best_total", result)
+        ids = [v["id"] for v in result["variants"]]
+        self.assertEqual(ids, ["ats-safe", "design", "mix"])
+        for row in result["variants"]:
+            self.assertIn("score_json", row)
+            self.assertIn("total", row["score_json"])
+            self.assertIn("rules", row["score_json"])
+            self.assertIn("delta_vs_best", row)
+            self.assertLessEqual(row["score_json"]["total"], result["best_total"])
+            self.assertEqual(
+                row["delta_vs_best"],
+                row["score_json"]["total"] - result["best_total"],
+            )
+        # Au moins une variante doit être le meilleur (delta 0).
+        self.assertTrue(any(v["delta_vs_best"] == 0 for v in result["variants"]))
+
+    def test_sidebar_fixture_design_differs_from_minimal(self) -> None:
+        pdf_path = SAMPLES / "02_sidebar.pdf"
+        self.assertTrue(pdf_path.is_file())
+        structural = extract_layout_from_pdf(pdf_path.read_bytes())
+        self.assertIsNotNone(structural)
+        assert structural is not None
+        result = score_import_layout_variants(
+            SAMPLE_CV,
+            [
+                {"id": "ats-safe", "layout": resolve_layout_for_scoring(None, "minimal")},
+                {"id": "design", "layout": structural},
+            ],
+        )
+        by_id = {v["id"]: v for v in result["variants"]}
+        # Sur un PDF sidebar, le structurel free-canvas est en général moins
+        # bien noté que le template minimal ATS-safe.
+        self.assertNotEqual(
+            by_id["ats-safe"]["score_json"]["total"],
+            by_id["design"]["score_json"]["total"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Service FE `scoreImportLayoutVariants` : score parallèle via `POST /api/ats/score-parsing`, shape `{ variants: [{ id, score_json, delta_vs_best }] }` + `differential_rule_ids`
- Helper BE `import_variant_scoring.py` + tests sur fixtures `import_samples`
- Dépend de AXE-324 (`buildImportLayoutVariants`) ; pas d’UI (AXE-326)

Fixes AXE-325
Closes #82

## Test plan
- [x] `node --test frontend/tests/unit/scoreImportLayoutVariants.test.js`
- [x] `pytest tests/test_import_variant_scoring.py`
- [x] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks`
- [ ] Smoke manuel : après import, scorer les 3 layouts (quand branché sur chooser AXE-326)


Made with [Cursor](https://cursor.com)