### PR TITLE
feat(import): JSON sémantique dual-key + parse LLM sectionné (AXE-332)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1538,7 +1538,9 @@ def _parse_cv_import_with_ai(text: str, user_id: str | None = None) -> tuple[dic
         parsed = _parse_cv_text_with_ai(text, user_id)
         cv, layout_hints = _split_cv_import_payload(parsed)
         cv = sync_dual_keys(cv)
-        semantic_meta = build_semantic_meta(cv, source="import_full_fallback", section_passes=["full"])
+        semantic_meta = build_semantic_meta(
+            cv, source="import_full_fallback", section_passes=["full"]
+        )
 
     return sync_dual_keys(cv), layout_hints or {}, semantic_meta
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1287,6 +1287,8 @@ Retourne UNIQUEMENT un objet JSON valide avec cette structure exacte (pas de mar
   "cv": {
   "prenom": "",
   "nom": "",
+  "first_name": "",
+  "last_name": "",
   "email": "",
   "telephone": "",
   "linkedin": "",
@@ -1352,6 +1354,7 @@ Retourne UNIQUEMENT un objet JSON valide avec cette structure exacte (pas de mar
 Règles :
 - Numérote les ids : exp_1, exp_2… / form_1, form_2… / proj_1, proj_2…
 - Extrais TOUT ce qui est dans le CV, ne saute rien
+- Dual-key : prenom = first_name et nom = last_name (mêmes valeurs, toujours synchronisés)
 - Pour les dates : garde le format d'origine (ex. "01/2024", "2023", "Aujourd'hui")
 - Si une info n'est pas trouvée, laisse une chaîne vide ""
 - Les bullet_points : chaque réalisation/responsabilité = 1 bullet point
@@ -1396,13 +1399,15 @@ def _extract_text_from_docx(file_bytes: bytes) -> str:
 
 def _split_cv_import_payload(parsed: dict) -> tuple[dict, dict]:
     """Extrait le CV et les layout_hints (format enveloppe ou legacy plat)."""
+    from backend.services.cv_semantic_schema import sync_dual_keys
+
     if not isinstance(parsed, dict):
         return {}, {}
     if isinstance(parsed.get("cv"), dict):
-        cv = parsed["cv"]
+        cv = sync_dual_keys(parsed["cv"])
         hints = parsed.get("layout_hints")
         return cv, hints if isinstance(hints, dict) else {}
-    return parsed, {}
+    return sync_dual_keys(parsed), {}
 
 
 def _parse_cv_text_with_ai(text: str, user_id: str | None = None) -> dict:
@@ -1463,10 +1468,79 @@ def _parse_cv_text_with_ai(text: str, user_id: str | None = None) -> dict:
     return parsed
 
 
-def _parse_cv_import_with_ai(text: str, user_id: str | None = None) -> tuple[dict, dict]:
-    """Parse texte CV via Gemini ; retourne (cv, layout_hints)."""
-    parsed = _parse_cv_text_with_ai(text, user_id)
-    return _split_cv_import_payload(parsed)
+def _parse_cv_import_with_ai(text: str, user_id: str | None = None) -> tuple[dict, dict, dict]:
+    """Parse texte CV via Gemini (passes par sections) ; retourne (cv, layout_hints, semantic_meta)."""
+    from backend.services.cv_import_semantic import parse_cv_by_sections
+    from backend.services.cv_semantic_schema import build_semantic_meta, sync_dual_keys
+
+    def _generate_section(prompt: str, uid: str | None) -> dict:
+        """Appel Gemini focalisé (réutilise le client / modèles d'import)."""
+        import os
+        import time
+
+        ensure_budget(uid)
+        api_key = os.environ.get("GEMINI_API_KEY")
+        if not api_key:
+            raise HTTPException(status_code=500, detail="GEMINI_API_KEY manquante.")
+        from google import genai
+        from google.genai import types
+
+        from backend.services.adapter import _extract_json
+
+        client = genai.Client(api_key=api_key)
+        cfg = types.GenerateContentConfig(temperature=0.1)
+        models_to_try = [GEMINI_MODEL_IMPORT]
+        if GEMINI_MODEL_IMPORT_FALLBACK and GEMINI_MODEL_IMPORT_FALLBACK != GEMINI_MODEL_IMPORT:
+            models_to_try.append(GEMINI_MODEL_IMPORT_FALLBACK)
+        r = None
+        for attempt, model_id in enumerate(models_to_try):
+            try:
+                r = client.models.generate_content(model=model_id, contents=prompt, config=cfg)
+            except Exception as exc:
+                logger.warning(
+                    "_parse_cv_import section generate: %s attempt %d: %s", model_id, attempt, exc
+                )
+                if attempt < len(models_to_try) - 1:
+                    time.sleep(0.35)
+                    continue
+                raise
+            if r and getattr(r, "text", None):
+                break
+            r = None
+            if attempt < len(models_to_try) - 1:
+                time.sleep(0.35)
+        if not r or not getattr(r, "text", None):
+            return {}
+        inp, out = usage_from_response(r)
+        if inp or out:
+            from backend.db import record_gemini_usage
+
+            record_gemini_usage(uid, "import_section", inp, out)
+        parsed = _extract_json(r.text)
+        return parsed if isinstance(parsed, dict) else {}
+
+    def _fallback_full(full_text: str, uid: str | None) -> dict:
+        parsed = _parse_cv_text_with_ai(full_text, uid)
+        cv_part, hints = _split_cv_import_payload(parsed)
+        return {"cv": cv_part, "layout_hints": hints}
+
+    try:
+        cv, layout_hints, semantic_meta = parse_cv_by_sections(
+            text,
+            user_id,
+            _generate_section,
+            fallback_full=_fallback_full,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.warning("parse_cv_by_sections failed (%s) — fallback full", exc)
+        parsed = _parse_cv_text_with_ai(text, user_id)
+        cv, layout_hints = _split_cv_import_payload(parsed)
+        cv = sync_dual_keys(cv)
+        semantic_meta = build_semantic_meta(cv, source="import_full_fallback", section_passes=["full"])
+
+    return sync_dual_keys(cv), layout_hints or {}, semantic_meta
 
 
 @app.post("/api/cv/import")
@@ -1524,7 +1598,7 @@ def api_cv_import_file(request: Request, file: UploadFile = File(...)):
 
     user_id = _get_user_id(request)
     try:
-        cv, layout_hints = _parse_cv_import_with_ai(text, user_id)
+        cv, layout_hints, semantic_meta = _parse_cv_import_with_ai(text, user_id)
     except GeminiQuotaExceeded:
         raise HTTPException(
             status_code=429, detail="Quota temporairement atteint. Réessaie plus tard."
@@ -1533,6 +1607,7 @@ def api_cv_import_file(request: Request, file: UploadFile = File(...)):
     vision_meta: dict[str, Any] = {}
     structural_layout: dict[str, Any] | None = None
     import_policy: dict[str, Any] | None = None
+    block_annotations: list[dict[str, Any]] = []
     if is_pdf:
         # Étape 1 (prioritaire) : reconstruction déterministe sans IA. Pour un PDF
         # natif (texte extractible), on copie la mise en page 1:1 - c'est le rendu
@@ -1572,6 +1647,15 @@ def api_cv_import_file(request: Request, file: UploadFile = File(...)):
             vision_meta=vision_meta,
         )
 
+        if structural_layout is not None:
+            from backend.services.cv_import_semantic import (
+                annotate_structural_blocks,
+                attach_annotations_to_layout,
+            )
+
+            block_annotations = annotate_structural_blocks(structural_layout, cv)
+            structural_layout = attach_annotations_to_layout(structural_layout, block_annotations)
+
     structural_blocks = (
         sum(len(p.get("blocks", [])) for p in structural_layout.get("pages", []))
         if structural_layout
@@ -1589,6 +1673,7 @@ def api_cv_import_file(request: Request, file: UploadFile = File(...)):
             "import_profile": cv_import_completeness(cv),
             "structural_layout": bool(structural_layout),
             "structural_blocks": structural_blocks,
+            "block_annotations": len(block_annotations),
             "vision_detection": bool(vision_meta),
             "vision_template": vision_meta.get("template_match"),
             "vision_confidence": vision_meta.get("confidence"),
@@ -1601,6 +1686,8 @@ def api_cv_import_file(request: Request, file: UploadFile = File(...)):
         "layout_hints": layout_hints,
         "layout": structural_layout,
         "vision": vision_meta,
+        "semantic_meta": semantic_meta,
+        "block_annotations": block_annotations,
     }
     if import_policy is not None:
         payload["import_policy"] = import_policy
@@ -1624,7 +1711,7 @@ def api_cv_import_text(request: Request, body: ImportTextBody):
 
     user_id = _get_user_id(request)
     try:
-        cv, layout_hints = _parse_cv_import_with_ai(text, user_id)
+        cv, layout_hints, semantic_meta = _parse_cv_import_with_ai(text, user_id)
     except GeminiQuotaExceeded:
         raise HTTPException(
             status_code=429, detail="Quota temporairement atteint. Réessaie plus tard."
@@ -1639,7 +1726,7 @@ def api_cv_import_text(request: Request, body: ImportTextBody):
             "import_profile": cv_import_completeness(cv),
         },
     )
-    return {"cv": cv, "layout_hints": layout_hints}
+    return {"cv": cv, "layout_hints": layout_hints, "semantic_meta": semantic_meta}
 
 
 def _render_empty_preview_html() -> str:

--- a/backend/services/cv_import_semantic.py
+++ b/backend/services/cv_import_semantic.py
@@ -1,0 +1,402 @@
+"""Import CV sémantique — passes par sections + annotations blocs (AXE-332)."""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Callable
+from copy import deepcopy
+from typing import Any
+
+from backend.services.cv_semantic_schema import build_semantic_meta, sync_dual_keys
+
+logger = logging.getLogger(__name__)
+
+GenerateFn = Callable[[str, str | None], dict]
+
+# Découpe heuristique du texte brut avant passes LLM focalisées.
+_SECTION_MARKERS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "identity",
+        re.compile(
+            r"^(?:identité|identity|profil|profile|coordonn[ée]es|contact)\s*[:.]?\s*$",
+            re.I,
+        ),
+    ),
+    (
+        "experiences",
+        re.compile(
+            r"^(?:(?:work|professional)\s+experiences?|exp[ée]riences?(?:\s+professionnelles?)?"
+            r"|work\s+history|employment)\s*[:.]?\s*$",
+            re.I,
+        ),
+    ),
+    (
+        "formations",
+        re.compile(
+            r"^(?:formations?|education|études|etudes|dipl[oô]mes?)\s*[:.]?\s*$",
+            re.I,
+        ),
+    ),
+    (
+        "skills",
+        re.compile(
+            r"^(?:comp[ée]tences?|skills?|technologies?|outils?)\s*[:.]?\s*$",
+            re.I,
+        ),
+    ),
+    (
+        "languages",
+        re.compile(r"^(?:langues?|languages?)\s*[:.]?\s*$", re.I),
+    ),
+    (
+        "certifications",
+        re.compile(r"^(?:certifications?|accreditations?)\s*[:.]?\s*$", re.I),
+    ),
+    (
+        "projets",
+        re.compile(
+            r"^(?:projets?|projects?|réalisations?|realisations?)\s*[:.]?\s*$",
+            re.I,
+        ),
+    ),
+    (
+        "resume",
+        re.compile(
+            r"^(?:r[ée]sum[ée]|summary|about|à propos|a propos)\s*[:.]?\s*$",
+            re.I,
+        ),
+    ),
+)
+
+_EMAIL_RE = re.compile(r"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}", re.I)
+_PHONE_RE = re.compile(r"(?:\+?\d[\d\s().-]{7,}\d)")
+
+_HEADING_CLASSIFY: tuple[tuple[str, re.Pattern[str]], ...] = tuple(
+    (name, pat) for name, pat in _SECTION_MARKERS if name != "identity"
+)
+
+SECTION_ORDER: tuple[str, ...] = (
+    "identity",
+    "resume",
+    "experiences",
+    "formations",
+    "skills",
+    "languages",
+    "certifications",
+    "projets",
+    "body",
+)
+
+
+def split_cv_text_into_sections(text: str) -> dict[str, str]:
+    """Découpe le texte CV en sections via titres de ligne (heuristique)."""
+    raw = (text or "").replace("\r\n", "\n")
+    lines = raw.split("\n")
+    buckets: dict[str, list[str]] = {k: [] for k in SECTION_ORDER}
+    current = "identity"
+    # Premières lignes → identity jusqu'au 1er vrai titre
+    seen_heading = False
+    for line in lines:
+        stripped = line.strip()
+        matched: str | None = None
+        if stripped and len(stripped) <= 64:
+            for name, pat in _SECTION_MARKERS:
+                if pat.match(stripped):
+                    matched = name
+                    break
+        if matched:
+            current = matched
+            seen_heading = True
+            continue
+        if not seen_heading and current == "identity":
+            buckets["identity"].append(line)
+        else:
+            if current not in buckets:
+                buckets[current] = []
+            buckets[current].append(line)
+    # Corps résiduel
+    out: dict[str, str] = {}
+    for key in SECTION_ORDER:
+        chunk = "\n".join(buckets.get(key) or []).strip()
+        if chunk:
+            out[key] = chunk
+    if not out and raw.strip():
+        out["body"] = raw.strip()
+    return out
+
+
+_IDENTITY_PROMPT = """Tu extrais UNIQUEMENT l'identité / contact d'un CV.
+Retourne UNIQUEMENT un JSON valide :
+{
+  "prenom": "", "nom": "", "first_name": "", "last_name": "",
+  "email": "", "telephone": "", "linkedin": "", "ville": "",
+  "titre_professionnel": ""
+}
+Règles : prenom↔first_name et nom↔last_name doivent être synchronisés (même valeur).
+Texte :
+"""
+
+_RESUME_PROMPT = """Tu extrais le résumé / accroche professionnelle.
+JSON unique : { "resume": "" }
+Texte :
+"""
+
+_EXPERIENCES_PROMPT = """Tu extrais les expériences professionnelles.
+JSON unique :
+{ "experiences": [ {
+  "id": "exp_1", "poste": "", "entreprise": "", "secteur": "",
+  "date_debut": "", "date_fin": "", "lieu": "", "contexte": "",
+  "bullet_points": [], "mots_cles": [], "clients": ""
+} ] }
+Ids exp_1, exp_2… Texte :
+"""
+
+_FORMATIONS_PROMPT = """Tu extrais formations / diplômes.
+JSON : { "formations": [ {
+  "id": "form_1", "diplome": "", "etablissement": "", "date": "", "mention": ""
+} ] }
+Texte :
+"""
+
+_SKILLS_PROMPT = """Tu extrais compétences / langues / logiciels.
+JSON : { "competences": {
+  "techniques": [], "logiciels": [],
+  "langues": [{"langue": "", "niveau": ""}], "autres": []
+} }
+Texte :
+"""
+
+_CERTS_PROMPT = """Tu extrais certifications.
+JSON : { "certifications": [ {
+  "id": "cert_1", "nom": "", "organisme": "", "date": ""
+} ] }
+Texte :
+"""
+
+_PROJETS_PROMPT = """Tu extrais projets / réalisations.
+JSON : { "projets": [ {
+  "id": "proj_1", "nom": "", "description": "", "mots_cles": []
+} ] }
+Texte :
+"""
+
+_SECTION_PROMPTS: dict[str, str] = {
+    "identity": _IDENTITY_PROMPT,
+    "resume": _RESUME_PROMPT,
+    "experiences": _EXPERIENCES_PROMPT,
+    "formations": _FORMATIONS_PROMPT,
+    "skills": _SKILLS_PROMPT,
+    "languages": _SKILLS_PROMPT,
+    "certifications": _CERTS_PROMPT,
+    "projets": _PROJETS_PROMPT,
+}
+
+
+def _merge_cv_parts(parts: list[dict[str, Any]]) -> dict[str, Any]:
+    merged: dict[str, Any] = {}
+    for part in parts:
+        if not isinstance(part, dict):
+            continue
+        for key, val in part.items():
+            if key == "layout_hints":
+                continue
+            if key == "competences" and isinstance(val, dict):
+                raw_base = merged.get("competences")
+                base: dict[str, Any] = raw_base if isinstance(raw_base, dict) else {}
+                merged["competences"] = {**base, **{k: v for k, v in val.items() if v}}
+            elif key in ("experiences", "formations", "certifications", "projets") and isinstance(
+                val, list
+            ):
+                prev_raw = merged.get(key)
+                prev: list[Any] = prev_raw if isinstance(prev_raw, list) else []
+                merged[key] = [*prev, *val]
+            elif val not in (None, "", [], {}):
+                merged[key] = val
+    return sync_dual_keys(merged)
+
+
+def _cv_has_minimum(cv: dict[str, Any]) -> bool:
+    if (cv.get("prenom") or cv.get("first_name") or cv.get("nom") or cv.get("last_name")) and (
+        cv.get("email") or cv.get("experiences") or cv.get("titre_professionnel")
+    ):
+        return True
+    exps = cv.get("experiences") or []
+    return isinstance(exps, list) and len(exps) >= 1
+
+
+def parse_cv_by_sections(
+    text: str,
+    user_id: str | None,
+    generate_json: GenerateFn,
+    *,
+    fallback_full: Callable[[str, str | None], dict] | None = None,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Parse par sections LLM puis merge. Retourne (cv, layout_hints, semantic_meta).
+
+    ``generate_json(prompt, user_id) -> dict`` doit appeler Gemini (ou un mock).
+    ``fallback_full`` : parse monolithique si résultat trop pauvre.
+    """
+    sections = split_cv_text_into_sections(text)
+    # identity : toujours inclure le début du doc si section vide
+    if "identity" not in sections and text.strip():
+        sections["identity"] = text.strip()[:2500]
+
+    parts: list[dict[str, Any]] = []
+    used_passes: list[str] = []
+    layout_hints: dict[str, Any] = {}
+
+    for name in SECTION_ORDER:
+        chunk = sections.get(name)
+        if not chunk or name == "body":
+            continue
+        prompt_prefix = _SECTION_PROMPTS.get(name)
+        if not prompt_prefix:
+            continue
+        # Évite double call skills/languages
+        if name == "languages" and "skills" in used_passes and "skills" in sections:
+            continue
+        try:
+            parsed = generate_json(prompt_prefix + chunk[:6000], user_id)
+        except Exception as exc:
+            logger.warning("cv_import_semantic: section %s failed: %s", name, exc)
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        hints = parsed.pop("layout_hints", None)
+        if isinstance(hints, dict) and hints:
+            layout_hints = {**layout_hints, **hints}
+        # Enveloppe éventuelle { "cv": {...} }
+        payload = parsed.get("cv") if isinstance(parsed.get("cv"), dict) else parsed
+        parts.append(payload)
+        used_passes.append(name)
+
+    cv = _merge_cv_parts(parts)
+
+    if (not _cv_has_minimum(cv)) and fallback_full is not None:
+        try:
+            full = fallback_full(text, user_id)
+            if isinstance(full, dict):
+                inner_raw = full.get("cv") if isinstance(full.get("cv"), dict) else full
+                inner: dict[str, Any] = inner_raw if isinstance(inner_raw, dict) else {}
+                fb_hints_raw = full.get("layout_hints")
+                fb_hints: dict[str, Any] = fb_hints_raw if isinstance(fb_hints_raw, dict) else {}
+                cv = sync_dual_keys({**inner, **{k: v for k, v in cv.items() if v}})
+                if fb_hints:
+                    layout_hints = {**fb_hints, **layout_hints}
+                used_passes.append("fallback_full")
+        except Exception as exc:
+            logger.warning("cv_import_semantic: fallback_full failed: %s", exc)
+
+    cv = sync_dual_keys(cv)
+    meta = build_semantic_meta(cv, source="import_sectioned", section_passes=used_passes)
+    return cv, layout_hints, meta
+
+
+def annotate_structural_blocks(
+    layout: dict[str, Any] | None,
+    cv: dict[str, Any] | None,
+    *,
+    min_confidence: float = 0.75,
+) -> list[dict[str, Any]]:
+    """Annote les blocs texte d'un layout structurel (déterministe, pas d'IA)."""
+    if not layout or not isinstance(layout.get("pages"), list):
+        return []
+    cv = sync_dual_keys(cv)
+    prenom = (cv.get("prenom") or "").strip().lower()
+    nom = (cv.get("nom") or "").strip().lower()
+    email = (cv.get("email") or "").strip().lower()
+    annotations: list[dict[str, Any]] = []
+
+    for page in layout["pages"]:
+        blocks = page.get("blocks") if isinstance(page, dict) else None
+        if not isinstance(blocks, list):
+            continue
+        page_h = float(page.get("height_mm") or page.get("h") or 297)
+        for block in blocks:
+            if not isinstance(block, dict) or block.get("type") != "text":
+                continue
+            bid = block.get("id")
+            if not bid:
+                continue
+            text = re.sub(r"\s+", " ", str(block.get("content") or "")).strip()
+            if not text:
+                continue
+
+            hit: dict[str, Any] | None = None
+            if len(text) <= 48:
+                for stype, pat in _HEADING_CLASSIFY:
+                    if pat.match(text):
+                        conf = 0.55
+                        style = block.get("style") if isinstance(block.get("style"), dict) else {}
+                        if style.get("bold"):
+                            conf += 0.2
+                        if float(style.get("font_size") or 0) >= 11:
+                            conf += 0.15
+                        if len(text) <= 32:
+                            conf += 0.1
+                        hit = {
+                            "block_id": bid,
+                            "type": stype if stype != "skills" else "skills",
+                            "kind": "heading",
+                            "confidence": min(1.0, conf),
+                            "section_label": text.upper(),
+                        }
+                        break
+
+            if hit is None and (prenom or nom):
+                lower = text.lower()
+                has_p = bool(prenom and prenom in lower)
+                has_n = bool(nom and nom in lower)
+                if has_p or has_n:
+                    conf = 0.45
+                    y = float(block.get("y") or 0)
+                    style = block.get("style") if isinstance(block.get("style"), dict) else {}
+                    if y < page_h * 0.32:
+                        conf += 0.25
+                    if float(style.get("font_size") or 0) >= 14 or style.get("bold"):
+                        conf += 0.2
+                    if has_p and has_n:
+                        conf += 0.15
+                    if conf >= min_confidence:
+                        hit = {
+                            "block_id": bid,
+                            "type": "identity",
+                            "kind": "identity",
+                            "confidence": min(1.0, conf),
+                            "bind": ["prenom", "nom", "titre_professionnel"],
+                        }
+
+            if hit is None:
+                conf = 0.0
+                if _EMAIL_RE.search(text):
+                    conf += 0.8
+                if _PHONE_RE.search(text):
+                    conf += 0.35
+                if email and email in text.lower():
+                    conf += 0.1
+                if conf >= min_confidence:
+                    hit = {
+                        "block_id": bid,
+                        "type": "contact",
+                        "kind": "contact",
+                        "confidence": min(1.0, conf),
+                        "bind": ["email", "telephone", "linkedin", "ville"],
+                    }
+
+            if hit and float(hit.get("confidence") or 0) >= min_confidence:
+                annotations.append(hit)
+
+    return annotations
+
+
+def attach_annotations_to_layout(
+    layout: dict[str, Any] | None,
+    annotations: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Attache ``semantic_annotations`` sur le layout (copie)."""
+    if not layout:
+        return layout
+    out = deepcopy(layout)
+    out["semantic_annotations"] = list(annotations)
+    return out

--- a/backend/services/cv_import_semantic.py
+++ b/backend/services/cv_import_semantic.py
@@ -8,18 +8,30 @@ from collections.abc import Callable
 from copy import deepcopy
 from typing import Any
 
+from backend.gemini_usage import GeminiQuotaExceeded
 from backend.services.cv_semantic_schema import build_semantic_meta, sync_dual_keys
 
 logger = logging.getLogger(__name__)
 
 GenerateFn = Callable[[str, str | None], dict]
 
+# Exceptions fatales : ne jamais avaler (429 / 5xx côté API).
+try:
+    from fastapi import HTTPException as _HTTPException
+except ImportError:  # pragma: no cover
+    _HTTPException = ()  # type: ignore[assignment, misc]
+
+_FATAL_EXC: tuple[type[BaseException], ...] = (GeminiQuotaExceeded,)
+if _HTTPException:
+    _FATAL_EXC = (*_FATAL_EXC, _HTTPException)
+
 # Découpe heuristique du texte brut avant passes LLM focalisées.
+# « Profil / Profile » → résumé (aligné FE structuralSemanticBind), pas identité.
 _SECTION_MARKERS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "identity",
         re.compile(
-            r"^(?:identité|identity|profil|profile|coordonn[ée]es|contact)\s*[:.]?\s*$",
+            r"^(?:identité|identity|coordonn[ée]es|contact)\s*[:.]?\s*$",
             re.I,
         ),
     ),
@@ -63,10 +75,22 @@ _SECTION_MARKERS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "resume",
         re.compile(
-            r"^(?:r[ée]sum[ée]|summary|about|à propos|a propos)\s*[:.]?\s*$",
+            r"^(?:profil|profile|r[ée]sum[ée]|summary|about|à propos|a propos)\s*[:.]?\s*$",
             re.I,
         ),
     ),
+)
+
+_CONTENT_SECTION_KEYS = frozenset(
+    {
+        "resume",
+        "experiences",
+        "formations",
+        "skills",
+        "languages",
+        "certifications",
+        "projets",
+    }
 )
 
 _EMAIL_RE = re.compile(r"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}", re.I)
@@ -181,6 +205,21 @@ JSON : { "projets": [ {
 Texte :
 """
 
+_LAYOUT_HINTS_PROMPT = """Tu déduis UNIQUEMENT le style de mise en page probable du CV.
+Retourne UNIQUEMENT un JSON valide :
+{
+  "layout_hints": {
+    "layout_style": "sidebar-left|sidebar-right|single-column|header-band",
+    "accent_color": "#RRGGBB ou vide si inconnu",
+    "sidebar_color": "#RRGGBB ou vide",
+    "header_color": "#RRGGBB ou vide",
+    "sections_emphasis": ["experiences", "formations", "skills", "projets"]
+  }
+}
+sections_emphasis = sections les plus fournies (ordre d'importance).
+Texte :
+"""
+
 _SECTION_PROMPTS: dict[str, str] = {
     "identity": _IDENTITY_PROMPT,
     "resume": _RESUME_PROMPT,
@@ -225,6 +264,28 @@ def _cv_has_minimum(cv: dict[str, Any]) -> bool:
     return isinstance(exps, list) and len(exps) >= 1
 
 
+def _cv_has_content_sections(cv: dict[str, Any]) -> bool:
+    """True si le CV a au moins une section métier (expériences, formations, …)."""
+    for key in ("experiences", "formations", "certifications", "projets"):
+        val = cv.get(key)
+        if isinstance(val, list) and len(val) >= 1:
+            return True
+    comps = cv.get("competences")
+    if isinstance(comps, dict):
+        for key in ("techniques", "logiciels", "langues", "autres"):
+            val = comps.get(key)
+            if isinstance(val, list) and len(val) >= 1:
+                return True
+    if (cv.get("resume") or "").strip():
+        return True
+    return False
+
+
+def _sections_look_headingless(sections: dict[str, str]) -> bool:
+    """Sans titres métier, tout le texte tombe dans identity → full parse requis."""
+    return not any(key in sections for key in _CONTENT_SECTION_KEYS)
+
+
 def parse_cv_by_sections(
     text: str,
     user_id: str | None,
@@ -235,7 +296,7 @@ def parse_cv_by_sections(
     """Parse par sections LLM puis merge. Retourne (cv, layout_hints, semantic_meta).
 
     ``generate_json(prompt, user_id) -> dict`` doit appeler Gemini (ou un mock).
-    ``fallback_full`` : parse monolithique si résultat trop pauvre.
+    ``fallback_full`` : parse monolithique si résultat trop pauvre / sans titres.
     """
     sections = split_cv_text_into_sections(text)
     # identity : toujours inclure le début du doc si section vide
@@ -245,35 +306,42 @@ def parse_cv_by_sections(
     parts: list[dict[str, Any]] = []
     used_passes: list[str] = []
     layout_hints: dict[str, Any] = {}
+    headingless = _sections_look_headingless(sections)
 
-    for name in SECTION_ORDER:
-        chunk = sections.get(name)
-        if not chunk or name == "body":
-            continue
-        prompt_prefix = _SECTION_PROMPTS.get(name)
-        if not prompt_prefix:
-            continue
-        # Évite double call skills/languages
-        if name == "languages" and "skills" in used_passes and "skills" in sections:
-            continue
-        try:
-            parsed = generate_json(prompt_prefix + chunk[:6000], user_id)
-        except Exception as exc:
-            logger.warning("cv_import_semantic: section %s failed: %s", name, exc)
-            continue
-        if not isinstance(parsed, dict):
-            continue
-        hints = parsed.pop("layout_hints", None)
-        if isinstance(hints, dict) and hints:
-            layout_hints = {**layout_hints, **hints}
-        # Enveloppe éventuelle { "cv": {...} }
-        payload = parsed.get("cv") if isinstance(parsed.get("cv"), dict) else parsed
-        parts.append(payload)
-        used_passes.append(name)
+    # Sans titres métier, le texte entier est dans identity → full parse d'emblée.
+    skip_sections = headingless and fallback_full is not None
+
+    if not skip_sections:
+        for name in SECTION_ORDER:
+            chunk = sections.get(name)
+            if not chunk or name == "body":
+                continue
+            prompt_prefix = _SECTION_PROMPTS.get(name)
+            if not prompt_prefix:
+                continue
+            try:
+                parsed = generate_json(prompt_prefix + chunk[:6000], user_id)
+            except _FATAL_EXC:
+                raise
+            except Exception as exc:
+                logger.warning("cv_import_semantic: section %s failed: %s", name, exc)
+                continue
+            if not isinstance(parsed, dict):
+                continue
+            hints = parsed.pop("layout_hints", None)
+            if isinstance(hints, dict) and hints:
+                layout_hints = {**layout_hints, **hints}
+            # Enveloppe éventuelle { "cv": {...} }
+            payload = parsed.get("cv") if isinstance(parsed.get("cv"), dict) else parsed
+            parts.append(payload)
+            used_passes.append(name)
 
     cv = _merge_cv_parts(parts)
 
-    if (not _cv_has_minimum(cv)) and fallback_full is not None:
+    need_full = fallback_full is not None and (
+        headingless or (not _cv_has_minimum(cv)) or (not _cv_has_content_sections(cv))
+    )
+    if need_full and fallback_full is not None:
         try:
             full = fallback_full(text, user_id)
             if isinstance(full, dict):
@@ -281,12 +349,45 @@ def parse_cv_by_sections(
                 inner: dict[str, Any] = inner_raw if isinstance(inner_raw, dict) else {}
                 fb_hints_raw = full.get("layout_hints")
                 fb_hints: dict[str, Any] = fb_hints_raw if isinstance(fb_hints_raw, dict) else {}
+                # Full parse comble les trous ; clés déjà remplies en section gagnent.
                 cv = sync_dual_keys({**inner, **{k: v for k, v in cv.items() if v}})
                 if fb_hints:
                     layout_hints = {**fb_hints, **layout_hints}
                 used_passes.append("fallback_full")
+        except _FATAL_EXC:
+            raise
         except Exception as exc:
             logger.warning("cv_import_semantic: fallback_full failed: %s", exc)
+
+    # Passe légère dédiée si le parse sectionné n'a pas fourni de hints.
+    if not layout_hints and text.strip():
+        try:
+            hints_parsed = generate_json(_LAYOUT_HINTS_PROMPT + text.strip()[:4000], user_id)
+            if isinstance(hints_parsed, dict):
+                raw_hints = hints_parsed.get("layout_hints")
+                if isinstance(raw_hints, dict) and raw_hints:
+                    layout_hints = raw_hints
+                    used_passes.append("layout_hints")
+                elif any(
+                    k in hints_parsed for k in ("layout_style", "accent_color", "sections_emphasis")
+                ):
+                    layout_hints = {
+                        k: hints_parsed[k]
+                        for k in (
+                            "layout_style",
+                            "accent_color",
+                            "sidebar_color",
+                            "header_color",
+                            "sections_emphasis",
+                        )
+                        if k in hints_parsed
+                    }
+                    if layout_hints:
+                        used_passes.append("layout_hints")
+        except _FATAL_EXC:
+            raise
+        except Exception as exc:
+            logger.warning("cv_import_semantic: layout_hints pass failed: %s", exc)
 
     cv = sync_dual_keys(cv)
     meta = build_semantic_meta(cv, source="import_sectioned", section_passes=used_passes)

--- a/backend/services/cv_import_semantic.py
+++ b/backend/services/cv_import_semantic.py
@@ -76,9 +76,10 @@ _SECTION_MARKERS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ),
 )
 
-_CONTENT_SECTION_KEYS = frozenset(
+# Titres « métier » : resume/profil seul ne compte pas (sinon le corps après Profil
+# est mangé par la passe résumé et le fallback full ne part jamais).
+_STRUCTURAL_SECTION_KEYS = frozenset(
     {
-        "resume",
         "experiences",
         "formations",
         "skills",
@@ -260,7 +261,11 @@ def _cv_has_minimum(cv: dict[str, Any]) -> bool:
 
 
 def _cv_has_content_sections(cv: dict[str, Any]) -> bool:
-    """True si le CV a au moins une section métier (expériences, formations, …)."""
+    """True si le CV a au moins une section métier (expériences, formations, …).
+
+    Un ``resume`` seul ne suffit pas : un bloc Profil/Summary peut contenir
+    (ou précéder) le reste du CV sans titres Expériences/Formations.
+    """
     for key in ("experiences", "formations", "certifications", "projets"):
         val = cv.get(key)
         if isinstance(val, list) and len(val) >= 1:
@@ -271,14 +276,12 @@ def _cv_has_content_sections(cv: dict[str, Any]) -> bool:
             val = comps.get(key)
             if isinstance(val, list) and len(val) >= 1:
                 return True
-    if (cv.get("resume") or "").strip():
-        return True
     return False
 
 
 def _sections_look_headingless(sections: dict[str, str]) -> bool:
-    """Sans titres métier, tout le texte tombe dans identity → full parse requis."""
-    return not any(key in sections for key in _CONTENT_SECTION_KEYS)
+    """Sans titres structurels, full parse requis (Profil/résumé seul ≠ structure)."""
+    return not any(key in sections for key in _STRUCTURAL_SECTION_KEYS)
 
 
 def parse_cv_by_sections(
@@ -354,7 +357,7 @@ def parse_cv_by_sections(
         except Exception as exc:
             logger.warning("cv_import_semantic: fallback_full failed: %s", exc)
 
-    # Passe légère dédiée si le parse sectionné n'a pas fourni de hints.
+    # Passe cosmétique : soft-fail même sur quota/HTTP — ne pas perdre un CV déjà parsé.
     if not layout_hints and text.strip():
         try:
             hints_parsed = generate_json(_LAYOUT_HINTS_PROMPT + text.strip()[:4000], user_id)
@@ -379,8 +382,6 @@ def parse_cv_by_sections(
                     }
                     if layout_hints:
                         used_passes.append("layout_hints")
-        except _FATAL_EXC:
-            raise
         except Exception as exc:
             logger.warning("cv_import_semantic: layout_hints pass failed: %s", exc)
 

--- a/backend/services/cv_import_semantic.py
+++ b/backend/services/cv_import_semantic.py
@@ -10,20 +10,14 @@ from typing import Any
 
 from backend.gemini_usage import GeminiQuotaExceeded
 from backend.services.cv_semantic_schema import build_semantic_meta, sync_dual_keys
+from fastapi import HTTPException
 
 logger = logging.getLogger(__name__)
 
 GenerateFn = Callable[[str, str | None], dict]
 
 # Exceptions fatales : ne jamais avaler (429 / 5xx côté API).
-try:
-    from fastapi import HTTPException as _HTTPException
-except ImportError:  # pragma: no cover
-    _HTTPException = ()  # type: ignore[assignment, misc]
-
-_FATAL_EXC: tuple[type[BaseException], ...] = (GeminiQuotaExceeded,)
-if _HTTPException:
-    _FATAL_EXC = (*_FATAL_EXC, _HTTPException)
+_FATAL_EXC: tuple[type[BaseException], ...] = (GeminiQuotaExceeded, HTTPException)
 
 # Découpe heuristique du texte brut avant passes LLM focalisées.
 # « Profil / Profile » → résumé (aligné FE structuralSemanticBind), pas identité.

--- a/backend/services/cv_import_semantic.py
+++ b/backend/services/cv_import_semantic.py
@@ -8,9 +8,10 @@ from collections.abc import Callable
 from copy import deepcopy
 from typing import Any
 
+from fastapi import HTTPException
+
 from backend.gemini_usage import GeminiQuotaExceeded
 from backend.services.cv_semantic_schema import build_semantic_meta, sync_dual_keys
-from fastapi import HTTPException
 
 logger = logging.getLogger(__name__)
 

--- a/backend/services/cv_semantic_schema.py
+++ b/backend/services/cv_semantic_schema.py
@@ -1,0 +1,132 @@
+"""Schéma CV sémantique — dual-key FR/EN (AXE-332).
+
+Source de vérité historique : clés FR (`prenom`, `nom`, …).
+Miroirs EN (`first_name`, `last_name`, …) synchronisés pour interop LLM / templates.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+# Paires (fr_key, en_key). FR gagne si les deux sont non vides et divergent.
+IDENTITY_DUAL_KEYS: tuple[tuple[str, str], ...] = (
+    ("prenom", "first_name"),
+    ("nom", "last_name"),
+)
+
+# Champs scalaires suivis dans semantic_meta.fields
+SCALAR_META_FIELDS: tuple[str, ...] = (
+    "prenom",
+    "nom",
+    "first_name",
+    "last_name",
+    "email",
+    "telephone",
+    "linkedin",
+    "ville",
+    "titre_professionnel",
+    "resume",
+)
+
+SECTION_META_KEYS: tuple[str, ...] = (
+    "experiences",
+    "formations",
+    "certifications",
+    "competences",
+    "projets",
+)
+
+
+def _nonempty_str(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def sync_dual_keys(cv: dict[str, Any] | None) -> dict[str, Any]:
+    """Assure la cohérence prenom↔first_name et nom↔last_name.
+
+    Règle : si une seule côté remplie → copie. Si les deux diffèrent → FR gagne.
+    """
+    out: dict[str, Any] = deepcopy(cv) if isinstance(cv, dict) else {}
+    for fr_key, en_key in IDENTITY_DUAL_KEYS:
+        fr_val = _nonempty_str(out.get(fr_key))
+        en_val = _nonempty_str(out.get(en_key))
+        if fr_val and en_val:
+            if fr_val.lower() != en_val.lower():
+                out[en_key] = fr_val
+            else:
+                out[fr_key] = fr_val
+                out[en_key] = en_val
+        elif fr_val:
+            out[en_key] = fr_val
+        elif en_val:
+            out[fr_key] = en_val
+            out[en_key] = en_val
+        else:
+            out.setdefault(fr_key, "")
+            out.setdefault(en_key, "")
+    return out
+
+
+def _section_filled(cv: dict[str, Any], key: str) -> bool:
+    val = cv.get(key)
+    if key == "competences" and isinstance(val, dict):
+        for list_key in ("techniques", "logiciels", "autres"):
+            items = val.get(list_key) or []
+            if any(_nonempty_str(x) for x in items):
+                return True
+        langues = val.get("langues") or []
+        return any(_nonempty_str(x.get("langue") if isinstance(x, dict) else x) for x in langues)
+    if isinstance(val, list):
+        for item in val:
+            if not isinstance(item, dict):
+                if _nonempty_str(item):
+                    return True
+                continue
+            for k, v in item.items():
+                if k == "id":
+                    continue
+                if isinstance(v, list) and any(_nonempty_str(x) for x in v):
+                    return True
+                if _nonempty_str(v):
+                    return True
+        return False
+    return bool(_nonempty_str(val))
+
+
+def estimate_field_confidence(cv: dict[str, Any]) -> dict[str, float]:
+    """Heuristique de confiance post-extraction (pas un 2e LLM)."""
+    conf: dict[str, float] = {}
+    for key in SCALAR_META_FIELDS:
+        conf[key] = 0.9 if _nonempty_str(cv.get(key)) else 0.0
+    # Dual-key : même confiance sur le miroir
+    for fr_key, en_key in IDENTITY_DUAL_KEYS:
+        c = max(conf.get(fr_key, 0.0), conf.get(en_key, 0.0))
+        conf[fr_key] = c
+        conf[en_key] = c
+    for key in SECTION_META_KEYS:
+        conf[key] = 0.85 if _section_filled(cv, key) else 0.0
+    return conf
+
+
+def build_semantic_meta(
+    cv: dict[str, Any] | None,
+    *,
+    field_confidence: dict[str, float] | None = None,
+    source: str = "import",
+    section_passes: list[str] | None = None,
+) -> dict[str, Any]:
+    """Métadonnées sémantiques exposées à l'API / FE (hints discrets si confiance basse)."""
+    synced = sync_dual_keys(cv)
+    conf = field_confidence or estimate_field_confidence(synced)
+    low = [k for k, v in conf.items() if 0 < v < 0.75]
+    missing = [k for k in ("prenom", "nom", "email") if not _nonempty_str(synced.get(k))]
+    return {
+        "schema_version": 1,
+        "source": source,
+        "dual_key": True,
+        "fields": {k: round(float(v), 3) for k, v in conf.items()},
+        "low_confidence_fields": low,
+        "missing_critical_fields": missing,
+        "section_passes": list(section_passes or []),
+    }

--- a/docs/axe-41-import-pipeline-spike.md
+++ b/docs/axe-41-import-pipeline-spike.md
@@ -137,6 +137,15 @@ Sur `buildStructuralImportLayout`, après sanitize :
 
 ---
 
+## Import JSON sémantique complet (AXE-332)
+
+- Dual-key FR/EN : `prenom`↔`first_name`, `nom`↔`last_name` (`backend/services/cv_semantic_schema.py`, `frontend/src/lib/cvDualKey.js`).
+- Parse import **par sections** LLM + fallback full (`cv_import_semantic.parse_cv_by_sections`).
+- Payload API : `cv` + `semantic_meta` + `block_annotations` (aussi `layout.semantic_annotations`).
+- FE : annotations API priment sur les heuristiques locales.
+
+---
+
 ## Backlog d'implémentation (tickets enfants)
 
 Créés sous le projet Éditeur / milestone P4, parent [AXE-41](https://linear.app/axel-project/issue/AXE-41) :

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -479,6 +479,7 @@ function CvEditorBeta({
     visionMeta = {},
     importPolicy = null,
     chosenVariant = null,
+    annotations = null,
   } = {}) => {
     const templates = templatesList || [];
     let finalLayout;
@@ -505,6 +506,7 @@ function CvEditorBeta({
         layoutHints,
         visionLayout,
         visionMeta,
+        annotations,
       }));
     }
 
@@ -598,6 +600,8 @@ function CvEditorBeta({
         visionLayout,
         visionMeta,
         importPolicy,
+        blockAnnotations,
+        semanticMeta,
       } = extractImportApiResponse(result);
       const nextCv = cvFromImportPayload(rawCv);
       const templates = templatesList || [];
@@ -606,6 +610,7 @@ function CvEditorBeta({
         layoutHints,
         visionLayout,
         visionMeta,
+        annotations: blockAnnotations,
       });
       let scoredRows = [];
       let bestTotal = null;
@@ -628,6 +633,7 @@ function CvEditorBeta({
           visionLayout,
           visionMeta,
           importPolicy,
+          annotations: blockAnnotations,
         });
         return;
       }
@@ -637,6 +643,8 @@ function CvEditorBeta({
         bestTotal,
         selectedId: defaultImportVariantId(merged),
         importPolicy,
+        semanticMeta,
+        blockAnnotations,
       });
     } catch (err) {
       setImportError(err?.message || 'Erreur lors de l\'import.');

--- a/frontend/src/data/cvDefault.js
+++ b/frontend/src/data/cvDefault.js
@@ -2,6 +2,8 @@
 export const defaultCv = () => ({
   prenom: '',
   nom: '',
+  first_name: '',
+  last_name: '',
   email: '',
   telephone: '',
   linkedin: '',

--- a/frontend/src/lib/canvasCvImportAdapter.js
+++ b/frontend/src/lib/canvasCvImportAdapter.js
@@ -1018,13 +1018,20 @@ function inferThemeColorsFromStructuralBlocks(layout) {
  * PDF (texte, formes, images positionnés). Aucun preset, aucune IA - juste un
  * nettoyage défensif via sanitizeLayoutV3.
  */
-export function buildStructuralImportLayout(cv, structuralLayout, { templateId = '' } = {}) {
+export function buildStructuralImportLayout(cv, structuralLayout, {
+  templateId = '',
+  annotations = null,
+} = {}) {
   const analysis = analyzeCvProfile(cv);
   // `freeform` : positions absolues figées (cf. reflow/pagination) → copie
   // fidèle du PDF, jamais ré-empilée en colonnes par l'auto-height.
   const sanitized = sanitizeLayoutV3({ ...structuralLayout, freeform: true });
-  // AXE-329 : titres / identité / contact → blocs sémantiques si confiance haute.
-  const { layout: boundLayout } = bindStructuralTextToSemanticBlocks(sanitized, cv);
+  // AXE-329 / AXE-332 : annotations API > heuristiques locales.
+  const { layout: boundLayout } = bindStructuralTextToSemanticBlocks(sanitized, cv, {
+    annotations: annotations
+      ?? structuralLayout?.semantic_annotations
+      ?? null,
+  });
   const layout = applyLayoutPagination(boundLayout);
   // Python extrait les couleurs thème directement depuis page.get_drawings()
   // (fiable quel que soit le chemin de rendu). Le JS n'intervient qu'en
@@ -1068,10 +1075,14 @@ export function buildFullCanvasImportLayout(cv, templatesList = [], {
   layoutHints = {},
   visionLayout = null,
   visionMeta = {},
+  annotations = null,
 } = {}) {
   // Priorité absolue : reconstruction structurelle (copie fidèle du PDF natif).
   if (isStructuralLayout(visionLayout)) {
-    return buildStructuralImportLayout(cv, visionLayout, { templateId });
+    return buildStructuralImportLayout(cv, visionLayout, {
+      templateId,
+      annotations: annotations ?? visionLayout?.semantic_annotations ?? null,
+    });
   }
 
   const confidence = Number(visionMeta?.confidence ?? 0);

--- a/frontend/src/lib/cvDualKey.js
+++ b/frontend/src/lib/cvDualKey.js
@@ -1,0 +1,44 @@
+/**
+ * Dual-key FR/EN pour le profil CV (AXE-332).
+ * Source de vérité historique : `prenom` / `nom` ; miroirs `first_name` / `last_name`.
+ */
+
+export const IDENTITY_DUAL_KEYS = Object.freeze([
+  ['prenom', 'first_name'],
+  ['nom', 'last_name'],
+]);
+
+function nonempty(value) {
+  return String(value ?? '').trim();
+}
+
+/**
+ * Synchronise prenom↔first_name et nom↔last_name.
+ * Si les deux diffèrent, FR gagne.
+ * @param {object} cv
+ * @returns {object}
+ */
+export function syncCvDualKeys(cv) {
+  const out = cv && typeof cv === 'object' ? { ...cv } : {};
+  for (const [frKey, enKey] of IDENTITY_DUAL_KEYS) {
+    const fr = nonempty(out[frKey]);
+    const en = nonempty(out[enKey]);
+    if (fr && en) {
+      if (fr.toLowerCase() !== en.toLowerCase()) {
+        out[enKey] = fr;
+      } else {
+        out[frKey] = fr;
+        out[enKey] = en;
+      }
+    } else if (fr) {
+      out[enKey] = fr;
+    } else if (en) {
+      out[frKey] = en;
+      out[enKey] = en;
+    } else {
+      if (out[frKey] === undefined) out[frKey] = '';
+      if (out[enKey] === undefined) out[enKey] = '';
+    }
+  }
+  return out;
+}

--- a/frontend/src/lib/cvImportUtils.js
+++ b/frontend/src/lib/cvImportUtils.js
@@ -2,6 +2,7 @@
  * Utilitaires partagés pour l'import CV (fichier / texte).
  */
 import { defaultCv } from '../data/cvDefault.js';
+import { syncCvDualKeys } from './cvDualKey.js';
 
 export const CV_IMPORT_SCALAR_KEYS = [
   { key: 'prenom', label: 'Prénom' },
@@ -139,6 +140,8 @@ export function extractImportApiResponse(result) {
       visionLayout: null,
       visionMeta: {},
       importPolicy: null,
+      semanticMeta: null,
+      blockAnnotations: [],
     };
   }
   const cv = result.cv && typeof result.cv === 'object' ? result.cv : result;
@@ -154,7 +157,23 @@ export function extractImportApiResponse(result) {
   const importPolicy = result.import_policy && typeof result.import_policy === 'object'
     ? result.import_policy
     : null;
-  return { cv, layoutHints, visionLayout, visionMeta, importPolicy };
+  const semanticMeta = result.semantic_meta && typeof result.semantic_meta === 'object'
+    ? result.semantic_meta
+    : null;
+  const blockAnnotations = Array.isArray(result.block_annotations)
+    ? result.block_annotations
+    : (Array.isArray(visionLayout?.semantic_annotations)
+      ? visionLayout.semantic_annotations
+      : []);
+  return {
+    cv,
+    layoutHints,
+    visionLayout,
+    visionMeta,
+    importPolicy,
+    semanticMeta,
+    blockAnnotations,
+  };
 }
 
 /**
@@ -170,10 +189,15 @@ export function cvFromImportPayload(parsed) {
     ? src.competences
     : {};
 
-  return {
+  const prenom = String(src.prenom ?? src.first_name ?? '').trim();
+  const nom = String(src.nom ?? src.last_name ?? '').trim();
+
+  return syncCvDualKeys({
     ...base,
-    prenom: String(src.prenom ?? '').trim(),
-    nom: String(src.nom ?? '').trim(),
+    prenom,
+    nom,
+    first_name: String(src.first_name ?? prenom).trim() || prenom,
+    last_name: String(src.last_name ?? nom).trim() || nom,
     email: String(src.email ?? '').trim(),
     telephone: String(src.telephone ?? '').trim(),
     linkedin: String(src.linkedin ?? '').trim(),
@@ -191,7 +215,7 @@ export function cvFromImportPayload(parsed) {
       langues: Array.isArray(competences.langues) ? competences.langues : [],
       autres: Array.isArray(competences.autres) ? competences.autres : [],
     },
-  };
+  });
 }
 
 export function startImportLoadingAnimation(setImportStepIndex, options = {}) {

--- a/frontend/src/lib/importLayoutVariants.js
+++ b/frontend/src/lib/importLayoutVariants.js
@@ -95,6 +95,7 @@ export function buildImportLayoutVariants(cv, templatesList = [], options = {}) 
     layoutHints = {},
     visionLayout = null,
     visionMeta = {},
+    annotations = null,
   } = options;
 
   const atsTemplate = pickAtsSafeTemplate(templatesList);
@@ -111,6 +112,7 @@ export function buildImportLayoutVariants(cv, templatesList = [], options = {}) 
     layoutHints,
     visionLayout,
     visionMeta,
+    annotations,
   });
 
   // Mix = clone du layout design (même source / hints), puis ATS + pagination.

--- a/frontend/src/lib/structuralSemanticBind.js
+++ b/frontend/src/lib/structuralSemanticBind.js
@@ -141,9 +141,9 @@ export function classifyStructuralTextBlock(block, cv = {}, { pageHeightMm = 297
     }
   }
 
-  // Identité : nom/prénom CV + haut de page + emphase.
-  const prenom = String(cv?.prenom || '').trim().toLowerCase();
-  const nom = String(cv?.nom || '').trim().toLowerCase();
+  // Identité : nom/prénom CV (+ dual-key EN) + haut de page + emphase.
+  const prenom = String(cv?.prenom || cv?.first_name || '').trim().toLowerCase();
+  const nom = String(cv?.nom || cv?.last_name || '').trim().toLowerCase();
   if (prenom || nom) {
     const lower = text.toLowerCase();
     const hasPrenom = prenom && lower.includes(prenom);
@@ -210,13 +210,25 @@ function toSemanticBlock(baseBlock, classification, regionBlocks) {
 
 /**
  * Applique le binding sémantique sur un layout structurel freeform.
+ * Si ``annotations`` (API AXE-332) est fourni, elles priment sur l'heuristique locale.
  * @returns {{ layout: object, boundCount: number, skippedLowConfidence: number }}
  */
 export function bindStructuralTextToSemanticBlocks(layout, cv = {}, {
   minConfidence = MIN_SEMANTIC_CONFIDENCE,
+  annotations = null,
 } = {}) {
   if (!layout || !Array.isArray(layout.pages)) {
     return { layout, boundCount: 0, skippedLowConfidence: 0 };
+  }
+
+  const annotationById = new Map();
+  const rawAnnotations = Array.isArray(annotations)
+    ? annotations
+    : (Array.isArray(layout.semantic_annotations) ? layout.semantic_annotations : []);
+  for (const ann of rawAnnotations) {
+    if (!ann?.block_id || !ann?.type) continue;
+    if (Number(ann.confidence) < minConfidence) continue;
+    annotationById.set(String(ann.block_id), ann);
   }
 
   let boundCount = 0;
@@ -231,6 +243,18 @@ export function bindStructuralTextToSemanticBlocks(layout, cv = {}, {
 
     const classifications = new Map();
     for (const block of textBlocks) {
+      const fromApi = annotationById.get(String(block.id));
+      if (fromApi) {
+        classifications.set(block.id, {
+          type: fromApi.type === 'skills' ? 'skills' : fromApi.type,
+          confidence: Number(fromApi.confidence) || 1,
+          kind: fromApi.kind || (fromApi.type === 'identity' || fromApi.type === 'contact'
+            ? fromApi.type
+            : 'heading'),
+          sectionLabel: fromApi.section_label || fromApi.sectionLabel,
+        });
+        continue;
+      }
       const hit = classifyStructuralTextBlock(block, cv);
       if (!hit) continue;
       if (hit.confidence < minConfidence) {
@@ -296,8 +320,14 @@ export function bindStructuralTextToSemanticBlocks(layout, cv = {}, {
     };
   });
 
+  const nextLayout = { ...layout, pages, freeform: true };
+  // annotations consommées — inutile de les repasser au canvas
+  if ('semantic_annotations' in nextLayout) {
+    delete nextLayout.semantic_annotations;
+  }
+
   return {
-    layout: { ...layout, pages, freeform: true },
+    layout: nextLayout,
     boundCount,
     skippedLowConfidence,
   };

--- a/frontend/tests/unit/cvDualKeyImport.test.js
+++ b/frontend/tests/unit/cvDualKeyImport.test.js
@@ -1,0 +1,81 @@
+/**
+ * AXE-332 — dual-key FR/EN
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { syncCvDualKeys } from '../../src/lib/cvDualKey.js';
+import { bindStructuralTextToSemanticBlocks } from '../../src/lib/structuralSemanticBind.js';
+import { cvFromImportPayload, extractImportApiResponse } from '../../src/lib/cvImportUtils.js';
+
+describe('cvDualKey', () => {
+  it('sync FR → EN', () => {
+    const out = syncCvDualKeys({ prenom: 'Ada', nom: 'Lovelace' });
+    assert.equal(out.first_name, 'Ada');
+    assert.equal(out.last_name, 'Lovelace');
+  });
+
+  it('FR wins on conflict', () => {
+    const out = syncCvDualKeys({ prenom: 'Ada', first_name: 'Other', nom: 'Lovelace', last_name: 'X' });
+    assert.equal(out.first_name, 'Ada');
+    assert.equal(out.last_name, 'Lovelace');
+  });
+});
+
+describe('cvImportUtils dual-key', () => {
+  it('cvFromImportPayload syncs dual keys', () => {
+    const cv = cvFromImportPayload({ first_name: 'Grace', last_name: 'Hopper', email: 'g@navy.mil' });
+    assert.equal(cv.prenom, 'Grace');
+    assert.equal(cv.nom, 'Hopper');
+    assert.equal(cv.first_name, 'Grace');
+  });
+
+  it('extractImportApiResponse exposes semantic_meta + annotations', () => {
+    const extracted = extractImportApiResponse({
+      cv: { prenom: 'Ada' },
+      layout_hints: {},
+      layout: { pages: [] },
+      semantic_meta: { schema_version: 1 },
+      block_annotations: [{ block_id: 'b1', type: 'identity', confidence: 0.9 }],
+    });
+    assert.equal(extracted.semanticMeta.schema_version, 1);
+    assert.equal(extracted.blockAnnotations.length, 1);
+  });
+});
+
+describe('structuralSemanticBind annotations', () => {
+  it('prefer API annotations over heuristics', () => {
+    const layout = {
+      version: 3,
+      pages: [{
+        blocks: [
+          {
+            id: 't1',
+            type: 'text',
+            x: 10,
+            y: 10,
+            w: 40,
+            h: 8,
+            content: 'Something odd',
+            style: { font_size: 11, bold: true },
+          },
+        ],
+      }],
+    };
+    const { layout: bound, boundCount } = bindStructuralTextToSemanticBlocks(
+      layout,
+      {},
+      {
+        annotations: [{
+          block_id: 't1',
+          type: 'experiences',
+          kind: 'heading',
+          confidence: 0.95,
+          section_label: 'EXPERIENCES',
+        }],
+      },
+    );
+    assert.equal(boundCount, 1);
+    const types = bound.pages[0].blocks.map((b) => b.type);
+    assert.ok(types.includes('experiences'));
+  });
+});

--- a/tests/test_cv_import_semantic.py
+++ b/tests/test_cv_import_semantic.py
@@ -1,0 +1,129 @@
+"""Tests AXE-332 — découpe sections + annotations blocs (sans Gemini)."""
+
+from backend.services.cv_import_semantic import (
+    annotate_structural_blocks,
+    parse_cv_by_sections,
+    split_cv_text_into_sections,
+)
+
+
+SAMPLE_TEXT = """
+Ada Lovelace
+ada@example.com
++33 6 00 00 00 00
+
+Expériences
+Software Engineer — Analytical Engines
+2020 — 2024
+- Built early algorithms
+
+Formations
+Mathematics — Cambridge
+2016
+
+Compétences
+Python, Algorithms
+"""
+
+
+def test_split_cv_text_into_sections_finds_blocks():
+    sections = split_cv_text_into_sections(SAMPLE_TEXT)
+    assert "identity" in sections
+    assert "ada@example.com" in sections["identity"].lower() or "Ada" in sections["identity"]
+    assert "experiences" in sections
+    assert "Software Engineer" in sections["experiences"]
+    assert "formations" in sections
+    assert "skills" in sections
+
+
+def test_parse_cv_by_sections_merges_mocked_passes():
+    calls: list[str] = []
+
+    def fake_generate(prompt: str, _uid: str | None) -> dict:
+        calls.append(prompt[:40])
+        if "identité" in prompt.lower() or "IDENTITY" in prompt or "contact" in prompt.lower():
+            return {
+                "prenom": "Ada",
+                "nom": "Lovelace",
+                "first_name": "Ada",
+                "last_name": "Lovelace",
+                "email": "ada@example.com",
+            }
+        if "expériences" in prompt.lower() or "experiences" in prompt.lower():
+            return {
+                "experiences": [
+                    {
+                        "id": "exp_1",
+                        "poste": "Software Engineer",
+                        "entreprise": "Analytical Engines",
+                        "bullet_points": ["Built early algorithms"],
+                    }
+                ]
+            }
+        if "formations" in prompt.lower():
+            return {
+                "formations": [
+                    {"id": "form_1", "diplome": "Mathematics", "etablissement": "Cambridge"}
+                ]
+            }
+        if "compétences" in prompt.lower() or "competences" in prompt.lower():
+            return {"competences": {"techniques": ["Python", "Algorithms"]}}
+        return {}
+
+    cv, _hints, meta = parse_cv_by_sections(SAMPLE_TEXT, "user-1", fake_generate)
+    assert cv["prenom"] == "Ada"
+    assert cv["first_name"] == "Ada"
+    assert cv["email"] == "ada@example.com"
+    assert len(cv.get("experiences") or []) >= 1
+    assert meta["source"] == "import_sectioned"
+    assert len(meta["section_passes"]) >= 1
+    assert calls  # au moins une passe
+
+
+def test_annotate_structural_blocks_identity_and_heading():
+    layout = {
+        "version": 3,
+        "pages": [
+            {
+                "height_mm": 297,
+                "blocks": [
+                    {
+                        "id": "b1",
+                        "type": "text",
+                        "x": 20,
+                        "y": 15,
+                        "w": 80,
+                        "h": 10,
+                        "content": "Ada Lovelace",
+                        "style": {"font_size": 18, "bold": True},
+                    },
+                    {
+                        "id": "b2",
+                        "type": "text",
+                        "x": 20,
+                        "y": 40,
+                        "w": 60,
+                        "h": 8,
+                        "content": "Expériences professionnelles",
+                        "style": {"font_size": 12, "bold": True},
+                    },
+                    {
+                        "id": "b3",
+                        "type": "text",
+                        "x": 20,
+                        "y": 55,
+                        "w": 90,
+                        "h": 8,
+                        "content": "ada@example.com",
+                    },
+                ],
+            }
+        ],
+    }
+    cv = {"prenom": "Ada", "nom": "Lovelace", "first_name": "Ada", "last_name": "Lovelace"}
+    anns = annotate_structural_blocks(layout, cv)
+    by_id = {a["block_id"]: a for a in anns}
+    assert by_id["b1"]["type"] == "identity"
+    assert by_id["b2"]["kind"] == "heading"
+    assert by_id["b2"]["type"] == "experiences"
+    assert by_id["b3"]["type"] == "contact"

--- a/tests/test_cv_import_semantic.py
+++ b/tests/test_cv_import_semantic.py
@@ -265,3 +265,78 @@ def test_layout_hints_pass_when_sections_succeed():
     assert "layout_hints" in meta["section_passes"]
     assert hints.get("layout_style") == "sidebar-left"
     assert hints.get("accent_color") == "#1863dc"
+
+
+def test_profil_only_heading_still_triggers_fallback_full():
+    """Profil seul ne doit pas bloquer le full parse (corps après = expériences)."""
+    text = """Ada Lovelace
+ada@example.com
+
+Profil
+Ingénieure passionnée.
+Software Engineer — Analytical Engines 2020-2024
+Built early algorithms
+"""
+    fallback_calls: list[str] = []
+
+    def fake_generate(prompt: str, _uid: str | None) -> dict:
+        low = prompt.lower()
+        if "mise en page" in low:
+            return {}
+        if "résumé" in low or "resume" in low or "accroche" in low:
+            return {"resume": "Ingénieure passionnée."}
+        if "identité" in low or "contact" in low:
+            return {"prenom": "Ada", "nom": "Lovelace", "email": "ada@example.com"}
+        return {}
+
+    def fake_full(full_text: str, _uid: str | None) -> dict:
+        fallback_calls.append(full_text[:30])
+        return {
+            "cv": {
+                "prenom": "Ada",
+                "nom": "Lovelace",
+                "email": "ada@example.com",
+                "resume": "Ingénieure passionnée.",
+                "experiences": [
+                    {
+                        "id": "exp_1",
+                        "poste": "Software Engineer",
+                        "entreprise": "Analytical Engines",
+                    }
+                ],
+            },
+            "layout_hints": {"layout_style": "single-column"},
+        }
+
+    cv, _hints, meta = parse_cv_by_sections(text, "user-1", fake_generate, fallback_full=fake_full)
+    assert fallback_calls, "Profil-only heading must call fallback_full"
+    assert "fallback_full" in meta["section_passes"]
+    assert len(cv.get("experiences") or []) >= 1
+
+
+def test_layout_hints_quota_does_not_abort_parsed_cv():
+    from backend.gemini_usage import GeminiQuotaExceeded
+
+    def fake_generate(prompt: str, _uid: str | None) -> dict:
+        low = prompt.lower()
+        if "mise en page" in low:
+            raise GeminiQuotaExceeded()
+        if "identité" in low or "contact" in low:
+            return {"prenom": "Ada", "nom": "Lovelace", "email": "ada@example.com"}
+        if "expériences" in low or "experiences" in low:
+            return {
+                "experiences": [
+                    {"id": "exp_1", "poste": "Software Engineer", "entreprise": "Engines"}
+                ]
+            }
+        if "formations" in low:
+            return {"formations": [{"id": "form_1", "diplome": "Mathematics"}]}
+        if "compétences" in low or "competences" in low:
+            return {"competences": {"techniques": ["Python"]}}
+        return {}
+
+    cv, hints, meta = parse_cv_by_sections(SAMPLE_TEXT, "user-1", fake_generate)
+    assert cv["prenom"] == "Ada"
+    assert len(cv.get("experiences") or []) >= 1
+    assert hints == {}
+    assert "layout_hints" not in meta["section_passes"]

--- a/tests/test_cv_import_semantic.py
+++ b/tests/test_cv_import_semantic.py
@@ -6,7 +6,6 @@ from backend.services.cv_import_semantic import (
     split_cv_text_into_sections,
 )
 
-
 SAMPLE_TEXT = """
 Ada Lovelace
 ada@example.com

--- a/tests/test_cv_import_semantic.py
+++ b/tests/test_cv_import_semantic.py
@@ -126,3 +126,142 @@ def test_annotate_structural_blocks_identity_and_heading():
     assert by_id["b2"]["kind"] == "heading"
     assert by_id["b2"]["type"] == "experiences"
     assert by_id["b3"]["type"] == "contact"
+
+
+def test_split_profil_heading_goes_to_resume_not_identity():
+    text = """Ada Lovelace
+ada@example.com
+
+Profil
+Ingénieure passionnée par les algorithmes.
+
+Expériences
+Software Engineer — Engines
+"""
+    sections = split_cv_text_into_sections(text)
+    assert "resume" in sections
+    assert "algorithmes" in sections["resume"].lower()
+    assert "profil" not in (sections.get("identity") or "").lower()
+
+
+def test_headingless_cv_triggers_fallback_full():
+    text = """Ada Lovelace
+ada@example.com
+Software Engineer at Analytical Engines 2020-2024
+Built early algorithms
+Mathematics Cambridge 2016
+Python Algorithms
+"""
+    fallback_calls: list[str] = []
+
+    def fake_generate(prompt: str, _uid: str | None) -> dict:
+        if "mise en page" in prompt.lower() or "layout_hints" in prompt.lower():
+            return {"layout_hints": {"layout_style": "single-column", "sections_emphasis": []}}
+        return {
+            "prenom": "Ada",
+            "nom": "Lovelace",
+            "email": "ada@example.com",
+        }
+
+    def fake_full(full_text: str, _uid: str | None) -> dict:
+        fallback_calls.append(full_text[:20])
+        return {
+            "cv": {
+                "prenom": "Ada",
+                "nom": "Lovelace",
+                "first_name": "Ada",
+                "last_name": "Lovelace",
+                "email": "ada@example.com",
+                "experiences": [
+                    {
+                        "id": "exp_1",
+                        "poste": "Software Engineer",
+                        "entreprise": "Analytical Engines",
+                    }
+                ],
+            },
+            "layout_hints": {"layout_style": "single-column"},
+        }
+
+    cv, hints, meta = parse_cv_by_sections(text, "user-1", fake_generate, fallback_full=fake_full)
+    assert fallback_calls, "heading-less CV must call fallback_full"
+    assert "fallback_full" in meta["section_passes"]
+    assert len(cv.get("experiences") or []) >= 1
+    assert hints.get("layout_style") == "single-column"
+
+
+def test_languages_pass_runs_even_after_skills():
+    text = """Ada Lovelace
+ada@example.com
+
+Compétences
+Python, Algorithms
+
+Langues
+Anglais — courant
+"""
+
+    def fake_generate(prompt: str, _uid: str | None) -> dict:
+        low = prompt.lower()
+        if "mise en page" in low:
+            return {"layout_hints": {"layout_style": "single-column"}}
+        if "identité" in low or "contact" in low:
+            return {"prenom": "Ada", "nom": "Lovelace", "email": "ada@example.com"}
+        if "compétences" in low or "competences" in low:
+            if "anglais" in low:
+                return {"competences": {"langues": [{"langue": "Anglais", "niveau": "courant"}]}}
+            return {"competences": {"techniques": ["Python", "Algorithms"]}}
+        return {}
+
+    cv, _hints, meta = parse_cv_by_sections(text, "user-1", fake_generate)
+    assert "skills" in meta["section_passes"]
+    assert "languages" in meta["section_passes"]
+    langues = (cv.get("competences") or {}).get("langues") or []
+    assert any((x.get("langue") or "").lower().startswith("anglais") for x in langues)
+
+
+def test_quota_exceeded_is_not_swallowed():
+    import pytest
+
+    from backend.gemini_usage import GeminiQuotaExceeded
+
+    def boom(_prompt: str, _uid: str | None) -> dict:
+        raise GeminiQuotaExceeded()
+
+    with pytest.raises(GeminiQuotaExceeded):
+        parse_cv_by_sections(SAMPLE_TEXT, "user-1", boom)
+
+
+def test_layout_hints_pass_when_sections_succeed():
+    def fake_generate(prompt: str, _uid: str | None) -> dict:
+        low = prompt.lower()
+        if "mise en page" in low:
+            return {
+                "layout_hints": {
+                    "layout_style": "sidebar-left",
+                    "accent_color": "#1863dc",
+                    "sections_emphasis": ["experiences"],
+                }
+            }
+        if "identité" in low or "contact" in low:
+            return {
+                "prenom": "Ada",
+                "nom": "Lovelace",
+                "email": "ada@example.com",
+            }
+        if "expériences" in low or "experiences" in low:
+            return {
+                "experiences": [
+                    {"id": "exp_1", "poste": "Software Engineer", "entreprise": "Engines"}
+                ]
+            }
+        if "formations" in low:
+            return {"formations": [{"id": "form_1", "diplome": "Mathematics"}]}
+        if "compétences" in low or "competences" in low:
+            return {"competences": {"techniques": ["Python"]}}
+        return {}
+
+    _cv, hints, meta = parse_cv_by_sections(SAMPLE_TEXT, "user-1", fake_generate)
+    assert "layout_hints" in meta["section_passes"]
+    assert hints.get("layout_style") == "sidebar-left"
+    assert hints.get("accent_color") == "#1863dc"

--- a/tests/test_cv_semantic_schema.py
+++ b/tests/test_cv_semantic_schema.py
@@ -1,0 +1,49 @@
+"""Tests AXE-332 — dual-key + semantic_meta."""
+
+from backend.services.cv_semantic_schema import (
+    build_semantic_meta,
+    estimate_field_confidence,
+    sync_dual_keys,
+)
+
+
+def test_sync_dual_keys_fr_fills_en():
+    out = sync_dual_keys({"prenom": "Ada", "nom": "Lovelace"})
+    assert out["first_name"] == "Ada"
+    assert out["last_name"] == "Lovelace"
+
+
+def test_sync_dual_keys_en_fills_fr():
+    out = sync_dual_keys({"first_name": "Grace", "last_name": "Hopper"})
+    assert out["prenom"] == "Grace"
+    assert out["nom"] == "Hopper"
+
+
+def test_sync_dual_keys_fr_wins_on_conflict():
+    out = sync_dual_keys({"prenom": "Ada", "first_name": "Other", "nom": "Lovelace", "last_name": "X"})
+    assert out["prenom"] == "Ada"
+    assert out["first_name"] == "Ada"
+    assert out["nom"] == "Lovelace"
+    assert out["last_name"] == "Lovelace"
+
+
+def test_build_semantic_meta_marks_missing_critical():
+    meta = build_semantic_meta({"prenom": "Ada"}, source="test")
+    assert meta["dual_key"] is True
+    assert meta["schema_version"] == 1
+    assert "email" in meta["missing_critical_fields"]
+    assert meta["fields"]["prenom"] >= 0.9
+    assert meta["fields"]["first_name"] >= 0.9
+
+
+def test_estimate_field_confidence_sections():
+    cv = sync_dual_keys(
+        {
+            "prenom": "A",
+            "nom": "B",
+            "experiences": [{"id": "exp_1", "poste": "Dev", "entreprise": "X"}],
+        }
+    )
+    conf = estimate_field_confidence(cv)
+    assert conf["experiences"] >= 0.8
+    assert conf["formations"] == 0.0

--- a/tests/test_cv_semantic_schema.py
+++ b/tests/test_cv_semantic_schema.py
@@ -20,7 +20,9 @@ def test_sync_dual_keys_en_fills_fr():
 
 
 def test_sync_dual_keys_fr_wins_on_conflict():
-    out = sync_dual_keys({"prenom": "Ada", "first_name": "Other", "nom": "Lovelace", "last_name": "X"})
+    out = sync_dual_keys(
+        {"prenom": "Ada", "first_name": "Other", "nom": "Lovelace", "last_name": "X"}
+    )
     assert out["prenom"] == "Ada"
     assert out["first_name"] == "Ada"
     assert out["nom"] == "Lovelace"


### PR DESCRIPTION
## Summary
- Sync dual-key identité (`prenom`/`nom` ↔ `first_name`/`last_name`) côté schéma import + FE.
- Parse LLM par sections avec `semantic_meta`, annotations blocs structurels dans la réponse API, fallback full parse si sections trop pauvres.
- FE : bind structurel préfère les annotations API aux heuristiques.

Fixes AXE-332
Closes #93

## Test plan
- [ ] `pytest tests/test_cv_semantic_schema.py tests/test_cv_import_semantic.py`
- [ ] `npm run test:unit` (cvDualKey + structuralSemanticBind)
- [ ] Import PDF/DOCX réel : vérifier `first_name`/`last_name` remplis + `semantic_meta` dans la réponse
- [ ] Canvas structurel : titres/corps liés via annotations (moins de freeform fantôme)
- [ ] Fallback : CV sans titres de section → full parse toujours OK


Made with [Cursor](https://cursor.com)