### PR TITLE
Improve: Lier freeform structurel → blocs sémantiques éditables

### DIFF
--- a/docs/axe-41-import-pipeline-spike.md
+++ b/docs/axe-41-import-pipeline-spike.md
@@ -127,6 +127,16 @@ Module : `backend/services/pdf_import_policy.py`.
 
 ---
 
+## Binding sémantique freeform (AXE-329)
+
+Sur `buildStructuralImportLayout`, après sanitize :
+
+- Heuristique FE (`structuralSemanticBind.js`) : titres FR/EN, identité (nom CV + haut de page), contact (email/tél).
+- Confiance ≥ 0.75 → bloc sémantique + `bind` (région titre→prochain titre) ; sinon reste `text` freeform.
+- `layout.freeform` reste `true` (pas de reflow colonne).
+
+---
+
 ## Backlog d'implémentation (tickets enfants)
 
 Créés sous le projet Éditeur / milestone P4, parent [AXE-41](https://linear.app/axel-project/issue/AXE-41) :
@@ -138,7 +148,7 @@ Créés sous le projet Éditeur / milestone P4, parent [AXE-41](https://linear.a
 | [AXE-326](https://linear.app/axel-project/issue/AXE-326) | Feat: UI chooser import Beta (preview + score + confirmation) | High — `EditorImportLayoutChooserModal` |
 | [AXE-327](https://linear.app/axel-project/issue/AXE-327) | Improve: Durcir Word (tables/runs) + refus `.doc` explicite | Medium |
 | [AXE-328](https://linear.app/axel-project/issue/AXE-328) | Improve: Policy PDF scanné — message UX, pas d'OCR MVP | Medium |
-| [AXE-329](https://linear.app/axel-project/issue/AXE-329) | Improve: Lier freeform structurel → blocs sémantiques éditables | Low |
+| [AXE-329](https://linear.app/axel-project/issue/AXE-329) | Improve: Lier freeform structurel → blocs sémantiques éditables | Low — `frontend/src/lib/structuralSemanticBind.js` |
 
 ---
 

--- a/frontend/src/lib/canvasCvImportAdapter.js
+++ b/frontend/src/lib/canvasCvImportAdapter.js
@@ -33,6 +33,7 @@ import {
   resolvePhotoUrl,
   resolveProjets,
 } from './freeCanvasContent.js';
+import { bindStructuralTextToSemanticBlocks } from './structuralSemanticBind.js';
 
 const DECORATIVE_TYPES = new Set(['shape:rect', 'shape:line']);
 
@@ -1022,7 +1023,9 @@ export function buildStructuralImportLayout(cv, structuralLayout, { templateId =
   // `freeform` : positions absolues figées (cf. reflow/pagination) → copie
   // fidèle du PDF, jamais ré-empilée en colonnes par l'auto-height.
   const sanitized = sanitizeLayoutV3({ ...structuralLayout, freeform: true });
-  const layout = applyLayoutPagination(sanitized);
+  // AXE-329 : titres / identité / contact → blocs sémantiques si confiance haute.
+  const { layout: boundLayout } = bindStructuralTextToSemanticBlocks(sanitized, cv);
+  const layout = applyLayoutPagination(boundLayout);
   // Python extrait les couleurs thème directement depuis page.get_drawings()
   // (fiable quel que soit le chemin de rendu). Le JS n'intervient qu'en
   // fallback pour les couleurs que Python n'a pas trouvées.

--- a/frontend/src/lib/structuralSemanticBind.js
+++ b/frontend/src/lib/structuralSemanticBind.js
@@ -9,39 +9,39 @@ import { createCvSectionBlockPreset } from './canvasCvSectionPresets.js';
 
 export const MIN_SEMANTIC_CONFIDENCE = 0.75;
 
-/** Patterns titres (alignés sur `cv_import_probe.SECTION_HEADING_PATTERNS`). */
+/** Patterns titres : ligne entière ≈ libellé de section (évite faux positifs corps). */
 const SECTION_HEADING_RULES = Object.freeze([
   {
     type: 'experiences',
-    re: /(?:^|[\s|/·•\-–—])(exp[ée]riences?(?:\s+professionnelles?)?|experience|work\s+history|employment)\b/i,
+    re: /^(?:[\s|/·•\-–—]*)(exp[ée]riences?(?:\s+professionnelles?)?|experience|work\s+history|employment)\s*$/i,
   },
   {
     type: 'formations',
-    re: /(?:^|[\s|/·•\-–—])(formations?|education|études|etudes|dipl[oô]mes?)\b/i,
+    re: /^(?:[\s|/·•\-–—]*)(formations?|education|études|etudes|dipl[oô]mes?)\s*$/i,
   },
   {
     type: 'skills',
-    re: /(?:^|[\s|/·•\-–—])(comp[ée]tences?|skills?|technologies?|outils?)\b/i,
+    re: /^(?:[\s|/·•\-–—]*)(comp[ée]tences?|skills?|technologies?|outils?)\s*$/i,
   },
   {
     type: 'languages',
-    re: /(?:^|[\s|/·•\-–—])(langues?|languages?)\b/i,
+    re: /^(?:[\s|/·•\-–—]*)(langues?|languages?)\s*$/i,
   },
   {
     type: 'certifications',
-    re: /(?:^|[\s|/·•\-–—])(certifications?|accreditations?)\b/i,
+    re: /^(?:[\s|/·•\-–—]*)(certifications?|accreditations?)\s*$/i,
   },
   {
     type: 'projets',
-    re: /(?:^|[\s|/·•\-–—])(projets?|projects?|réalisations?|realisations?)\b/i,
+    re: /^(?:[\s|/·•\-–—]*)(projets?|projects?|réalisations?|realisations?)\s*$/i,
   },
   {
     type: 'resume',
-    re: /(?:^|[\s|/·•\-–—])(profil|r[ée]sum[ée]|summary|about|à propos|a propos)\b/i,
+    re: /^(?:[\s|/·•\-–—]*)(profil|r[ée]sum[ée]|summary|about|à propos|a propos)\s*$/i,
   },
   {
     type: 'contact',
-    re: /(?:^|[\s|/·•\-–—])(contact|coordonn[ée]es)\b/i,
+    re: /^(?:[\s|/·•\-–—]*)(contact|coordonn[ée]es)\s*$/i,
   },
 ]);
 
@@ -77,16 +77,18 @@ export function decodeStructuralText(content) {
   return decoded.replace(/\s+/g, ' ').trim();
 }
 
-function sameColumn(a, b) {
-  const ax = Number(a.x) || 0;
-  const aw = Number(a.w) || 0;
-  const bx = Number(b.x) || 0;
-  const bw = Number(b.w) || 0;
-  const left = Math.max(ax, bx);
-  const right = Math.min(ax + aw, bx + bw);
+function sameColumn(head, body) {
+  // Corps majoritairement sous la bande du titre, sans démarrer à gauche (sidebar).
+  const hx = Number(head.x) || 0;
+  const hw = Number(head.w) || 0;
+  const bx = Number(body.x) || 0;
+  const bw = Number(body.w) || 0;
+  if (bx < hx - 5) return false;
+  if (bx > hx + hw + 5) return false;
+  const left = Math.max(hx, bx);
+  const right = Math.min(hx + hw, bx + bw);
   const overlap = Math.max(0, right - left);
-  const minW = Math.max(1, Math.min(aw, bw));
-  return overlap / minW >= 0.35;
+  return overlap / Math.max(1, bw) >= 0.5;
 }
 
 function unionBox(blocks) {
@@ -123,23 +125,22 @@ export function classifyStructuralTextBlock(block, cv = {}, { pageHeightMm = 297
   const text = decodeStructuralText(block.content);
   if (!text) return null;
 
-  // Titres de section (courts).
-  if (text.length <= 80) {
-    const hay = ` ${text}`;
+  // Titres : ligne entière = libellé (pas un mot-clé dans une phrase corps).
+  if (text.length <= 48) {
     for (const rule of SECTION_HEADING_RULES) {
-      if (rule.re.test(hay)) {
-        const bold = Boolean(block.style?.bold);
-        const fontSize = Number(block.style?.font_size) || 0;
-        let confidence = 0.82;
-        if (bold || fontSize >= 11) confidence += 0.1;
-        if (text.length <= 40) confidence += 0.05;
-        return {
-          type: rule.type,
-          confidence: Math.min(1, confidence),
-          kind: 'heading',
-          sectionLabel: text.toUpperCase(),
-        };
-      }
+      if (!rule.re.test(text)) continue;
+      const bold = Boolean(block.style?.bold);
+      const fontSize = Number(block.style?.font_size) || 0;
+      let confidence = 0.55;
+      if (bold) confidence += 0.2;
+      if (fontSize >= 11) confidence += 0.15;
+      if (text.length <= 32) confidence += 0.1;
+      return {
+        type: rule.type,
+        confidence: Math.min(1, confidence),
+        kind: 'heading',
+        sectionLabel: text.toUpperCase(),
+      };
     }
   }
 
@@ -192,13 +193,15 @@ function toSemanticBlock(baseBlock, classification, regionBlocks) {
   if (classification.sectionLabel) {
     style.section_label = classification.sectionLabel;
   }
+  // Hauteur = bbox freeform uniquement (pas preset.h) pour ne pas chevaucher
+  // les sections suivantes en layout freeform sans reflow.
   const out = {
     id: baseBlock.id,
     type: preset.type,
     x: box.x,
     y: box.y,
     w: box.w,
-    h: Math.max(box.h, Number(preset.h) || 12),
+    h: box.h,
     z: box.z,
     style,
   };
@@ -255,9 +258,11 @@ export function bindStructuralTextToSemanticBlocks(layout, cv = {}, {
       for (let j = i + 1; j < textBlocks.length; j += 1) {
         const next = textBlocks[j];
         if (consumed.has(next.id)) continue;
-        const nextCls = classifications.get(next.id);
-        if (nextCls?.kind === 'heading') break;
+        // Autre colonne : ignorer (ne pas stopper la région).
         if (!sameColumn(head, next)) continue;
+        const nextCls = classifications.get(next.id);
+        // Prochain titre *dans la même colonne* → fin de région.
+        if (nextCls?.kind === 'heading') break;
         // Trop loin verticalement → autre zone.
         const gap = (Number(next.y) || 0) - ((Number(region[region.length - 1].y) || 0)
           + (Number(region[region.length - 1].h) || 0));

--- a/frontend/src/lib/structuralSemanticBind.js
+++ b/frontend/src/lib/structuralSemanticBind.js
@@ -1,0 +1,286 @@
+/**
+ * AXE-329 — lie les blocs texte freeform d'un import structurel PDF
+ * vers des types sémantiques éditables (identity, experiences, …).
+ *
+ * Heuristique pure (pas d'IA) : confiance basse → le bloc reste `text`.
+ */
+
+import { createCvSectionBlockPreset } from './canvasCvSectionPresets.js';
+
+export const MIN_SEMANTIC_CONFIDENCE = 0.75;
+
+/** Patterns titres (alignés sur `cv_import_probe.SECTION_HEADING_PATTERNS`). */
+const SECTION_HEADING_RULES = Object.freeze([
+  {
+    type: 'experiences',
+    re: /(?:^|[\s|/·•\-–—])(exp[ée]riences?(?:\s+professionnelles?)?|experience|work\s+history|employment)\b/i,
+  },
+  {
+    type: 'formations',
+    re: /(?:^|[\s|/·•\-–—])(formations?|education|études|etudes|dipl[oô]mes?)\b/i,
+  },
+  {
+    type: 'skills',
+    re: /(?:^|[\s|/·•\-–—])(comp[ée]tences?|skills?|technologies?|outils?)\b/i,
+  },
+  {
+    type: 'languages',
+    re: /(?:^|[\s|/·•\-–—])(langues?|languages?)\b/i,
+  },
+  {
+    type: 'certifications',
+    re: /(?:^|[\s|/·•\-–—])(certifications?|accreditations?)\b/i,
+  },
+  {
+    type: 'projets',
+    re: /(?:^|[\s|/·•\-–—])(projets?|projects?|réalisations?|realisations?)\b/i,
+  },
+  {
+    type: 'resume',
+    re: /(?:^|[\s|/·•\-–—])(profil|r[ée]sum[ée]|summary|about|à propos|a propos)\b/i,
+  },
+  {
+    type: 'contact',
+    re: /(?:^|[\s|/·•\-–—])(contact|coordonn[ée]es)\b/i,
+  },
+]);
+
+const EMAIL_RE = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i;
+const PHONE_RE = /(?:\+?\d[\d\s().-]{7,}\d)/;
+
+export function decodeStructuralText(content) {
+  return String(content || '')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function sameColumn(a, b) {
+  const ax = Number(a.x) || 0;
+  const aw = Number(a.w) || 0;
+  const bx = Number(b.x) || 0;
+  const bw = Number(b.w) || 0;
+  const left = Math.max(ax, bx);
+  const right = Math.min(ax + aw, bx + bw);
+  const overlap = Math.max(0, right - left);
+  const minW = Math.max(1, Math.min(aw, bw));
+  return overlap / minW >= 0.35;
+}
+
+function unionBox(blocks) {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  let z = 1;
+  for (const b of blocks) {
+    const x = Number(b.x) || 0;
+    const y = Number(b.y) || 0;
+    const w = Number(b.w) || 0;
+    const h = Number(b.h) || 0;
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    maxX = Math.max(maxX, x + w);
+    maxY = Math.max(maxY, y + h);
+    z = Math.max(z, Number(b.z) || 1);
+  }
+  return {
+    x: minX,
+    y: minY,
+    w: Math.max(8, maxX - minX),
+    h: Math.max(6, maxY - minY),
+    z,
+  };
+}
+
+/**
+ * @returns {{ type: string, confidence: number, kind: string, sectionLabel?: string } | null}
+ */
+export function classifyStructuralTextBlock(block, cv = {}, { pageHeightMm = 297 } = {}) {
+  if (!block || block.type !== 'text') return null;
+  const text = decodeStructuralText(block.content);
+  if (!text) return null;
+
+  // Titres de section (courts).
+  if (text.length <= 80) {
+    const hay = ` ${text}`;
+    for (const rule of SECTION_HEADING_RULES) {
+      if (rule.re.test(hay)) {
+        const bold = Boolean(block.style?.bold);
+        const fontSize = Number(block.style?.font_size) || 0;
+        let confidence = 0.82;
+        if (bold || fontSize >= 11) confidence += 0.1;
+        if (text.length <= 40) confidence += 0.05;
+        return {
+          type: rule.type,
+          confidence: Math.min(1, confidence),
+          kind: 'heading',
+          sectionLabel: text.toUpperCase(),
+        };
+      }
+    }
+  }
+
+  // Identité : nom/prénom CV + haut de page + emphase.
+  const prenom = String(cv?.prenom || '').trim().toLowerCase();
+  const nom = String(cv?.nom || '').trim().toLowerCase();
+  if (prenom || nom) {
+    const lower = text.toLowerCase();
+    const hasPrenom = prenom && lower.includes(prenom);
+    const hasNom = nom && lower.includes(nom);
+    if (hasPrenom || hasNom) {
+      const y = Number(block.y) || 0;
+      const fontSize = Number(block.style?.font_size) || 0;
+      const bold = Boolean(block.style?.bold);
+      let confidence = 0.45;
+      if (y < pageHeightMm * 0.32) confidence += 0.25;
+      if (fontSize >= 14 || bold) confidence += 0.2;
+      if (hasPrenom && hasNom) confidence += 0.15;
+      if (confidence >= MIN_SEMANTIC_CONFIDENCE) {
+        return { type: 'identity', confidence: Math.min(1, confidence), kind: 'identity' };
+      }
+    }
+  }
+
+  // Contact : email / téléphone.
+  let contactConf = 0;
+  if (EMAIL_RE.test(text)) contactConf += 0.55;
+  if (PHONE_RE.test(text)) contactConf += 0.35;
+  const cvEmail = String(cv?.email || '').trim().toLowerCase();
+  if (cvEmail && text.toLowerCase().includes(cvEmail)) contactConf += 0.2;
+  if (contactConf >= MIN_SEMANTIC_CONFIDENCE) {
+    return { type: 'contact', confidence: Math.min(1, contactConf), kind: 'contact' };
+  }
+
+  return null;
+}
+
+function toSemanticBlock(baseBlock, classification, regionBlocks) {
+  const preset = createCvSectionBlockPreset(classification.type);
+  if (!preset) return null;
+  const box = unionBox(regionBlocks.length ? regionBlocks : [baseBlock]);
+  const style = {
+    ...(preset.style || {}),
+    ...(baseBlock.style && typeof baseBlock.style === 'object' ? {
+      color: baseBlock.style.color,
+      font_family: baseBlock.style.font_family,
+      align: baseBlock.style.align || preset.style?.align,
+    } : {}),
+  };
+  if (classification.sectionLabel) {
+    style.section_label = classification.sectionLabel;
+  }
+  const out = {
+    id: baseBlock.id,
+    type: preset.type,
+    x: box.x,
+    y: box.y,
+    w: box.w,
+    h: Math.max(box.h, Number(preset.h) || 12),
+    z: box.z,
+    style,
+  };
+  if (preset.bind !== undefined) {
+    out.bind = Array.isArray(preset.bind) ? [...preset.bind] : preset.bind;
+  }
+  return out;
+}
+
+/**
+ * Applique le binding sémantique sur un layout structurel freeform.
+ * @returns {{ layout: object, boundCount: number, skippedLowConfidence: number }}
+ */
+export function bindStructuralTextToSemanticBlocks(layout, cv = {}, {
+  minConfidence = MIN_SEMANTIC_CONFIDENCE,
+} = {}) {
+  if (!layout || !Array.isArray(layout.pages)) {
+    return { layout, boundCount: 0, skippedLowConfidence: 0 };
+  }
+
+  let boundCount = 0;
+  let skippedLowConfidence = 0;
+
+  const pages = layout.pages.map((page) => {
+    const blocks = Array.isArray(page?.blocks) ? page.blocks : [];
+    const textBlocks = blocks
+      .filter((b) => b?.type === 'text')
+      .slice()
+      .sort((a, b) => (Number(a.y) - Number(b.y)) || (Number(a.x) - Number(b.x)));
+
+    const classifications = new Map();
+    for (const block of textBlocks) {
+      const hit = classifyStructuralTextBlock(block, cv);
+      if (!hit) continue;
+      if (hit.confidence < minConfidence) {
+        skippedLowConfidence += 1;
+        continue;
+      }
+      classifications.set(block.id, hit);
+    }
+
+    const consumed = new Set();
+    const semanticNew = [];
+
+    // 1) Titres → région jusqu'au prochain titre (même colonne).
+    for (let i = 0; i < textBlocks.length; i += 1) {
+      const head = textBlocks[i];
+      if (consumed.has(head.id)) continue;
+      const cls = classifications.get(head.id);
+      if (!cls || cls.kind !== 'heading') continue;
+
+      const region = [head];
+      consumed.add(head.id);
+      for (let j = i + 1; j < textBlocks.length; j += 1) {
+        const next = textBlocks[j];
+        if (consumed.has(next.id)) continue;
+        const nextCls = classifications.get(next.id);
+        if (nextCls?.kind === 'heading') break;
+        if (!sameColumn(head, next)) continue;
+        // Trop loin verticalement → autre zone.
+        const gap = (Number(next.y) || 0) - ((Number(region[region.length - 1].y) || 0)
+          + (Number(region[region.length - 1].h) || 0));
+        if (gap > 28) break;
+        region.push(next);
+        consumed.add(next.id);
+      }
+
+      const semantic = toSemanticBlock(head, cls, region);
+      if (semantic) {
+        semanticNew.push(semantic);
+        boundCount += 1;
+      } else {
+        region.forEach((b) => consumed.delete(b.id));
+      }
+    }
+
+    // 2) Identité / contact (blocs isolés, non déjà absorbés).
+    for (const block of textBlocks) {
+      if (consumed.has(block.id)) continue;
+      const cls = classifications.get(block.id);
+      if (!cls || (cls.kind !== 'identity' && cls.kind !== 'contact')) continue;
+      const semantic = toSemanticBlock(block, cls, [block]);
+      if (!semantic) continue;
+      consumed.add(block.id);
+      semanticNew.push(semantic);
+      boundCount += 1;
+    }
+
+    const kept = blocks.filter((b) => !consumed.has(b.id));
+    return {
+      ...page,
+      blocks: [...kept, ...semanticNew],
+    };
+  });
+
+  return {
+    layout: { ...layout, pages, freeform: true },
+    boundCount,
+    skippedLowConfidence,
+  };
+}

--- a/frontend/src/lib/structuralSemanticBind.js
+++ b/frontend/src/lib/structuralSemanticBind.js
@@ -49,16 +49,32 @@ const EMAIL_RE = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i;
 const PHONE_RE = /(?:\+?\d[\d\s().-]{7,}\d)/;
 
 export function decodeStructuralText(content) {
-  return String(content || '')
-    .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
-    .replace(/\s+/g, ' ')
-    .trim();
+  // Une seule passe : éviter le double-unescape CodeQL
+  // (`&amp;lt;` ne doit pas devenir `<`).
+  const decoded = String(content || '').replace(
+    /&(#(?:x[0-9a-f]+|\d+)|[a-z]+);/gi,
+    (entity) => {
+      const lower = entity.toLowerCase();
+      if (lower === '&nbsp;') return ' ';
+      if (lower === '&amp;') return '&';
+      if (lower === '&lt;') return '<';
+      if (lower === '&gt;') return '>';
+      if (lower === '&quot;') return '"';
+      if (lower === '&#39;' || lower === '&apos;') return "'";
+      const dec = /^&#(\d+);$/.exec(entity);
+      if (dec) {
+        const code = Number(dec[1]);
+        if (code > 0 && code < 0x110000) return String.fromCharCode(code);
+      }
+      const hex = /^&#x([0-9a-f]+);$/i.exec(entity);
+      if (hex) {
+        const code = parseInt(hex[1], 16);
+        if (code > 0 && code < 0x110000) return String.fromCharCode(code);
+      }
+      return entity;
+    },
+  );
+  return decoded.replace(/\s+/g, ' ').trim();
 }
 
 function sameColumn(a, b) {

--- a/frontend/src/lib/structuralSemanticBind.js
+++ b/frontend/src/lib/structuralSemanticBind.js
@@ -13,35 +13,35 @@ export const MIN_SEMANTIC_CONFIDENCE = 0.75;
 const SECTION_HEADING_RULES = Object.freeze([
   {
     type: 'experiences',
-    re: /^(?:[\s|/·•\-–—]*)(exp[ée]riences?(?:\s+professionnelles?)?|experience|work\s+history|employment)\s*$/i,
+    re: /^(?:[\s|/·•\-–—]*)((?:work|professional)\s+experiences?|exp[ée]riences?(?:\s+professionnelles?)?|work\s+history|employment)\s*[:.]?\s*$/i,
   },
   {
     type: 'formations',
-    re: /^(?:[\s|/·•\-–—]*)(formations?|education|études|etudes|dipl[oô]mes?)\s*$/i,
+    re: /^(?:[\s|/·•\-–—]*)(formations?|education|études|etudes|dipl[oô]mes?)\s*[:.]?\s*$/i,
   },
   {
     type: 'skills',
-    re: /^(?:[\s|/·•\-–—]*)(comp[ée]tences?|skills?|technologies?|outils?)\s*$/i,
+    re: /^(?:[\s|/·•\-–—]*)(comp[ée]tences?|skills?|technologies?|outils?)\s*[:.]?\s*$/i,
   },
   {
     type: 'languages',
-    re: /^(?:[\s|/·•\-–—]*)(langues?|languages?)\s*$/i,
+    re: /^(?:[\s|/·•\-–—]*)(langues?|languages?)\s*[:.]?\s*$/i,
   },
   {
     type: 'certifications',
-    re: /^(?:[\s|/·•\-–—]*)(certifications?|accreditations?)\s*$/i,
+    re: /^(?:[\s|/·•\-–—]*)(certifications?|accreditations?)\s*[:.]?\s*$/i,
   },
   {
     type: 'projets',
-    re: /^(?:[\s|/·•\-–—]*)(projets?|projects?|réalisations?|realisations?)\s*$/i,
+    re: /^(?:[\s|/·•\-–—]*)(projets?|projects?|réalisations?|realisations?)\s*[:.]?\s*$/i,
   },
   {
     type: 'resume',
-    re: /^(?:[\s|/·•\-–—]*)(profil|r[ée]sum[ée]|summary|about|à propos|a propos)\s*$/i,
+    re: /^(?:[\s|/·•\-–—]*)(profil|r[ée]sum[ée]|summary|about|à propos|a propos)\s*[:.]?\s*$/i,
   },
   {
     type: 'contact',
-    re: /^(?:[\s|/·•\-–—]*)(contact|coordonn[ée]es)\s*$/i,
+    re: /^(?:[\s|/·•\-–—]*)(contact|coordonn[ée]es)\s*[:.]?\s*$/i,
   },
 ]);
 
@@ -78,17 +78,14 @@ export function decodeStructuralText(content) {
 }
 
 function sameColumn(head, body) {
-  // Corps majoritairement sous la bande du titre, sans démarrer à gauche (sidebar).
+  // Les titres PDF ont souvent un `w` = largeur glyphes (ex. « Formation » ~35mm)
+  // alors que le corps est plus large : on aligne sur le bord gauche, pas sur `w`.
   const hx = Number(head.x) || 0;
-  const hw = Number(head.w) || 0;
   const bx = Number(body.x) || 0;
-  const bw = Number(body.w) || 0;
-  if (bx < hx - 5) return false;
-  if (bx > hx + hw + 5) return false;
-  const left = Math.max(hx, bx);
-  const right = Math.min(hx + hw, bx + bw);
-  const overlap = Math.max(0, right - left);
-  return overlap / Math.max(1, bw) >= 0.5;
+  // Sidebar : démarre nettement à gauche du titre.
+  if (bx < hx - 8) return false;
+  // Même colonne : bords gauches proches, ou corps légèrement indenté sous le titre.
+  return Math.abs(bx - hx) <= 14 || (bx >= hx - 2 && bx <= hx + 28);
 }
 
 function unionBox(blocks) {

--- a/frontend/tests/unit/canvasCvImportAdapter.test.js
+++ b/frontend/tests/unit/canvasCvImportAdapter.test.js
@@ -155,9 +155,57 @@ test('buildStructuralImportLayout : copie fidèle, aucun preset', () => {
   assert.equal(title.style.bold, true);
 });
 
-test('buildStructuralImportLayout : marque le layout freeform (pas de reflow)', () => {
-  const result = buildStructuralImportLayout(DENSE_CV, STRUCTURAL_LAYOUT, { templateId: '' });
+test('buildStructuralImportLayout : lie titres freeform → blocs sémantiques (AXE-329)', () => {
+  const structural = {
+    version: 3,
+    format: 'A4',
+    grid: 'free',
+    unit: 'mm',
+    source: 'pdf_structural',
+    pages: [{
+      id: 'page_1',
+      blocks: [
+        {
+          type: 'text',
+          content: 'Marie Martin',
+          x: 20,
+          y: 16,
+          w: 90,
+          h: 8,
+          z: 3,
+          style: { font_size: 18, bold: true },
+        },
+        {
+          type: 'text',
+          content: 'Expérience professionnelle',
+          x: 20,
+          y: 70,
+          w: 100,
+          h: 6,
+          z: 3,
+          style: { font_size: 12, bold: true },
+        },
+        {
+          type: 'text',
+          content: 'Head of Growth — ScaleUp',
+          x: 20,
+          y: 80,
+          w: 110,
+          h: 5,
+          z: 3,
+          style: {},
+        },
+      ],
+    }],
+    theme: { template_id: 'imported' },
+  };
+  const result = buildStructuralImportLayout(DENSE_CV, structural, { templateId: 'minimal' });
+  assert.equal(result.importSource, 'structural');
   assert.equal(result.layout.freeform, true);
+  const blocks = result.layout.pages[0].blocks;
+  assert.ok(blocks.some((b) => b.type === 'identity' && Array.isArray(b.bind)));
+  assert.ok(blocks.some((b) => b.type === 'experiences' && b.bind === 'experiences'));
+  assert.equal(blocks.some((b) => b.type === 'text' && String(b.content || '').includes('Head of Growth')), false);
 });
 
 test('applyImportedRoundImageShapes : anneau vectoriel → image en cercle', () => {

--- a/frontend/tests/unit/structuralSemanticBind.test.js
+++ b/frontend/tests/unit/structuralSemanticBind.test.js
@@ -12,6 +12,8 @@ import {
 test('decodeStructuralText décode entités HTML', () => {
   assert.equal(decodeStructuralText('A &amp; B'), 'A & B');
   assert.equal(decodeStructuralText('  Exp&#233;rience  '), 'Expérience');
+  // Pas de double-unescape : &amp;lt; reste &lt; littéral après une passe.
+  assert.equal(decodeStructuralText('&amp;lt;'), '&lt;');
 });
 
 test('classifyStructuralTextBlock : titre expérience haute confiance', () => {

--- a/frontend/tests/unit/structuralSemanticBind.test.js
+++ b/frontend/tests/unit/structuralSemanticBind.test.js
@@ -29,19 +29,61 @@ test('classifyStructuralTextBlock : corps avec mot-clé → null (pas faux titre
   assert.equal(hit, null);
 });
 
-test('classifyStructuralTextBlock : titre expérience haute confiance', () => {
+test('classifyStructuralTextBlock : Work Experience + ponctuation', () => {
   const hit = classifyStructuralTextBlock({
     type: 'text',
-    content: 'Expérience professionnelle',
+    content: 'Work Experience:',
     x: 20,
     y: 80,
-    w: 100,
+    w: 55,
     h: 6,
     style: { bold: true, font_size: 12 },
   });
   assert.equal(hit?.type, 'experiences');
-  assert.equal(hit?.kind, 'heading');
   assert.ok(hit.confidence >= MIN_SEMANTIC_CONFIDENCE);
+});
+
+test('bindStructuralTextToSemanticBlocks : titre court absorbe corps plus large', () => {
+  const layout = sanitizeLayoutV3({
+    version: 3,
+    format: 'A4',
+    grid: 'free',
+    unit: 'mm',
+    freeform: true,
+    pages: [{
+      id: 'p1',
+      blocks: [
+        {
+          id: 'h1',
+          type: 'text',
+          content: 'Formation',
+          x: 20,
+          y: 100,
+          w: 32,
+          h: 6,
+          z: 2,
+          style: { bold: true, font_size: 12 },
+        },
+        {
+          id: 'b1',
+          type: 'text',
+          content: 'Master Management — Universite Lyon (2018)',
+          x: 20,
+          y: 110,
+          w: 120,
+          h: 5,
+          z: 2,
+          style: {},
+        },
+      ],
+    }],
+  });
+  const { layout: out, boundCount } = bindStructuralTextToSemanticBlocks(layout, {});
+  assert.equal(boundCount, 1);
+  const form = out.pages[0].blocks.find((b) => b.type === 'formations');
+  assert.ok(form);
+  assert.ok(form.h >= 14, `h=${form.h}`);
+  assert.equal(out.pages[0].blocks.some((b) => b.id === 'b1'), false);
 });
 
 test('classifyStructuralTextBlock : corps long → null (pas de faux positif)', () => {

--- a/frontend/tests/unit/structuralSemanticBind.test.js
+++ b/frontend/tests/unit/structuralSemanticBind.test.js
@@ -16,6 +16,19 @@ test('decodeStructuralText décode entités HTML', () => {
   assert.equal(decodeStructuralText('&amp;lt;'), '&lt;');
 });
 
+test('classifyStructuralTextBlock : corps avec mot-clé → null (pas faux titre)', () => {
+  const hit = classifyStructuralTextBlock({
+    type: 'text',
+    content: 'Mon expérience récente chez NovaSoft',
+    x: 20,
+    y: 100,
+    w: 120,
+    h: 5,
+    style: { font_size: 10 },
+  });
+  assert.equal(hit, null);
+});
+
 test('classifyStructuralTextBlock : titre expérience haute confiance', () => {
   const hit = classifyStructuralTextBlock({
     type: 'text',
@@ -176,11 +189,81 @@ test('bindStructuralTextToSemanticBlocks : heading + corps → experiences, free
   const form = blocks.find((b) => b.type === 'formations');
   assert.ok(exp);
   assert.equal(exp.bind, 'experiences');
-  assert.ok(exp.h >= 18);
+  // Hauteur = bbox freeform (pas preset 80mm) pour éviter le chevauchement.
+  assert.ok(exp.h >= 18 && exp.h < 40, `h inattendu: ${exp.h}`);
   assert.ok(form);
   assert.equal(form.bind, 'formations');
   assert.equal(blocks.some((b) => b.id === 'b1'), false);
   assert.equal(blocks.some((b) => b.type === 'text' && b.content === 'Product Manager — NovaSoft'), false);
+});
+
+test('bindStructuralTextToSemanticBlocks : ignore sidebar d\'une autre colonne', () => {
+  const layout = sanitizeLayoutV3({
+    version: 3,
+    format: 'A4',
+    grid: 'free',
+    unit: 'mm',
+    freeform: true,
+    pages: [{
+      id: 'p1',
+      blocks: [
+        {
+          id: 'h1',
+          type: 'text',
+          content: 'Expérience professionnelle',
+          x: 70,
+          y: 40,
+          w: 110,
+          h: 6,
+          z: 2,
+          style: { bold: true, font_size: 12 },
+        },
+        {
+          id: 'main1',
+          type: 'text',
+          content: 'PM — NovaSoft',
+          x: 70,
+          y: 50,
+          w: 100,
+          h: 5,
+          z: 2,
+          style: {},
+        },
+        {
+          id: 'side1',
+          type: 'text',
+          content: 'SQL, Python',
+          x: 8,
+          y: 52,
+          w: 50,
+          h: 5,
+          z: 2,
+          style: {},
+        },
+        {
+          id: 'hSide',
+          type: 'text',
+          content: 'Compétences',
+          x: 8,
+          y: 40,
+          w: 50,
+          h: 6,
+          z: 2,
+          style: { bold: true, font_size: 11 },
+        },
+      ],
+    }],
+  });
+  const { layout: out } = bindStructuralTextToSemanticBlocks(layout, {});
+  const blocks = out.pages[0].blocks;
+  const exp = blocks.find((b) => b.type === 'experiences');
+  const skills = blocks.find((b) => b.type === 'skills');
+  assert.ok(exp);
+  assert.ok(skills);
+  // Sidebar non avalée par le titre main.
+  assert.ok(exp.w < 130);
+  assert.equal(blocks.some((b) => b.id === 'side1'), false);
+  assert.ok((skills.h || 0) >= 10);
 });
 
 test('bindStructuralTextToSemanticBlocks : confiance basse → freeform inchangé', () => {

--- a/frontend/tests/unit/structuralSemanticBind.test.js
+++ b/frontend/tests/unit/structuralSemanticBind.test.js
@@ -1,0 +1,216 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { sanitizeLayoutV3 } from '../../src/lib/cvLayoutModelV3.js';
+import {
+  MIN_SEMANTIC_CONFIDENCE,
+  bindStructuralTextToSemanticBlocks,
+  classifyStructuralTextBlock,
+  decodeStructuralText,
+} from '../../src/lib/structuralSemanticBind.js';
+
+test('decodeStructuralText décode entités HTML', () => {
+  assert.equal(decodeStructuralText('A &amp; B'), 'A & B');
+  assert.equal(decodeStructuralText('  Exp&#233;rience  '), 'Expérience');
+});
+
+test('classifyStructuralTextBlock : titre expérience haute confiance', () => {
+  const hit = classifyStructuralTextBlock({
+    type: 'text',
+    content: 'Expérience professionnelle',
+    x: 20,
+    y: 80,
+    w: 100,
+    h: 6,
+    style: { bold: true, font_size: 12 },
+  });
+  assert.equal(hit?.type, 'experiences');
+  assert.equal(hit?.kind, 'heading');
+  assert.ok(hit.confidence >= MIN_SEMANTIC_CONFIDENCE);
+});
+
+test('classifyStructuralTextBlock : corps long → null (pas de faux positif)', () => {
+  const hit = classifyStructuralTextBlock({
+    type: 'text',
+    content: 'J\'ai beaucoup d\'expérience professionnelle dans le secteur mais ce n\'est pas un titre de section.',
+    x: 20,
+    y: 100,
+    w: 120,
+    h: 10,
+    style: {},
+  });
+  assert.equal(hit, null);
+});
+
+test('classifyStructuralTextBlock : identité si nom CV + haut de page', () => {
+  const hit = classifyStructuralTextBlock(
+    {
+      type: 'text',
+      content: 'Camille Durand',
+      x: 20,
+      y: 18,
+      w: 80,
+      h: 8,
+      style: { bold: true, font_size: 18 },
+    },
+    { prenom: 'Camille', nom: 'Durand' },
+  );
+  assert.equal(hit?.type, 'identity');
+  assert.ok(hit.confidence >= MIN_SEMANTIC_CONFIDENCE);
+});
+
+test('classifyStructuralTextBlock : identité faible confiance si bas de page', () => {
+  const hit = classifyStructuralTextBlock(
+    {
+      type: 'text',
+      content: 'Camille',
+      x: 20,
+      y: 250,
+      w: 40,
+      h: 5,
+      style: { font_size: 10 },
+    },
+    { prenom: 'Camille', nom: 'Durand' },
+  );
+  assert.equal(hit, null);
+});
+
+test('classifyStructuralTextBlock : contact via email', () => {
+  const hit = classifyStructuralTextBlock(
+    {
+      type: 'text',
+      content: 'camille.durand@example.fr | +33 6 11 22 33 44',
+      x: 20,
+      y: 40,
+      w: 120,
+      h: 5,
+      style: {},
+    },
+    { email: 'camille.durand@example.fr' },
+  );
+  assert.equal(hit?.type, 'contact');
+  assert.ok(hit.confidence >= MIN_SEMANTIC_CONFIDENCE);
+});
+
+test('bindStructuralTextToSemanticBlocks : heading + corps → experiences, freeform conservé', () => {
+  const layout = sanitizeLayoutV3({
+    version: 3,
+    format: 'A4',
+    grid: 'free',
+    unit: 'mm',
+    freeform: true,
+    pages: [{
+      id: 'p1',
+      blocks: [
+        { id: 'shape', type: 'shape:rect', x: 0, y: 0, w: 10, h: 297, z: 0, style: { color: '#003c33' } },
+        {
+          id: 'h1',
+          type: 'text',
+          content: 'Expérience professionnelle',
+          x: 20,
+          y: 60,
+          w: 100,
+          h: 6,
+          z: 2,
+          style: { bold: true, font_size: 12 },
+        },
+        {
+          id: 'b1',
+          type: 'text',
+          content: 'Product Manager — NovaSoft',
+          x: 20,
+          y: 70,
+          w: 110,
+          h: 5,
+          z: 2,
+          style: {},
+        },
+        {
+          id: 'b2',
+          type: 'text',
+          content: 'Lancement de 3 features',
+          x: 20,
+          y: 78,
+          w: 110,
+          h: 5,
+          z: 2,
+          style: {},
+        },
+        {
+          id: 'h2',
+          type: 'text',
+          content: 'Formation',
+          x: 20,
+          y: 120,
+          w: 60,
+          h: 6,
+          z: 2,
+          style: { bold: true, font_size: 12 },
+        },
+        {
+          id: 'f1',
+          type: 'text',
+          content: 'Master Management',
+          x: 20,
+          y: 130,
+          w: 90,
+          h: 5,
+          z: 2,
+          style: {},
+        },
+      ],
+    }],
+  });
+
+  const { layout: out, boundCount } = bindStructuralTextToSemanticBlocks(layout, {
+    prenom: 'Camille',
+    nom: 'Durand',
+  });
+  assert.equal(out.freeform, true);
+  assert.equal(boundCount, 2);
+  const blocks = out.pages[0].blocks;
+  assert.ok(blocks.some((b) => b.type === 'shape:rect'));
+  const exp = blocks.find((b) => b.type === 'experiences');
+  const form = blocks.find((b) => b.type === 'formations');
+  assert.ok(exp);
+  assert.equal(exp.bind, 'experiences');
+  assert.ok(exp.h >= 18);
+  assert.ok(form);
+  assert.equal(form.bind, 'formations');
+  assert.equal(blocks.some((b) => b.id === 'b1'), false);
+  assert.equal(blocks.some((b) => b.type === 'text' && b.content === 'Product Manager — NovaSoft'), false);
+});
+
+test('bindStructuralTextToSemanticBlocks : confiance basse → freeform inchangé', () => {
+  const layout = sanitizeLayoutV3({
+    version: 3,
+    format: 'A4',
+    grid: 'free',
+    unit: 'mm',
+    freeform: true,
+    pages: [{
+      id: 'p1',
+      blocks: [
+        {
+          id: 't1',
+          type: 'text',
+          content: 'Note de bas de page sans signal',
+          x: 20,
+          y: 200,
+          w: 80,
+          h: 5,
+          z: 1,
+          style: {},
+        },
+      ],
+    }],
+  });
+  const { layout: out, boundCount, skippedLowConfidence } = bindStructuralTextToSemanticBlocks(
+    layout,
+    {},
+  );
+  assert.equal(boundCount, 0);
+  assert.equal(skippedLowConfidence, 0);
+  assert.equal(out.pages[0].blocks[0].type, 'text');
+  assert.equal(out.pages[0].blocks[0].content.includes('Note'), true);
+});


### PR DESCRIPTION
## Summary
- Heuristique FE pour lier le texte freeform d'un import PDF structurel vers des blocs sémantiques (`identity`, `experiences`, …)
- Confiance basse → reste freeform
- Branché dans `buildStructuralImportLayout` ; doc spike mise à jour

## Linear / GitHub
- Linear: https://linear.app/axel-project/issue/AXE-329/improve-lier-freeform-structurel-blocs-semantiques-editables
- Fixes AXE-329
- Closes #90

## Test plan
- [ ] `node --test frontend/tests/unit/structuralSemanticBind.test.js`
- [ ] Import PDF natif avec titres de section → blocs `experiences` / `formations` éditables
- [ ] Lignes ambiguës restent en `text` freeform
- [ ] `layout.freeform` toujours true (pas de reflow)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Les imports PDF structurels associent automatiquement les textes détectés aux sections sémantiques du CV, comme l’identité, les coordonnées et les expériences.
  * Le mode de mise en page libre est conservé, tandis que les contenus non reconnus restent disponibles.
  * La détection s’appuie sur un niveau de confiance afin de limiter les associations incorrectes.

* **Documentation**
  * La documentation précise le fonctionnement de cette association sémantique.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->