### PR TITLE
feat(import): UI chooser 3 variantes après import — AXE-326

### DIFF
--- a/docs/axe-41-import-pipeline-spike.md
+++ b/docs/axe-41-import-pipeline-spike.md
@@ -122,7 +122,7 @@ Créés sous le projet Éditeur / milestone P4, parent [AXE-41](https://linear.a
 |--------|-------|----------|
 | [AXE-324](https://linear.app/axel-project/issue/AXE-324) | Feat: Générer 3 variantes layout à l'import (ATS-safe / structurel / mix) | High — service FE `frontend/src/lib/importLayoutVariants.js` |
 | [AXE-325](https://linear.app/axel-project/issue/AXE-325) | Feat: Scorer les 3 sorties d'import (`ats_score` + delta) | High — FE `scoreImportLayoutVariants.js` + BE `import_variant_scoring.py` |
-| [AXE-326](https://linear.app/axel-project/issue/AXE-326) | Feat: UI chooser import Beta (preview + score + confirmation) | High |
+| [AXE-326](https://linear.app/axel-project/issue/AXE-326) | Feat: UI chooser import Beta (preview + score + confirmation) | High — `EditorImportLayoutChooserModal` |
 | [AXE-327](https://linear.app/axel-project/issue/AXE-327) | Improve: Durcir Word (tables/runs) + refus `.doc` explicite | Medium |
 | [AXE-328](https://linear.app/axel-project/issue/AXE-328) | Improve: Policy PDF scanné — message UX, pas d'OCR MVP | Medium |
 | [AXE-329](https://linear.app/axel-project/issue/AXE-329) | Improve: Lier freeform structurel → blocs sémantiques éditables | Low |

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -22,6 +22,17 @@ import {
   recommendTemplateLabel,
   summarizeImportAdaptation,
 } from '../../lib/canvasCvImportAdapter.js';
+import { buildImportLayoutVariants } from '../../lib/importLayoutVariants.js';
+import { scoreImportLayoutVariants } from '../../lib/scoreImportLayoutVariants.js';
+import {
+  defaultImportVariantId,
+  importChooserToastMessage,
+  mergeBuiltAndScoredVariants,
+  resolveImportVariant,
+  sortImportVariantsForChooser,
+} from '../../lib/importLayoutChooser.js';
+import EditorImportLayoutChooserModal from './EditorImportLayoutChooserModal.jsx';
+import '../../styles/EditorImportLayoutChooserModal.css';
 import {
   applyCvFieldsFromRoot,
   readBlockContentFromRoot,
@@ -188,6 +199,8 @@ function CvEditorBeta({
   const [transferRequest, setTransferRequest] = useState(null);
   const [importModalOpen, setImportModalOpen] = useState(false);
   const [importLoading, setImportLoading] = useState(false);
+  const [importChooser, setImportChooser] = useState(null);
+  const [importChooserConfirming, setImportChooserConfirming] = useState(false);
   const [importStepIndex, setImportStepIndex] = useState(0);
   const [importError, setImportError] = useState('');
   const [importToast, setImportToast] = useState('');
@@ -464,20 +477,36 @@ function CvEditorBeta({
     layoutHints = {},
     visionLayout = null,
     visionMeta = {},
+    chosenVariant = null,
   } = {}) => {
     const templates = templatesList || [];
-    const {
-      layout: finalLayout,
-      recommendedTemplateId,
-      analysis,
-      blockCount,
-      importSource,
-    } = buildFullCanvasImportLayout(nextCv, templates, {
-      templateId,
-      layoutHints,
-      visionLayout,
-      visionMeta,
-    });
+    let finalLayout;
+    let recommendedTemplateId;
+    let analysis = null;
+    let blockCount;
+    let importSource;
+
+    if (chosenVariant?.layout) {
+      finalLayout = chosenVariant.layout;
+      recommendedTemplateId = chosenVariant.recommendedTemplateId || '';
+      blockCount = chosenVariant.blockCount
+        || (finalLayout?.pages || []).reduce((n, p) => n + (p?.blocks?.length || 0), 0);
+      importSource = chosenVariant.importSource || chosenVariant.id || 'preset';
+    } else {
+      ({
+        layout: finalLayout,
+        recommendedTemplateId,
+        analysis,
+        blockCount,
+        importSource,
+      } = buildFullCanvasImportLayout(nextCv, templates, {
+        templateId,
+        layoutHints,
+        visionLayout,
+        visionMeta,
+      }));
+    }
+
     const recTemplate = templates.find((t) => t?.id === recommendedTemplateId) || templates[0];
     const contextKey = IMPORTED_CANVAS_CONTEXT_KEY;
     const nextTemplateOptions = recTemplate
@@ -492,6 +521,7 @@ function CvEditorBeta({
     setCv(nextCv);
     setStartupPromptOpen(false);
     setImportModalOpen(false);
+    setImportChooser(null);
     setImportError('');
     resetLayout(finalLayout);
     layoutRef.current = finalLayout;
@@ -516,21 +546,25 @@ function CvEditorBeta({
     } catch (err) {
       setLoadError(err?.message || 'Import réussi mais enregistrement échoué.');
     }
-    const label = recommendTemplateLabel(recTemplate?.id, templates);
-    let sourceNote = '';
-    if (importSource === 'structural') {
-      sourceNote = ' · copie fidèle du PDF';
-    } else if (importSource === 'vision-guided') {
-      sourceNote = ' · analyse visuelle PDF';
-    } else if (visionMeta?.source === 'gemini_vision') {
-      sourceNote = ' · vision partielle';
-    }
-    if (importSource === 'structural') {
-      setImportToast(`${blockCount} éléments importés${sourceNote}`);
+    if (chosenVariant) {
+      setImportToast(importChooserToastMessage(chosenVariant));
     } else {
-      setImportToast(`${summarizeImportAdaptation(analysis, label, blockCount, {
-        fromVision: importSource === 'vision-guided',
-      })}${sourceNote}`);
+      const label = recommendTemplateLabel(recTemplate?.id, templates);
+      let sourceNote = '';
+      if (importSource === 'structural') {
+        sourceNote = ' · copie fidèle du PDF';
+      } else if (importSource === 'vision-guided') {
+        sourceNote = ' · analyse visuelle PDF';
+      } else if (visionMeta?.source === 'gemini_vision') {
+        sourceNote = ' · vision partielle';
+      }
+      if (importSource === 'structural') {
+        setImportToast(`${blockCount} éléments importés${sourceNote}`);
+      } else {
+        setImportToast(`${summarizeImportAdaptation(analysis, label, blockCount, {
+          fromVision: importSource === 'vision-guided',
+        })}${sourceNote}`);
+      }
     }
   }, [
     templatesList,
@@ -546,6 +580,7 @@ function CvEditorBeta({
 
   const runCvImport = useCallback(async (importFn) => {
     setImportModalOpen(false);
+    setImportChooser(null);
     setImportLoading(true);
     setImportStepIndex(0);
     setImportError('');
@@ -561,7 +596,38 @@ function CvEditorBeta({
         visionMeta,
       } = extractImportApiResponse(result);
       const nextCv = cvFromImportPayload(rawCv);
-      await applyImportedCvToCanvas(nextCv, { layoutHints, visionLayout, visionMeta });
+      const templates = templatesList || [];
+      const { variants: built } = buildImportLayoutVariants(nextCv, templates, {
+        templateId,
+        layoutHints,
+        visionLayout,
+        visionMeta,
+      });
+      let scoredRows = [];
+      let bestTotal = null;
+      try {
+        const scored = await scoreImportLayoutVariants(built, nextCv, {
+          includeLayout: true,
+        });
+        scoredRows = scored.variants || [];
+        bestTotal = scored.best_total;
+      } catch {
+        // Scoring optionnel pour le chooser : on affiche quand même les 3 layouts.
+        scoredRows = [];
+      }
+      const merged = sortImportVariantsForChooser(
+        mergeBuiltAndScoredVariants(built, scoredRows),
+      );
+      if (merged.length === 0) {
+        await applyImportedCvToCanvas(nextCv, { layoutHints, visionLayout, visionMeta });
+        return;
+      }
+      setImportChooser({
+        cv: nextCv,
+        variants: merged,
+        bestTotal,
+        selectedId: defaultImportVariantId(merged),
+      });
     } catch (err) {
       setImportError(err?.message || 'Erreur lors de l\'import.');
       setImportModalOpen(true);
@@ -572,7 +638,40 @@ function CvEditorBeta({
         importCleanupRef.current = null;
       }
     }
-  }, [applyImportedCvToCanvas]);
+  }, [applyImportedCvToCanvas, templatesList, templateId]);
+
+  const handleImportChooserConfirm = useCallback(async (variant) => {
+    if (!importChooser?.cv || !variant?.layout) return;
+    setImportChooserConfirming(true);
+    try {
+      await applyImportedCvToCanvas(importChooser.cv, { chosenVariant: variant });
+    } finally {
+      setImportChooserConfirming(false);
+    }
+  }, [importChooser, applyImportedCvToCanvas]);
+
+  const handleImportChooserCancel = useCallback(async () => {
+    if (!importChooser?.cv) {
+      setImportChooser(null);
+      return;
+    }
+    const designOrDefault = resolveImportVariant(
+      importChooser.variants,
+      'design',
+    );
+    setImportChooserConfirming(true);
+    try {
+      if (designOrDefault?.layout) {
+        await applyImportedCvToCanvas(importChooser.cv, {
+          chosenVariant: designOrDefault,
+        });
+      } else {
+        setImportChooser(null);
+      }
+    } finally {
+      setImportChooserConfirming(false);
+    }
+  }, [importChooser, applyImportedCvToCanvas]);
 
   const handleImportFile = useCallback((file) => {
     if (!file) return;
@@ -1810,7 +1909,7 @@ function CvEditorBeta({
       </footer>
 
       <EditorCvImportModal
-        open={importModalOpen && !importLoading}
+        open={importModalOpen && !importLoading && !importChooser}
         onClose={() => {
           if (!importLoading) setImportModalOpen(false);
         }}
@@ -1826,6 +1925,16 @@ function CvEditorBeta({
           subtitle="Analyse en cours - cela peut prendre jusqu'à une minute pour un PDF complexe."
         />
       )}
+
+      <EditorImportLayoutChooserModal
+        open={Boolean(importChooser) && !importLoading}
+        variants={importChooser?.variants || []}
+        bestTotal={importChooser?.bestTotal}
+        initialSelectedId={importChooser?.selectedId || ''}
+        confirming={importChooserConfirming}
+        onConfirm={handleImportChooserConfirm}
+        onCancel={handleImportChooserCancel}
+      />
 
     </div>
   );

--- a/frontend/src/components/editor/EditorImportLayoutChooserModal.jsx
+++ b/frontend/src/components/editor/EditorImportLayoutChooserModal.jsx
@@ -3,7 +3,9 @@ import { useEffect, useState } from 'react';
 import { scoreToneFor } from '../../lib/atsScoreClient.js';
 import {
   defaultImportVariantId,
+  isBestAtsVariant,
   resolveImportVariant,
+  variantHasAtsScore,
 } from '../../lib/importLayoutChooser.js';
 import ImportLayoutMiniPreview from './ImportLayoutMiniPreview.jsx';
 import '../../styles/EditorImportLayoutChooserModal.css';
@@ -78,9 +80,10 @@ export default function EditorImportLayoutChooserModal({
         <div className="editor-import-chooser-grid" role="listbox" aria-label="Variantes d'import">
           {variants.map((variant) => {
             const score = variant?.score_json?.total;
+            const hasScore = variantHasAtsScore(variant);
             const tone = scoreToneFor(score);
             const isSelected = variant.id === selectedId;
-            const isBest = variant.delta_vs_best === 0;
+            const isBest = isBestAtsVariant(variant);
             return (
               <button
                 key={variant.id}
@@ -95,15 +98,14 @@ export default function EditorImportLayoutChooserModal({
                 <div className="editor-import-chooser-card__meta">
                   <strong>{variant.label || variant.id}</strong>
                   <span className={`editor-import-chooser-score tone-${tone}`}>
-                    {Number.isFinite(score) ? score : '—'}
-                    {Number.isFinite(bestTotal) && Number.isFinite(score) ? (
+                    {hasScore ? score : '—'}
+                    {Number.isFinite(bestTotal) && hasScore ? (
                       <small>{formatDelta(variant.delta_vs_best)}</small>
                     ) : null}
                   </span>
                   <span className="editor-import-chooser-card__sub">
                     {variant.blockCount || 0} blocs
                     {isBest ? ' · meilleur ATS' : ''}
-                    {variant.importSource ? ` · ${variant.importSource}` : ''}
                   </span>
                 </div>
               </button>

--- a/frontend/src/components/editor/EditorImportLayoutChooserModal.jsx
+++ b/frontend/src/components/editor/EditorImportLayoutChooserModal.jsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from 'react';
+
+import { scoreToneFor } from '../../lib/atsScoreClient.js';
+import {
+  defaultImportVariantId,
+  resolveImportVariant,
+} from '../../lib/importLayoutChooser.js';
+import ImportLayoutMiniPreview from './ImportLayoutMiniPreview.jsx';
+import '../../styles/EditorImportLayoutChooserModal.css';
+
+function formatDelta(delta) {
+  if (!Number.isFinite(delta) || delta === 0) return 'Meilleur score';
+  return delta > 0 ? `+${delta} vs meilleur` : `${delta} vs meilleur`;
+}
+
+export default function EditorImportLayoutChooserModal({
+  open,
+  variants = [],
+  bestTotal = null,
+  initialSelectedId = '',
+  onConfirm,
+  onCancel,
+  confirming = false,
+}) {
+  const [selectedId, setSelectedId] = useState(
+    () => initialSelectedId || defaultImportVariantId(variants),
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    setSelectedId(initialSelectedId || defaultImportVariantId(variants));
+  }, [open, initialSelectedId, variants]);
+
+  if (!open) return null;
+
+  const selected = resolveImportVariant(variants, selectedId);
+
+  const handleConfirm = () => {
+    if (!selected || confirming) return;
+    onConfirm?.(selected);
+  };
+
+  return (
+    <div
+      className="editor-import-chooser-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="editor-import-chooser-title"
+      onClick={() => {
+        if (!confirming) onCancel?.();
+      }}
+    >
+      <div
+        className="editor-import-chooser-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="editor-import-chooser-head">
+          <div>
+            <span className="editor-import-chooser-eyebrow">Choix de mise en page</span>
+            <h2 id="editor-import-chooser-title">Trois variantes après import</h2>
+            <p>
+              Ce n&apos;est pas une copie pixel-perfect : on reconstruit un canvas
+              éditable. Comparez le rendu approximatif et le score ATS, puis
+              continuez avec la variante qui vous convient.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="editor-import-chooser-close"
+            onClick={() => onCancel?.()}
+            aria-label="Fermer"
+            disabled={confirming}
+          >
+            ×
+          </button>
+        </header>
+
+        <div className="editor-import-chooser-grid" role="listbox" aria-label="Variantes d'import">
+          {variants.map((variant) => {
+            const score = variant?.score_json?.total;
+            const tone = scoreToneFor(score);
+            const isSelected = variant.id === selectedId;
+            const isBest = variant.delta_vs_best === 0;
+            return (
+              <button
+                key={variant.id}
+                type="button"
+                role="option"
+                aria-selected={isSelected}
+                className={`editor-import-chooser-card${isSelected ? ' is-selected' : ''}`}
+                onClick={() => setSelectedId(variant.id)}
+                disabled={confirming}
+              >
+                <ImportLayoutMiniPreview layout={variant.layout} />
+                <div className="editor-import-chooser-card__meta">
+                  <strong>{variant.label || variant.id}</strong>
+                  <span className={`editor-import-chooser-score tone-${tone}`}>
+                    {Number.isFinite(score) ? score : '—'}
+                    {Number.isFinite(bestTotal) && Number.isFinite(score) ? (
+                      <small>{formatDelta(variant.delta_vs_best)}</small>
+                    ) : null}
+                  </span>
+                  <span className="editor-import-chooser-card__sub">
+                    {variant.blockCount || 0} blocs
+                    {isBest ? ' · meilleur ATS' : ''}
+                    {variant.importSource ? ` · ${variant.importSource}` : ''}
+                  </span>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        <footer className="editor-import-chooser-actions">
+          <button type="button" onClick={() => onCancel?.()} disabled={confirming}>
+            Utiliser Design proche
+          </button>
+          <button
+            type="button"
+            className="editor-import-chooser-primary"
+            onClick={handleConfirm}
+            disabled={!selected || confirming}
+          >
+            {confirming
+              ? 'Application…'
+              : `Continuer avec ${selected?.label || 'cette variante'}`}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/editor/ImportLayoutMiniPreview.jsx
+++ b/frontend/src/components/editor/ImportLayoutMiniPreview.jsx
@@ -1,0 +1,60 @@
+/**
+ * Vignette proportionnelle d'un layout v3 (blocs page 1).
+ * Approximation visuelle — pas un rendu pixel-perfect (AXE-326).
+ */
+
+const PAGE_W = 210;
+const PAGE_H = 297;
+
+function asNum(v, fallback = 0) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function blockFill(block) {
+  const type = typeof block?.type === 'string' ? block.type : '';
+  if (type.startsWith('shape:')) {
+    return block?.style?.color || block?.style?.fill || '#d9d9dd';
+  }
+  if (type === 'photo' || type === 'image') return '#c5c5ce';
+  if (type === 'identity' || type === 'title') return '#17171c';
+  if (type === 'contact') return '#75758a';
+  return '#93939f';
+}
+
+export default function ImportLayoutMiniPreview({ layout, className = '' }) {
+  const page = layout?.pages?.[0];
+  const blocks = Array.isArray(page?.blocks) ? page.blocks : [];
+  const sorted = [...blocks].sort((a, b) => asNum(a.z) - asNum(b.z));
+
+  return (
+    <div
+      className={`import-layout-mini ${className}`.trim()}
+      aria-hidden="true"
+    >
+      <div className="import-layout-mini__page">
+        {sorted.slice(0, 40).map((block) => {
+          if (!block?.id) return null;
+          const x = (asNum(block.x) / PAGE_W) * 100;
+          const y = (asNum(block.y) / PAGE_H) * 100;
+          const w = Math.max((asNum(block.w, 10) / PAGE_W) * 100, 1.5);
+          const h = Math.max((asNum(block.h, 4) / PAGE_H) * 100, 0.8);
+          return (
+            <span
+              key={block.id}
+              className="import-layout-mini__block"
+              style={{
+                left: `${x}%`,
+                top: `${y}%`,
+                width: `${w}%`,
+                height: `${h}%`,
+                background: blockFill(block),
+                opacity: String(block.type || '').startsWith('shape:') ? 0.55 : 0.85,
+              }}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/importLayoutChooser.js
+++ b/frontend/src/lib/importLayoutChooser.js
@@ -5,16 +5,33 @@
 import { IMPORT_VARIANT_IDS } from './importLayoutVariants.js';
 
 /**
+ * True si la variante a un score parsing numérique.
+ * @param {object} variant
+ */
+export function variantHasAtsScore(variant) {
+  return Number.isFinite(variant?.score_json?.total);
+}
+
+/**
+ * True si c'est la meilleure variante ATS (score présent + delta 0).
+ * Sans score (échec API), on ne marque personne « meilleur ».
+ * @param {object} variant
+ */
+export function isBestAtsVariant(variant) {
+  return variantHasAtsScore(variant) && variant.delta_vs_best === 0;
+}
+
+/**
  * Id sélectionné par défaut : `design` (comportement historique), sinon
- * meilleure variante (`delta_vs_best === 0`), sinon première.
- * @param {Array<{ id: string, delta_vs_best?: number }>} variants
+ * meilleure variante scorée (`delta_vs_best === 0`), sinon première.
+ * @param {Array<{ id: string, delta_vs_best?: number|null, score_json?: object }>} variants
  */
 export function defaultImportVariantId(variants = []) {
   const list = Array.isArray(variants) ? variants : [];
   if (list.length === 0) return '';
   const design = list.find((v) => v?.id === 'design');
   if (design) return design.id;
-  const best = list.find((v) => v?.delta_vs_best === 0);
+  const best = list.find((v) => isBestAtsVariant(v));
   if (best) return best.id;
   return list[0]?.id || '';
 }
@@ -36,6 +53,7 @@ export function resolveImportVariant(variants = [], selectedId = '') {
 /**
  * Fusionne les layouts construits (AXE-324) avec les scores (AXE-325).
  * Conserve toujours le `layout` de `built` (source de vérité).
+ * Sans score : `delta_vs_best` reste `null` (pas 0 → évite « meilleur ATS » faux).
  *
  * @param {Array<object>} built
  * @param {Array<object>} scored
@@ -45,12 +63,16 @@ export function mergeBuiltAndScoredVariants(built = [], scored = []) {
     (Array.isArray(scored) ? scored : []).map((s) => [s.id, s]),
   );
   return (Array.isArray(built) ? built : []).map((v) => {
-    const s = scoreById.get(v.id) || {};
+    const s = scoreById.get(v.id);
+    const score_json = s?.score_json || null;
+    const hasScore = Number.isFinite(score_json?.total);
     return {
       ...v,
-      score_json: s.score_json || null,
-      delta_vs_best: Number.isFinite(s.delta_vs_best) ? s.delta_vs_best : 0,
-      label: v.label || s.label || v.id,
+      score_json,
+      delta_vs_best: hasScore && Number.isFinite(s?.delta_vs_best)
+        ? s.delta_vs_best
+        : null,
+      label: v.label || s?.label || v.id,
     };
   });
 }

--- a/frontend/src/lib/importLayoutChooser.js
+++ b/frontend/src/lib/importLayoutChooser.js
@@ -1,0 +1,89 @@
+/**
+ * AXE-326 — Helpers purs pour le chooser de variantes d'import.
+ */
+
+import { IMPORT_VARIANT_IDS } from './importLayoutVariants.js';
+
+/**
+ * Id sélectionné par défaut : `design` (comportement historique), sinon
+ * meilleure variante (`delta_vs_best === 0`), sinon première.
+ * @param {Array<{ id: string, delta_vs_best?: number }>} variants
+ */
+export function defaultImportVariantId(variants = []) {
+  const list = Array.isArray(variants) ? variants : [];
+  if (list.length === 0) return '';
+  const design = list.find((v) => v?.id === 'design');
+  if (design) return design.id;
+  const best = list.find((v) => v?.delta_vs_best === 0);
+  if (best) return best.id;
+  return list[0]?.id || '';
+}
+
+/**
+ * Retrouve une variante par id (fallback default / première).
+ * @param {Array<object>} variants
+ * @param {string} selectedId
+ */
+export function resolveImportVariant(variants = [], selectedId = '') {
+  const list = Array.isArray(variants) ? variants : [];
+  if (list.length === 0) return null;
+  const found = list.find((v) => v?.id === selectedId);
+  if (found) return found;
+  const fallbackId = defaultImportVariantId(list);
+  return list.find((v) => v?.id === fallbackId) || list[0];
+}
+
+/**
+ * Fusionne les layouts construits (AXE-324) avec les scores (AXE-325).
+ * Conserve toujours le `layout` de `built` (source de vérité).
+ *
+ * @param {Array<object>} built
+ * @param {Array<object>} scored
+ */
+export function mergeBuiltAndScoredVariants(built = [], scored = []) {
+  const scoreById = new Map(
+    (Array.isArray(scored) ? scored : []).map((s) => [s.id, s]),
+  );
+  return (Array.isArray(built) ? built : []).map((v) => {
+    const s = scoreById.get(v.id) || {};
+    return {
+      ...v,
+      score_json: s.score_json || null,
+      delta_vs_best: Number.isFinite(s.delta_vs_best) ? s.delta_vs_best : 0,
+      label: v.label || s.label || v.id,
+    };
+  });
+}
+
+/** Ordre d'affichage stable des 3 ids produit. */
+export function sortImportVariantsForChooser(variants = []) {
+  const list = Array.isArray(variants) ? [...variants] : [];
+  const order = new Map(IMPORT_VARIANT_IDS.map((id, i) => [id, i]));
+  return list.sort((a, b) => {
+    const ia = order.has(a?.id) ? order.get(a.id) : 99;
+    const ib = order.has(b?.id) ? order.get(b.id) : 99;
+    return ia - ib;
+  });
+}
+
+/**
+ * Message toast après confirmation.
+ * @param {object} variant
+ */
+export function importChooserToastMessage(variant) {
+  if (!variant) return 'CV importé.';
+  const score = variant.score_json?.total;
+  const scoreBit = Number.isFinite(score) ? ` · score ATS ${score}` : '';
+  const label = variant.label || variant.id || 'variante';
+  const n = variant.blockCount || 0;
+  if (variant.id === 'ats-safe') {
+    return `${n} éléments · variante ATS-safe${scoreBit}`;
+  }
+  if (variant.id === 'mix') {
+    return `${n} éléments · mix design + ATS${scoreBit}`;
+  }
+  if (variant.importSource === 'structural') {
+    return `${n} éléments importés · copie fidèle du PDF${scoreBit}`;
+  }
+  return `${n} éléments · ${label}${scoreBit}`;
+}

--- a/frontend/src/styles/EditorImportLayoutChooserModal.css
+++ b/frontend/src/styles/EditorImportLayoutChooserModal.css
@@ -1,0 +1,234 @@
+.editor-import-chooser-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1250;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(7, 24, 41, 0.55);
+}
+
+.editor-import-chooser-modal {
+  width: min(920px, 100%);
+  max-height: min(90vh, 760px);
+  overflow: auto;
+  background: var(--color-canvas, #fff);
+  border-radius: 16px;
+  border: 1px solid var(--color-hairline, #d9d9dd);
+  padding: 1.25rem 1.35rem 1.2rem;
+  font-family: var(--app-font-family);
+}
+
+.editor-import-chooser-eyebrow {
+  display: inline-flex;
+  margin-bottom: 0.35rem;
+  padding: 0.15rem 0.55rem;
+  border-radius: 30px;
+  background: var(--color-pale-blue, #f1f5ff);
+  color: var(--color-action-blue, #1863dc);
+  font-size: 0.68rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.editor-import-chooser-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.editor-import-chooser-head h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1.2rem;
+  font-weight: 500;
+  color: var(--color-ink, #212121);
+}
+
+.editor-import-chooser-head p {
+  margin: 0;
+  max-width: 42rem;
+  font-size: 0.84rem;
+  line-height: 1.45;
+  color: var(--color-body-muted, #616161);
+}
+
+.editor-import-chooser-close {
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid var(--color-hairline, #d9d9dd);
+  border-radius: 8px;
+  background: var(--color-canvas, #fff);
+  color: var(--color-ink, #212121);
+  font-size: 1.35rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.editor-import-chooser-close:hover:not(:disabled) {
+  background: var(--color-soft-stone, #eeece7);
+}
+
+.editor-import-chooser-close:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.editor-import-chooser-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.editor-import-chooser-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px;
+  border: 1px solid var(--color-card-border, #f2f2f2);
+  border-radius: 12px;
+  background: var(--color-canvas, #fff);
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  color: inherit;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.editor-import-chooser-card:hover:not(:disabled) {
+  border-color: var(--color-hairline, #d9d9dd);
+  background: var(--color-soft-stone, #eeece7);
+}
+
+.editor-import-chooser-card.is-selected {
+  border-color: var(--color-primary, #17171c);
+  background: var(--color-pale-blue, #f1f5ff);
+}
+
+.editor-import-chooser-card:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.editor-import-chooser-card:focus-visible {
+  outline: 2px solid var(--color-focus-blue, #4c6ee6);
+  outline-offset: 2px;
+}
+
+.import-layout-mini {
+  width: 100%;
+  aspect-ratio: 210 / 297;
+  border-radius: 8px;
+  border: 1px solid var(--color-hairline, #d9d9dd);
+  background: var(--color-canvas, #fff);
+  overflow: hidden;
+}
+
+.import-layout-mini__page {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: #fafafa;
+}
+
+.import-layout-mini__block {
+  position: absolute;
+  border-radius: 1px;
+  pointer-events: none;
+}
+
+.editor-import-chooser-card__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.editor-import-chooser-card__meta strong {
+  font-size: 0.92rem;
+  font-weight: 500;
+  color: var(--color-ink, #212121);
+}
+
+.editor-import-chooser-score {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 1.15rem;
+  font-weight: 500;
+  color: var(--color-primary, #17171c);
+}
+
+.editor-import-chooser-score small {
+  font-size: 0.72rem;
+  font-weight: 400;
+  color: var(--color-slate, #75758a);
+}
+
+.editor-import-chooser-score.tone-good {
+  color: var(--color-deep-green, #003c33);
+}
+
+.editor-import-chooser-score.tone-meh {
+  color: var(--color-action-blue, #1863dc);
+}
+
+.editor-import-chooser-score.tone-bad {
+  color: var(--color-error, #b30000);
+}
+
+.editor-import-chooser-card__sub {
+  font-size: 0.75rem;
+  color: var(--color-muted, #93939f);
+}
+
+.editor-import-chooser-actions {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 1.1rem;
+}
+
+.editor-import-chooser-actions button {
+  border: 1px solid var(--color-hairline, #d9d9dd);
+  border-radius: 32px;
+  background: transparent;
+  color: var(--color-ink, #212121);
+  padding: 10px 16px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.editor-import-chooser-actions button:hover:not(:disabled) {
+  background: var(--color-soft-stone, #eeece7);
+}
+
+.editor-import-chooser-actions button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.editor-import-chooser-primary {
+  border-color: var(--color-primary, #17171c) !important;
+  background: var(--color-primary, #17171c) !important;
+  color: var(--color-on-dark, #fff) !important;
+}
+
+.editor-import-chooser-primary:hover:not(:disabled) {
+  background: #2a2a32 !important;
+}
+
+@media (max-width: 768px) {
+  .editor-import-chooser-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .editor-import-chooser-modal {
+    width: min(520px, 100%);
+  }
+}

--- a/frontend/tests/unit/importLayoutChooser.test.js
+++ b/frontend/tests/unit/importLayoutChooser.test.js
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import {
   defaultImportVariantId,
   importChooserToastMessage,
+  isBestAtsVariant,
   mergeBuiltAndScoredVariants,
   resolveImportVariant,
   sortImportVariantsForChooser,
@@ -23,8 +24,8 @@ test('defaultImportVariantId privilégie design', () => {
 test('defaultImportVariantId sans design : meilleur score', () => {
   assert.equal(
     defaultImportVariantId([
-      { id: 'ats-safe', delta_vs_best: 0 },
-      { id: 'mix', delta_vs_best: -8 },
+      { id: 'ats-safe', delta_vs_best: 0, score_json: { total: 95 } },
+      { id: 'mix', delta_vs_best: -8, score_json: { total: 87 } },
     ]),
     'ats-safe',
   );
@@ -53,6 +54,32 @@ test('mergeBuiltAndScoredVariants conserve layout built', () => {
   assert.equal(merged[0].layout, layoutA);
   assert.equal(merged[0].score_json.total, 91);
   assert.equal(merged[0].delta_vs_best, 0);
+});
+
+test('mergeBuiltAndScoredVariants sans score : delta null (pas faux meilleur)', () => {
+  const merged = mergeBuiltAndScoredVariants(
+    [
+      { id: 'ats-safe', layout: {} },
+      { id: 'design', layout: {} },
+    ],
+    [],
+  );
+  assert.equal(merged[0].delta_vs_best, null);
+  assert.equal(merged[0].score_json, null);
+  assert.equal(merged[1].delta_vs_best, null);
+  assert.equal(isBestAtsVariant(merged[0]), false);
+});
+
+test('isBestAtsVariant exige un score', () => {
+  assert.equal(isBestAtsVariant({ delta_vs_best: 0 }), false);
+  assert.equal(
+    isBestAtsVariant({ delta_vs_best: 0, score_json: { total: 95 } }),
+    true,
+  );
+  assert.equal(
+    isBestAtsVariant({ delta_vs_best: -5, score_json: { total: 80 } }),
+    false,
+  );
 });
 
 test('sortImportVariantsForChooser ordre produit', () => {

--- a/frontend/tests/unit/importLayoutChooser.test.js
+++ b/frontend/tests/unit/importLayoutChooser.test.js
@@ -1,0 +1,77 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  defaultImportVariantId,
+  importChooserToastMessage,
+  mergeBuiltAndScoredVariants,
+  resolveImportVariant,
+  sortImportVariantsForChooser,
+} from '../../src/lib/importLayoutChooser.js';
+
+test('defaultImportVariantId privilégie design', () => {
+  assert.equal(
+    defaultImportVariantId([
+      { id: 'ats-safe', delta_vs_best: 0 },
+      { id: 'design', delta_vs_best: -10 },
+      { id: 'mix', delta_vs_best: -5 },
+    ]),
+    'design',
+  );
+});
+
+test('defaultImportVariantId sans design : meilleur score', () => {
+  assert.equal(
+    defaultImportVariantId([
+      { id: 'ats-safe', delta_vs_best: 0 },
+      { id: 'mix', delta_vs_best: -8 },
+    ]),
+    'ats-safe',
+  );
+});
+
+test('resolveImportVariant fallback design', () => {
+  const variants = [
+    { id: 'ats-safe', layout: { a: 1 } },
+    { id: 'design', layout: { b: 2 } },
+  ];
+  assert.equal(resolveImportVariant(variants, 'ghost').id, 'design');
+  assert.equal(resolveImportVariant(variants, 'ats-safe').id, 'ats-safe');
+});
+
+test('mergeBuiltAndScoredVariants conserve layout built', () => {
+  const layoutA = { pages: [{ id: 'p1', blocks: [] }] };
+  const merged = mergeBuiltAndScoredVariants(
+    [{ id: 'ats-safe', layout: layoutA, label: 'ATS-safe', blockCount: 3 }],
+    [{
+      id: 'ats-safe',
+      layout: { pages: [] },
+      score_json: { total: 91 },
+      delta_vs_best: 0,
+    }],
+  );
+  assert.equal(merged[0].layout, layoutA);
+  assert.equal(merged[0].score_json.total, 91);
+  assert.equal(merged[0].delta_vs_best, 0);
+});
+
+test('sortImportVariantsForChooser ordre produit', () => {
+  const sorted = sortImportVariantsForChooser([
+    { id: 'mix' },
+    { id: 'ats-safe' },
+    { id: 'design' },
+  ]);
+  assert.deepEqual(sorted.map((v) => v.id), ['ats-safe', 'design', 'mix']);
+});
+
+test('importChooserToastMessage inclut score', () => {
+  const msg = importChooserToastMessage({
+    id: 'mix',
+    label: 'Mix',
+    blockCount: 12,
+    score_json: { total: 88 },
+  });
+  assert.match(msg, /12/);
+  assert.match(msg, /88/);
+  assert.match(msg, /mix/i);
+});


### PR DESCRIPTION
## Summary
- Modal `EditorImportLayoutChooserModal` après import réussi : 3 cartes (preview miniature, score ATS, label)
- Branche `buildImportLayoutVariants` (AXE-324) + `scoreImportLayoutVariants` (AXE-325)
- Copy explicite « pas pixel-perfect » ; confirmation applique layout + autosave ; annuler → Design proche
- Helpers purs testés (`importLayoutChooser.js`)

Fixes AXE-326
Closes #84

## Test plan
- [x] `node --test frontend/tests/unit/importLayoutChooser.test.js`
- [x] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks`
- [ ] Smoke : Importer un PDF → chooser 3 cartes → Continuer avec… → canvas + toast
- [ ] Annuler / fermer → applique Design proche
- [ ] Mobile : grille 1 colonne


Made with [Cursor](https://cursor.com)