### PR TITLE
Improve: Policy PDF scanné — message UX, pas d'OCR MVP

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1486,11 +1486,18 @@ def api_cv_import_file(request: Request, file: UploadFile = File(...)):
         is_docx_upload,
         is_legacy_doc,
     )
+    from backend.services.pdf_import_policy import (
+        PDF_SCANNED_REFUSAL_DETAIL,
+        build_pdf_import_policy,
+        is_insufficient_import_text,
+    )
 
     if is_legacy_doc(filename=file.filename, content_type=content_type, file_bytes=file_bytes):
         raise HTTPException(status_code=400, detail=DOC_LEGACY_REFUSAL_DETAIL)
 
-    if content_type == "application/pdf" or (file.filename or "").lower().endswith(".pdf"):
+    is_pdf = content_type == "application/pdf" or (file.filename or "").lower().endswith(".pdf")
+
+    if is_pdf:
         text = _extract_text_from_pdf(file_bytes)
     elif is_docx_upload(filename=file.filename, content_type=content_type, file_bytes=file_bytes):
         text = _extract_text_from_docx(file_bytes)
@@ -1503,7 +1510,10 @@ def api_cv_import_file(request: Request, file: UploadFile = File(...)):
                 detail="Format non reconnu. Envoie un PDF, un .docx ou un fichier texte.",
             )
 
-    if len(text.strip()) < 50:
+    if is_insufficient_import_text(text):
+        # PDF scanné / image : message produit dédié (OCR hors MVP).
+        if is_pdf:
+            raise HTTPException(status_code=400, detail=PDF_SCANNED_REFUSAL_DETAIL)
         raise HTTPException(
             status_code=400, detail="Le fichier ne contient pas assez de texte pour un CV."
         )
@@ -1522,7 +1532,7 @@ def api_cv_import_file(request: Request, file: UploadFile = File(...)):
 
     vision_meta: dict[str, Any] = {}
     structural_layout: dict[str, Any] | None = None
-    is_pdf = content_type == "application/pdf" or (file.filename or "").lower().endswith(".pdf")
+    import_policy: dict[str, Any] | None = None
     if is_pdf:
         # Étape 1 (prioritaire) : reconstruction déterministe sans IA. Pour un PDF
         # natif (texte extractible), on copie la mise en page 1:1 - c'est le rendu
@@ -1535,8 +1545,7 @@ def api_cv_import_file(request: Request, file: UploadFile = File(...)):
             logger.warning("Import PDF: extraction structurelle échouée: %s", exc)
             structural_layout = None
 
-        # Étape 2 (repli) : seulement si le PDF n'est pas natif (scanné/illisible),
-        # on retombe sur la vision Gemini pour deviner un template + couleurs.
+        # Étape 2 (repli) : texte OK mais pas de layout mm → vision/preset (pas d'OCR).
         if structural_layout is None:
             from backend.services.cv_import_layout_vision import (
                 detection_to_layout_hints,
@@ -1558,6 +1567,11 @@ def api_cv_import_file(request: Request, file: UploadFile = File(...)):
                 else:
                     logger.warning("Import PDF: vision sans détection - repli preset")
 
+        import_policy = build_pdf_import_policy(
+            structural_layout=structural_layout,
+            vision_meta=vision_meta,
+        )
+
     structural_blocks = (
         sum(len(p.get("blocks", [])) for p in structural_layout.get("pages", []))
         if structural_layout
@@ -1578,14 +1592,19 @@ def api_cv_import_file(request: Request, file: UploadFile = File(...)):
             "vision_detection": bool(vision_meta),
             "vision_template": vision_meta.get("template_match"),
             "vision_confidence": vision_meta.get("confidence"),
+            "import_layout_mode": (import_policy or {}).get("layout_mode"),
+            "ocr": False,
         },
     )
-    return {
+    payload: dict[str, Any] = {
         "cv": cv,
         "layout_hints": layout_hints,
         "layout": structural_layout,
         "vision": vision_meta,
     }
+    if import_policy is not None:
+        payload["import_policy"] = import_policy
+    return payload
 
 
 @app.post("/api/cv/import-text")

--- a/backend/services/pdf_import_policy.py
+++ b/backend/services/pdf_import_policy.py
@@ -1,0 +1,60 @@
+"""Policy import PDF — scanned / OCR hors MVP (AXE-328).
+
+Chemins :
+- PDF scanné (texte non extractible) → **refus 400** + message UX (pas d'OCR).
+- PDF texte OK mais layout structurel ``None`` → **fallback** texte IA + vision/preset.
+"""
+
+from __future__ import annotations
+
+# Aligné sur le seuil historique de ``/api/cv/import`` (texte trop court).
+MIN_IMPORT_TEXT_CHARS = 50
+
+PDF_SCANNED_REFUSAL_DETAIL = (
+    "Ce PDF semble scanné (image sans texte sélectionnable). "
+    "L'OCR n'est pas disponible pour l'instant. "
+    "Exporte un PDF avec texte sélectionnable, un fichier .docx, "
+    "ou colle le texte de ton CV."
+)
+
+LAYOUT_FALLBACK_TEXT_AI = "text_ai_vision_or_preset"
+LAYOUT_MODE_STRUCTURAL = "structural"
+LAYOUT_MODE_REFUSED_SCANNED = "refused_scanned"
+
+
+def is_insufficient_import_text(
+    text: str | None, *, min_chars: int = MIN_IMPORT_TEXT_CHARS
+) -> bool:
+    """True si le texte extrait est trop court pour un import CV."""
+    return len((text or "").strip()) < min_chars
+
+
+def build_pdf_import_policy(
+    *,
+    structural_layout: dict | None,
+    vision_meta: dict | None = None,
+) -> dict:
+    """Métadonnées policy exposées au FE (pas d'OCR MVP)."""
+    has_structural = bool(structural_layout)
+    has_vision = bool(vision_meta)
+    if has_structural:
+        layout_mode = LAYOUT_MODE_STRUCTURAL
+        layout_fallback = None
+    else:
+        layout_mode = LAYOUT_FALLBACK_TEXT_AI
+        layout_fallback = LAYOUT_FALLBACK_TEXT_AI
+    return {
+        "ocr": False,
+        "pdf_native_layout": has_structural,
+        "layout_mode": layout_mode,
+        "layout_fallback": layout_fallback,
+        "vision_used": has_vision,
+        "message": (
+            None
+            if has_structural
+            else (
+                "Mise en page PDF non recopiée (fichier sans structure native). "
+                "Contenu extrait puis adapté — pas un fac-similé. OCR hors MVP."
+            )
+        ),
+    }

--- a/docs/axe-41-import-pipeline-spike.md
+++ b/docs/axe-41-import-pipeline-spike.md
@@ -81,7 +81,7 @@ Module : `backend/services/cv_import_probe.py` (offline, sans Gemini).
 | PDF natif mono-colonne | **Haute** | Structurel + texte cohérents |
 | PDF natif sidebar / formes | **Moyenne–haute** | Blocs déplaçables ; sémantique sections encore IA |
 | PDF dense multi-sections | **Moyenne** | Ordre lecture OK ; édition fine = freeform text |
-| PDF scanné / image | **Basse** | Structurel → `None` ; vision seule ; OCR hors MVP |
+| PDF scanné / image | **Refus** | Texte non extractible → 400 UX ; **pas d'OCR** (AXE-328) |
 | DOCX | **Contenu haute / layout nulle** | Pas de positions mm ; sortir (a) ou preset |
 | `.doc` binaire | **Nulle** | Refuser ou convertir avant upload |
 
@@ -106,11 +106,24 @@ Risque produit principal : l’utilisateur attend un clone Canva du PDF ; il fau
 1. Générer les 3 variantes layout à partir d’un import réussi.
 2. Scorer chacune (`score_parsing` ; optionnel `verify-pdf` sur (a)/(c)).
 3. UI chooser Beta (cartes avant / score / « Continuer avec… »).
-4. Refus clair `.doc` + scanned sans OCR (« texte non extractible »).
+4. Refus clair `.doc` + PDF scanné sans OCR (messages UX dédiés).
 
 **Out (V2)**
 
 - OCR, import `.doc`, reconstruction Word mm, mapping freeform → blocs sémantiques complets.
+
+---
+
+## Policy PDF scanné (AXE-328)
+
+| Situation | Comportement MVP |
+|-----------|------------------|
+| PDF sans texte sélectionnable (scanné / image) | **400** + message : pas d'OCR ; demander PDF texte, `.docx`, ou collage texte |
+| PDF avec texte mais `extract_layout_from_pdf` → `None` | **Fallback** : parse IA du texte + vision/preset (pas de copie mm) ; `import_policy.layout_fallback` |
+| PDF natif structurel OK | Copie layout mm (`pdf_structural`) |
+
+Champ API : `import_policy` (`ocr: false`, `layout_mode`, `message` optionnel).  
+Module : `backend/services/pdf_import_policy.py`.
 
 ---
 

--- a/frontend/src/components/OnboardingWizard.jsx
+++ b/frontend/src/components/OnboardingWizard.jsx
@@ -129,7 +129,7 @@ export default function OnboardingWizard({ session, onComplete }) {
                   </svg>
                 </div>
                 <span className="onb-method-title">Importer un CV</span>
-                <span className="onb-method-desc">PDF ou Word - on extrait tout automatiquement</span>
+                <span className="onb-method-desc">PDF texte ou Word (.docx) — pas de PDF scanné</span>
               </button>
 
               <button type="button" className="onb-method-card" onClick={handleManual} disabled={loading}>

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -477,6 +477,7 @@ function CvEditorBeta({
     layoutHints = {},
     visionLayout = null,
     visionMeta = {},
+    importPolicy = null,
     chosenVariant = null,
   } = {}) => {
     const templates = templatesList || [];
@@ -557,6 +558,8 @@ function CvEditorBeta({
         sourceNote = ' · analyse visuelle PDF';
       } else if (visionMeta?.source === 'gemini_vision') {
         sourceNote = ' · vision partielle';
+      } else if (importPolicy?.layout_fallback) {
+        sourceNote = ' · contenu adapté (pas de copie layout PDF)';
       }
       if (importSource === 'structural') {
         setImportToast(`${blockCount} éléments importés${sourceNote}`);
@@ -594,6 +597,7 @@ function CvEditorBeta({
         layoutHints,
         visionLayout,
         visionMeta,
+        importPolicy,
       } = extractImportApiResponse(result);
       const nextCv = cvFromImportPayload(rawCv);
       const templates = templatesList || [];
@@ -619,7 +623,12 @@ function CvEditorBeta({
         mergeBuiltAndScoredVariants(built, scoredRows),
       );
       if (merged.length === 0) {
-        await applyImportedCvToCanvas(nextCv, { layoutHints, visionLayout, visionMeta });
+        await applyImportedCvToCanvas(nextCv, {
+          layoutHints,
+          visionLayout,
+          visionMeta,
+          importPolicy,
+        });
         return;
       }
       setImportChooser({
@@ -627,6 +636,7 @@ function CvEditorBeta({
         variants: merged,
         bestTotal,
         selectedId: defaultImportVariantId(merged),
+        importPolicy,
       });
     } catch (err) {
       setImportError(err?.message || 'Erreur lors de l\'import.');
@@ -644,7 +654,10 @@ function CvEditorBeta({
     if (!importChooser?.cv || !variant?.layout) return;
     setImportChooserConfirming(true);
     try {
-      await applyImportedCvToCanvas(importChooser.cv, { chosenVariant: variant });
+      await applyImportedCvToCanvas(importChooser.cv, {
+        chosenVariant: variant,
+        importPolicy: importChooser.importPolicy,
+      });
     } finally {
       setImportChooserConfirming(false);
     }
@@ -664,6 +677,7 @@ function CvEditorBeta({
       if (designOrDefault?.layout) {
         await applyImportedCvToCanvas(importChooser.cv, {
           chosenVariant: designOrDefault,
+          importPolicy: importChooser.importPolicy,
         });
       } else {
         setImportChooser(null);
@@ -1931,6 +1945,7 @@ function CvEditorBeta({
         variants={importChooser?.variants || []}
         bestTotal={importChooser?.bestTotal}
         initialSelectedId={importChooser?.selectedId || ''}
+        policyNotice={importChooser?.importPolicy?.message || ''}
         confirming={importChooserConfirming}
         onConfirm={handleImportChooserConfirm}
         onCancel={handleImportChooserCancel}

--- a/frontend/src/components/editor/EditorCvImportModal.jsx
+++ b/frontend/src/components/editor/EditorCvImportModal.jsx
@@ -27,9 +27,10 @@ export default function EditorCvImportModal({
             <span className="editor-cv-import-eyebrow">Import intelligent</span>
             <h2 id="editor-cv-import-title">Importer un CV</h2>
             <p>
-              PDF natif (texte sélectionnable) : mise en page recopiée en blocs éditables
-              (texte, couleurs, formes, photo). Word et PDF scanné : extraction du contenu
-              puis adaptation automatique - le rendu peut différer de l&apos;original.
+              PDF natif (texte sélectionnable) : mise en page recopiée en blocs éditables.
+              Word (.docx) : contenu extrait puis adapté. Les PDF scannés (image sans texte)
+              ne sont pas supportés — pas d&apos;OCR pour l&apos;instant ; exporte un PDF texte,
+              un .docx, ou colle le texte.
             </p>
           </div>
           <button type="button" className="editor-cv-import-close" onClick={onClose} aria-label="Fermer">×</button>
@@ -56,7 +57,7 @@ export default function EditorCvImportModal({
               <line x1="12" y1="3" x2="12" y2="15" />
             </svg>
             <strong>Choisir un fichier</strong>
-            <span>PDF ou DOCX — extraction + adaptation canvas en quelques secondes (.doc non supporté)</span>
+            <span>PDF texte ou DOCX — pas de PDF scanné (OCR hors MVP)</span>
           </button>
         </div>
 

--- a/frontend/src/components/editor/EditorImportLayoutChooserModal.jsx
+++ b/frontend/src/components/editor/EditorImportLayoutChooserModal.jsx
@@ -20,6 +20,7 @@ export default function EditorImportLayoutChooserModal({
   variants = [],
   bestTotal = null,
   initialSelectedId = '',
+  policyNotice = '',
   onConfirm,
   onCancel,
   confirming = false,
@@ -65,6 +66,9 @@ export default function EditorImportLayoutChooserModal({
               éditable. Comparez le rendu approximatif et le score ATS, puis
               continuez avec la variante qui vous convient.
             </p>
+            {policyNotice ? (
+              <p className="editor-import-chooser-policy" role="note">{policyNotice}</p>
+            ) : null}
           </div>
           <button
             type="button"

--- a/frontend/src/lib/cvImportUtils.js
+++ b/frontend/src/lib/cvImportUtils.js
@@ -133,7 +133,13 @@ export function applyImportMergeChoices(cv, parsed, choices) {
 /** Extrait CV + layout + hints depuis la réponse API import. */
 export function extractImportApiResponse(result) {
   if (!result || typeof result !== 'object') {
-    return { cv: null, layoutHints: {}, visionLayout: null, visionMeta: {} };
+    return {
+      cv: null,
+      layoutHints: {},
+      visionLayout: null,
+      visionMeta: {},
+      importPolicy: null,
+    };
   }
   const cv = result.cv && typeof result.cv === 'object' ? result.cv : result;
   const layoutHints = result.layout_hints && typeof result.layout_hints === 'object'
@@ -145,7 +151,10 @@ export function extractImportApiResponse(result) {
   const visionMeta = result.vision && typeof result.vision === 'object'
     ? result.vision
     : {};
-  return { cv, layoutHints, visionLayout, visionMeta };
+  const importPolicy = result.import_policy && typeof result.import_policy === 'object'
+    ? result.import_policy
+    : null;
+  return { cv, layoutHints, visionLayout, visionMeta, importPolicy };
 }
 
 /**

--- a/frontend/src/styles/EditorImportLayoutChooserModal.css
+++ b/frontend/src/styles/EditorImportLayoutChooserModal.css
@@ -55,6 +55,16 @@
   color: var(--color-body-muted, #616161);
 }
 
+.editor-import-chooser-policy {
+  margin: 0.55rem 0 0 !important;
+  padding: 0.55rem 0.7rem;
+  border-radius: 8px;
+  border: 1px solid var(--color-hairline, #d9d9dd);
+  background: var(--color-pale-blue, #f1f5ff);
+  color: var(--color-dark-navy, #071829) !important;
+  font-size: 0.8rem !important;
+}
+
 .editor-import-chooser-close {
   flex-shrink: 0;
   width: 2rem;

--- a/frontend/tests/unit/cvImportUtils.test.js
+++ b/frontend/tests/unit/cvImportUtils.test.js
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { extractImportApiResponse } from '../../src/lib/cvImportUtils.js';
+
+test('extractImportApiResponse : import_policy exposé', () => {
+  const result = extractImportApiResponse({
+    cv: { prenom: 'Camille' },
+    layout_hints: { template_match: 'minimal' },
+    layout: null,
+    vision: { source: 'gemini_vision' },
+    import_policy: {
+      ocr: false,
+      layout_fallback: 'text_ai_vision_or_preset',
+      message: 'note policy',
+    },
+  });
+  assert.equal(result.cv.prenom, 'Camille');
+  assert.equal(result.importPolicy?.ocr, false);
+  assert.equal(result.importPolicy?.layout_fallback, 'text_ai_vision_or_preset');
+  assert.equal(result.importPolicy?.message, 'note policy');
+});
+
+test('extractImportApiResponse : sans policy → null', () => {
+  const result = extractImportApiResponse({ cv: { nom: 'Durand' } });
+  assert.equal(result.importPolicy, null);
+});

--- a/tests/test_pdf_import_policy.py
+++ b/tests/test_pdf_import_policy.py
@@ -1,0 +1,86 @@
+"""AXE-328 — policy PDF scanné (refus OCR) + fallback layout."""
+
+from __future__ import annotations
+
+import unittest
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from fastapi import HTTPException
+
+from backend import main
+from backend.services.pdf_import_policy import (
+    LAYOUT_FALLBACK_TEXT_AI,
+    LAYOUT_MODE_STRUCTURAL,
+    PDF_SCANNED_REFUSAL_DETAIL,
+    build_pdf_import_policy,
+    is_insufficient_import_text,
+)
+
+
+def _blank_pdf_bytes() -> bytes:
+    try:
+        import pymupdf as fitz
+    except ImportError:
+        import fitz
+    doc = fitz.open()
+    doc.new_page(width=595, height=842)
+    data = doc.tobytes()
+    doc.close()
+    return data
+
+
+class TestPdfImportPolicyHelpers(unittest.TestCase):
+    def test_insufficient_text(self):
+        self.assertTrue(is_insufficient_import_text(""))
+        self.assertTrue(is_insufficient_import_text("court"))
+        self.assertFalse(is_insufficient_import_text("x" * 50))
+
+    def test_build_policy_structural(self):
+        policy = build_pdf_import_policy(
+            structural_layout={"pages": [{"blocks": [1]}]},
+            vision_meta={},
+        )
+        self.assertFalse(policy["ocr"])
+        self.assertTrue(policy["pdf_native_layout"])
+        self.assertEqual(policy["layout_mode"], LAYOUT_MODE_STRUCTURAL)
+        self.assertIsNone(policy["layout_fallback"])
+        self.assertIsNone(policy["message"])
+
+    def test_build_policy_fallback(self):
+        policy = build_pdf_import_policy(
+            structural_layout=None,
+            vision_meta={"source": "gemini_vision"},
+        )
+        self.assertFalse(policy["ocr"])
+        self.assertFalse(policy["pdf_native_layout"])
+        self.assertEqual(policy["layout_mode"], LAYOUT_FALLBACK_TEXT_AI)
+        self.assertEqual(policy["layout_fallback"], LAYOUT_FALLBACK_TEXT_AI)
+        self.assertTrue(policy["vision_used"])
+        self.assertIn("OCR", policy["message"] or "")
+
+
+class TestApiCvImportScannedPdf(unittest.TestCase):
+    def test_blank_pdf_returns_400_scanned_message(self):
+        req = SimpleNamespace(headers={}, state=SimpleNamespace())
+        upload = MagicMock()
+        upload.filename = "scan.pdf"
+        upload.content_type = "application/pdf"
+        upload.file = BytesIO(_blank_pdf_bytes())
+
+        with (
+            patch.object(main, "_require_user_id"),
+            patch.object(main, "_get_user_id", return_value="user_test"),
+            patch.object(main, "check_rate_limit"),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                main.api_cv_import_file(req, upload)
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(ctx.exception.detail, PDF_SCANNED_REFUSAL_DETAIL)
+        self.assertIn("OCR", ctx.exception.detail)
+        self.assertIn(".docx", ctx.exception.detail)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Refuse scanned / image-only PDFs with a dedicated **400** message (no OCR MVP)
- Keep fallback when text is extractable but structural layout is missing (IA + vision/preset)
- Expose `import_policy` on import response + FE notice in chooser / modal copy
- Short policy section in `docs/axe-41-import-pipeline-spike.md`

## Linear / GitHub
- Linear: https://linear.app/axel-project/issue/AXE-328/improve-policy-pdf-scanne-message-ux-pas-docr-mvp
- Fixes AXE-328
- Closes #88

## Test plan
- [ ] Upload blank/scanned PDF → 400 with OCR / convert message
- [ ] Upload native PDF → structural path unchanged
- [ ] Upload PDF with text but no structural → import succeeds + `import_policy.layout_fallback`
- [ ] `pytest tests/test_pdf_import_policy.py` + FE `cvImportUtils.test.js`


Made with [Cursor](https://cursor.com)