### PR TITLE
feat(canvas): composer En-tête guidé (AXE-334)

### DIFF
--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -115,6 +115,12 @@ import EditorImageEditPopover from './EditorImageEditPopover.jsx';
 import EditorCanvaTransferModal from './EditorCanvaTransferModal.jsx';
 import EditorCvImportModal from './EditorCvImportModal.jsx';
 import EditorOnboardingTour from './EditorOnboardingTour.jsx';
+import HeaderComposerModal from './HeaderComposerModal.jsx';
+import {
+  applyHeaderComposerToLayout,
+  mergeHeaderComposerCv,
+} from '../../lib/headerComposerPresets.js';
+import '../../styles/HeaderComposerModal.css';
 
 import {
   buildCanvasPdfFilename,
@@ -178,6 +184,7 @@ function CvEditorBeta({
   const [canvasSnapEnabled, setCanvasSnapEnabled] = useState(true);
   const [imageEditBlockId, setImageEditBlockId] = useState(null);
   const [sidebarSection, setSidebarSection] = useState('sections');
+  const [headerComposerOpen, setHeaderComposerOpen] = useState(false);
   const [placementPreset, setPlacementPreset] = useState(null);
   const [startupPromptOpen, setStartupPromptOpen] = useState(false);
   const [onboardingDismissed, setOnboardingDismissed] = useState(() => isEditorOnboardingDismissed());
@@ -424,11 +431,37 @@ function CvEditorBeta({
 
   const handleEmptyAddSection = useCallback(() => {
     setSidebarSection('sections');
+    setHeaderComposerOpen(true);
   }, []);
 
   const handleEmptyChooseTemplate = useCallback(() => {
     setSidebarSection('design');
   }, []);
+
+  const handleOpenHeaderComposer = useCallback(() => {
+    setSidebarSection('sections');
+    setHeaderComposerOpen(true);
+  }, []);
+
+  const handleHeaderComposerConfirm = useCallback((payload) => {
+    if (!layout || !payload || profileLoadError) return;
+    const nextCv = mergeHeaderComposerCv(cv, payload.values, payload.fields);
+    handleCvChange(nextCv);
+    const { layout: nextLayout, placedIds } = applyHeaderComposerToLayout(layout, 0, {
+      variantId: payload.variantId,
+      fields: payload.fields,
+    });
+    commitLayout(nextLayout);
+    // Persister cv + layout ensemble (évite un flush avec l’ancien cv).
+    if (nextCv) autoSave.schedule({ ...nextCv, layout: nextLayout });
+    if (placedIds.length) {
+      setSelectedBlockIds(placedIds);
+      setEditingBlockId(null);
+      setImageEditBlockId(null);
+    }
+    setHeaderComposerOpen(false);
+    setStartupPromptOpen(false);
+  }, [layout, cv, handleCvChange, commitLayout, autoSave, profileLoadError]);
 
   const handleDismissOnboarding = useCallback(() => {
     dismissEditorOnboarding();
@@ -1763,6 +1796,7 @@ function CvEditorBeta({
           onShowGridChange={setShowCanvasGrid}
           onSnapEnabledChange={setCanvasSnapEnabled}
           onBeginPlacement={handleBeginPlacement}
+          onOpenHeaderComposer={handleOpenHeaderComposer}
           onCancelPlacement={handleCancelPlacement}
           onSelectBlock={handleSelectBlock}
           onBlockPatch={handleBlockPatchById}
@@ -1849,27 +1883,13 @@ function CvEditorBeta({
                   <span className="cv-editor-beta-start-panel__eyebrow">Démarrer en Beta</span>
                   <h2>Comment veux-tu commencer ?</h2>
                   <p>
-                    Ton profil est chargé, mais aucune mise en page canvas n&apos;est encore
-                    enregistrée. Choisis une option pour ne pas rester sur une page vide.
+                    Ne reste pas sur une page vide : importe ton CV, pars d’un modèle,
+                    ou génère une mise en page depuis ton profil.
                   </p>
                   <div className="cv-editor-beta-start-panel__actions">
                     <button
                       type="button"
                       className="cv-editor-beta-start-panel__primary"
-                      onClick={handleGenerateStarterCanvas}
-                    >
-                      Générer depuis mon profil
-                    </button>
-                    <button
-                      type="button"
-                      className="cv-editor-beta-start-panel__secondary"
-                      onClick={handleChooseAtsSafeTemplate}
-                    >
-                      Choisir un modèle ATS-safe
-                    </button>
-                    <button
-                      type="button"
-                      className="cv-editor-beta-start-panel__import"
                       onClick={() => {
                         clearCanvasSelection();
                         setImportError('');
@@ -1880,6 +1900,20 @@ function CvEditorBeta({
                     </button>
                     <button
                       type="button"
+                      className="cv-editor-beta-start-panel__secondary"
+                      onClick={handleChooseAtsSafeTemplate}
+                    >
+                      Choisir un modèle
+                    </button>
+                    <button
+                      type="button"
+                      className="cv-editor-beta-start-panel__import"
+                      onClick={handleGenerateStarterCanvas}
+                    >
+                      Générer depuis mon profil
+                    </button>
+                    <button
+                      type="button"
                       className="cv-editor-beta-start-panel__advanced"
                       onClick={handlePickBlankCanvas}
                     >
@@ -1887,8 +1921,9 @@ function CvEditorBeta({
                     </button>
                   </div>
                   <p className="cv-editor-beta-start-panel__hint">
-                    « Générer depuis mon profil » crée une mise en page ATS-safe à partir de
-                    tes données. « Page blanche » efface le layout serveur (reload → canvas vide).
+                    Après démarrage, utilise « Composer l’en-tête » dans Sections pour
+                    poser identité + contact avec un design soigné. La page blanche
+                    est réservée aux utilisateurs avancés.
                   </p>
                 </div>
               </section>
@@ -1957,6 +1992,13 @@ function CvEditorBeta({
         confirming={importChooserConfirming}
         onConfirm={handleImportChooserConfirm}
         onCancel={handleImportChooserCancel}
+      />
+
+      <HeaderComposerModal
+        open={headerComposerOpen}
+        cv={cv}
+        onConfirm={handleHeaderComposerConfirm}
+        onCancel={() => setHeaderComposerOpen(false)}
       />
 
     </div>

--- a/frontend/src/components/editor/EditorCanvaSidebar.jsx
+++ b/frontend/src/components/editor/EditorCanvaSidebar.jsx
@@ -205,6 +205,7 @@ export default function EditorCanvaSidebar({
   onShowGridChange,
   onSnapEnabledChange,
   onBeginPlacement,
+  onOpenHeaderComposer,
   onCancelPlacement,
   onSelectBlock,
   onBlockPatch,
@@ -384,7 +385,21 @@ export default function EditorCanvaSidebar({
             <>
               <h3 className="editor-canva-drawer__title">Sections CV</h3>
               <p className="editor-canva-drawer__hint editor-canva-drawer__hint--subtle">
-                Blocs liés à ton CV de base (contenu partagé avec le mode Stable). Clique puis place sur le canevas.
+                Commence par un composer guidé, ou place un bloc libre ensuite.
+              </p>
+              <button
+                type="button"
+                className="editor-canva-composer-cta"
+                disabled={disabled}
+                onClick={() => onOpenHeaderComposer?.()}
+              >
+                <span className="editor-canva-composer-cta__label">Composer l’en-tête</span>
+                <span className="editor-canva-composer-cta__hint">
+                  Design + champs + inputs — puis free-edit
+                </span>
+              </button>
+              <p className="editor-canva-drawer__hint editor-canva-drawer__hint--subtle">
+                Blocs individuels (avancé) — liés à ton CV de base.
               </p>
               <div className="editor-canva-drawer__grid editor-canva-drawer__grid--sections">
                 {CV_SECTION_ITEMS.map((item) => {

--- a/frontend/src/components/editor/FreeCanvas.jsx
+++ b/frontend/src/components/editor/FreeCanvas.jsx
@@ -866,7 +866,7 @@ export default function FreeCanvas({
                   <div className="free-canvas-page-empty" role="status">
                     <p className="free-canvas-page-empty__title">Cette page est vide</p>
                     <p className="free-canvas-page-empty__text">
-                      Ajoute une section CV ou pars d’un modèle pour démarrer.
+                      Compose ton en-tête ou pars d’un modèle pour démarrer.
                     </p>
                     <div className="free-canvas-page-empty__actions">
                       <button
@@ -877,7 +877,7 @@ export default function FreeCanvas({
                           onEmptyAddSection?.();
                         }}
                       >
-                        Ajouter une section
+                        Composer l’en-tête
                       </button>
                       <button
                         type="button"

--- a/frontend/src/components/editor/FreeCanvasBlock.jsx
+++ b/frontend/src/components/editor/FreeCanvasBlock.jsx
@@ -16,6 +16,7 @@ import {
   getEditableFieldConfig,
 } from '../../lib/editableFieldBehavior.js';
 import {
+  bindIncludesPath,
   resolveCompetenceList,
   resolveBoundText,
   resolveCertifications,
@@ -91,24 +92,34 @@ function SemanticBlockBody({ block, cv, editing = false }) {
 
   switch (type) {
     case 'identity': {
-      const prenom = getFieldDisplayValue(cv, 'prenom');
-      const nom = getFieldDisplayValue(cv, 'nom');
-      const title = getFieldDisplayValue(cv, 'titre_professionnel');
+      const showPrenom = bindIncludesPath(bind, 'prenom');
+      const showNom = bindIncludesPath(bind, 'nom');
+      const showTitle = bindIncludesPath(bind, 'titre_professionnel');
+      const prenom = showPrenom ? getFieldDisplayValue(cv, 'prenom') : '';
+      const nom = showNom ? getFieldDisplayValue(cv, 'nom') : '';
+      const title = showTitle ? getFieldDisplayValue(cv, 'titre_professionnel') : '';
       const inlineTitle = style.header_layout === 'inline-title';
-      const nameEl = editing ? (
-        <>
-          <CanvasEditableField path="prenom" editing className="free-canvas-block__inline-name">
-            {prenom || 'Prénom'}
-          </CanvasEditableField>
-          {' '}
-          <CanvasEditableField path="nom" editing className="free-canvas-block__inline-name">
-            {nom || 'Nom'}
-          </CanvasEditableField>
-        </>
-      ) : (
-        <BlockText>{resolveBoundText(cv, ['prenom', 'nom']) || 'Prénom Nom'}</BlockText>
-      );
-      const titleEl = (editing || title) ? (
+      const nameBind = ['prenom', 'nom'].filter((p) => bindIncludesPath(bind, p));
+      const nameEl = (showPrenom || showNom) ? (
+        editing ? (
+          <>
+            {showPrenom ? (
+              <CanvasEditableField path="prenom" editing className="free-canvas-block__inline-name">
+                {prenom || 'Prénom'}
+              </CanvasEditableField>
+            ) : null}
+            {showPrenom && showNom ? ' ' : null}
+            {showNom ? (
+              <CanvasEditableField path="nom" editing className="free-canvas-block__inline-name">
+                {nom || 'Nom'}
+              </CanvasEditableField>
+            ) : null}
+          </>
+        ) : (
+          <BlockText>{resolveBoundText(cv, nameBind) || 'Prénom Nom'}</BlockText>
+        )
+      ) : null;
+      const titleEl = showTitle && (editing || title) ? (
         editing ? (
           <CanvasEditableField path="titre_professionnel" editing>
             {title || 'Titre professionnel'}
@@ -126,23 +137,25 @@ function SemanticBlockBody({ block, cv, editing = false }) {
               style.identity_divider ? 'free-canvas-block__identity--divider' : '',
             ].filter(Boolean).join(' ')}
           >
-            <span className="free-canvas-block__identity-name">{nameEl}</span>
+            {nameEl ? <span className="free-canvas-block__identity-name">{nameEl}</span> : null}
+            {nameEl && titleEl ? (
+              <span className="free-canvas-block__identity-sep"> - </span>
+            ) : null}
             {titleEl ? (
-              <>
-                <span className="free-canvas-block__identity-sep"> - </span>
-                <span className="free-canvas-block__identity-title free-canvas-block__identity-title--accent">
-                  {titleEl}
-                </span>
-              </>
+              <span className="free-canvas-block__identity-title free-canvas-block__identity-title--accent">
+                {titleEl}
+              </span>
             ) : null}
           </h1>
         );
       }
       return (
         <div className={`free-canvas-block__identity${style.identity_divider ? ' free-canvas-block__identity--divider' : ''}`}>
-          <div className="free-canvas-block__identity-name" style={{ textAlign: style.align || 'left' }}>
-            {nameEl}
-          </div>
+          {nameEl ? (
+            <div className="free-canvas-block__identity-name" style={{ textAlign: style.align || 'left' }}>
+              {nameEl}
+            </div>
+          ) : null}
           {titleEl ? (
             <div
               className={
@@ -173,9 +186,12 @@ function SemanticBlockBody({ block, cv, editing = false }) {
       );
     }
     case 'contact': {
-      const tel = getFieldDisplayValue(cv, 'telephone');
-      const email = getFieldDisplayValue(cv, 'email');
-      const linkedin = getFieldDisplayValue(cv, 'linkedin');
+      const showTel = bindIncludesPath(bind, 'telephone');
+      const showEmail = bindIncludesPath(bind, 'email');
+      const showLinkedin = bindIncludesPath(bind, 'linkedin');
+      const tel = showTel ? getFieldDisplayValue(cv, 'telephone') : '';
+      const email = showEmail ? getFieldDisplayValue(cv, 'email') : '';
+      const linkedin = showLinkedin ? getFieldDisplayValue(cv, 'linkedin') : '';
       const contactCls = [
         'free-canvas-block__contact',
         style.contact_divider ? 'free-canvas-block__contact--divider' : '',
@@ -185,7 +201,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
       ].filter(Boolean).join(' ');
       if (style.contact_layout === 'header-bar') {
         const segments = [];
-        if (editing || tel) {
+        if (showTel && (editing || tel)) {
           segments.push(
             <span key="tel" className="free-canvas-block__contact-segment">
               <HiPhone size={12} className="free-canvas-block__contact-icon" aria-hidden />
@@ -198,7 +214,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
             </span>,
           );
         }
-        if (editing || email) {
+        if (showEmail && (editing || email)) {
           segments.push(
             <span key="email" className="free-canvas-block__contact-segment">
               <HiEnvelope size={12} className="free-canvas-block__contact-icon" aria-hidden />
@@ -211,7 +227,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
             </span>,
           );
         }
-        if (editing || linkedin) {
+        if (showLinkedin && (editing || linkedin)) {
           segments.push(
             <span key="linkedin" className="free-canvas-block__contact-segment">
               <HiLink size={12} className="free-canvas-block__contact-icon" aria-hidden />
@@ -240,7 +256,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
           {style.section_label ? (
             <SectionHeading label={style.section_label} titleStyle={style.title_style} zone={style.zone} />
           ) : null}
-          {(editing || tel) ? (
+          {showTel && (editing || tel) ? (
             <p>
               <HiPhone size={12} className="free-canvas-block__contact-icon" aria-hidden />
               {' '}
@@ -251,7 +267,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
               )}
             </p>
           ) : null}
-          {(editing || email) ? (
+          {showEmail && (editing || email) ? (
             <p>
               <HiEnvelope size={12} className="free-canvas-block__contact-icon" aria-hidden />
               {' '}
@@ -262,7 +278,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
               )}
             </p>
           ) : null}
-          {(editing || linkedin) ? (
+          {showLinkedin && (editing || linkedin) ? (
             <p>
               <HiLink size={12} className="free-canvas-block__contact-icon" aria-hidden />
               {' '}

--- a/frontend/src/components/editor/FreeCanvasBlock.jsx
+++ b/frontend/src/components/editor/FreeCanvasBlock.jsx
@@ -17,6 +17,7 @@ import {
 } from '../../lib/editableFieldBehavior.js';
 import {
   bindIncludesPath,
+  identityNameEmptyLabel,
   resolveCompetenceList,
   resolveBoundText,
   resolveCertifications,
@@ -116,7 +117,9 @@ function SemanticBlockBody({ block, cv, editing = false }) {
             ) : null}
           </>
         ) : (
-          <BlockText>{resolveBoundText(cv, nameBind) || 'Prénom Nom'}</BlockText>
+          <BlockText>
+            {resolveBoundText(cv, nameBind) || identityNameEmptyLabel(bind)}
+          </BlockText>
         )
       ) : null;
       const titleEl = showTitle && (editing || title) ? (

--- a/frontend/src/components/editor/HeaderComposerModal.jsx
+++ b/frontend/src/components/editor/HeaderComposerModal.jsx
@@ -1,0 +1,195 @@
+import { useEffect, useState } from 'react';
+
+import {
+  HEADER_COMPOSER_CONTACT_FIELDS,
+  HEADER_COMPOSER_FIELD_LABELS,
+  HEADER_COMPOSER_IDENTITY_FIELDS,
+  HEADER_COMPOSER_VARIANTS,
+  defaultHeaderComposerState,
+  resolveHeaderComposerVariant,
+  selectedContactBinds,
+  selectedIdentityBinds,
+} from '../../lib/headerComposerPresets.js';
+import '../../styles/HeaderComposerModal.css';
+
+/**
+ * Composer guidé En-tête (AXE-334 P0).
+ * Design variant + champs + inputs → place sur le canvas.
+ */
+export default function HeaderComposerModal({
+  open,
+  cv = null,
+  confirming = false,
+  onConfirm,
+  onCancel,
+}) {
+  const [variantId, setVariantId] = useState(HEADER_COMPOSER_VARIANTS[0].id);
+  const [fields, setFields] = useState(() => defaultHeaderComposerState(cv).fields);
+  const [values, setValues] = useState(() => defaultHeaderComposerState(cv).values);
+
+  useEffect(() => {
+    if (!open) return;
+    const initial = defaultHeaderComposerState(cv);
+    setVariantId(HEADER_COMPOSER_VARIANTS[0].id);
+    setFields(initial.fields);
+    setValues(initial.values);
+  }, [open, cv]);
+
+  if (!open) return null;
+
+  const identityOk = selectedIdentityBinds(fields).length > 0;
+  const contactOk = selectedContactBinds(fields).length > 0;
+  const canPlace = identityOk || contactOk;
+
+  const toggleField = (key) => {
+    setFields((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const setValue = (key, next) => {
+    setValues((prev) => ({ ...prev, [key]: next }));
+  };
+
+  const handleConfirm = () => {
+    if (!canPlace || confirming) return;
+    onConfirm?.({
+      variantId: resolveHeaderComposerVariant(variantId).id,
+      fields: { ...fields },
+      values: { ...values },
+    });
+  };
+
+  const renderFieldRow = (key) => {
+    const checked = Boolean(fields[key]);
+    const label = HEADER_COMPOSER_FIELD_LABELS[key] || key;
+    return (
+      <div key={key} className="header-composer-field">
+        <label className="header-composer-field__check">
+          <input
+            type="checkbox"
+            checked={checked}
+            onChange={() => toggleField(key)}
+            disabled={confirming}
+          />
+          <span>{label}</span>
+        </label>
+        {checked ? (
+          <input
+            type="text"
+            className="header-composer-field__input"
+            value={values[key] || ''}
+            onChange={(e) => setValue(key, e.target.value)}
+            placeholder={label}
+            disabled={confirming}
+            autoComplete="off"
+          />
+        ) : (
+          <p className="header-composer-field__hint">
+            Masqué sur le canvas — reste dans ton CV
+          </p>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div
+      className="header-composer-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="header-composer-title"
+      onClick={() => {
+        if (!confirming) onCancel?.();
+      }}
+    >
+      <div
+        className="header-composer-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="header-composer-head">
+          <div>
+            <span className="header-composer-eyebrow">Composer</span>
+            <h2 id="header-composer-title">En-tête du CV</h2>
+            <p>
+              Choisis un design, coche ce que tu affiches, renseigne tes infos —
+              puis place. Tu pourras tout bouger librement ensuite.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="header-composer-close"
+            onClick={() => onCancel?.()}
+            aria-label="Fermer"
+            disabled={confirming}
+          >
+            ×
+          </button>
+        </header>
+
+        <section className="header-composer-section" aria-label="Design">
+          <h3 className="header-composer-section__title">Design</h3>
+          <div className="header-composer-variants" role="listbox" aria-label="Variantes d’en-tête">
+            {HEADER_COMPOSER_VARIANTS.map((variant) => {
+              const selected = variant.id === variantId;
+              return (
+                <button
+                  key={variant.id}
+                  type="button"
+                  role="option"
+                  aria-selected={selected}
+                  className={`header-composer-variant${selected ? ' is-selected' : ''}`}
+                  onClick={() => setVariantId(variant.id)}
+                  disabled={confirming}
+                >
+                  <span
+                    className={`header-composer-variant__preview header-composer-variant__preview--${variant.id}`}
+                    aria-hidden
+                  />
+                  <strong>{variant.label}</strong>
+                  <span>{variant.description}</span>
+                </button>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="header-composer-section" aria-label="Identité">
+          <h3 className="header-composer-section__title">Identité</h3>
+          <div className="header-composer-fields">
+            {HEADER_COMPOSER_IDENTITY_FIELDS.map(renderFieldRow)}
+          </div>
+        </section>
+
+        <section className="header-composer-section" aria-label="Contact">
+          <h3 className="header-composer-section__title">Contact (optionnel)</h3>
+          <div className="header-composer-fields">
+            {HEADER_COMPOSER_CONTACT_FIELDS.map(renderFieldRow)}
+          </div>
+        </section>
+
+        {!canPlace ? (
+          <p className="header-composer-warn" role="status">
+            Coche au moins un champ pour placer l’en-tête.
+          </p>
+        ) : null}
+
+        <footer className="header-composer-actions">
+          <button type="button" onClick={() => onCancel?.()} disabled={confirming}>
+            Annuler
+          </button>
+          <button
+            type="button"
+            className="header-composer-primary"
+            onClick={handleConfirm}
+            disabled={!canPlace || confirming}
+          >
+            {confirming
+              ? 'Placement…'
+              : contactOk
+                ? 'Placer l’en-tête'
+                : 'Placer l’identité'}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/freeCanvasContent.js
+++ b/frontend/src/lib/freeCanvasContent.js
@@ -40,6 +40,21 @@ export function bindIncludesPath(bind, path) {
 }
 
 /**
+ * Placeholder nom affiché quand les champs bindés sont vides
+ * (ne jamais mentionner un champ hors bind).
+ * @param {string|string[]|null|undefined} bind
+ * @returns {string}
+ */
+export function identityNameEmptyLabel(bind) {
+  const showPrenom = bindIncludesPath(bind, 'prenom');
+  const showNom = bindIncludesPath(bind, 'nom');
+  if (showPrenom && showNom) return 'Prénom Nom';
+  if (showPrenom) return 'Prénom';
+  if (showNom) return 'Nom';
+  return '';
+}
+
+/**
  * Concatene les champs lies (ex. prenom + nom) avec un separateur.
  */
 export function resolveBoundText(cv, bind, { separator = ' ' } = {}) {

--- a/frontend/src/lib/freeCanvasContent.js
+++ b/frontend/src/lib/freeCanvasContent.js
@@ -27,6 +27,19 @@ export function normalizeBind(bind) {
 }
 
 /**
+ * true si le chemin est affiché pour ce bind.
+ * Bind vide / absent = legacy : tout afficher.
+ * @param {string|string[]|null|undefined} bind
+ * @param {string} path
+ */
+export function bindIncludesPath(bind, path) {
+  if (typeof path !== 'string' || !path) return false;
+  const paths = normalizeBind(bind);
+  if (!paths.length) return true;
+  return paths.includes(path);
+}
+
+/**
  * Concatene les champs lies (ex. prenom + nom) avec un separateur.
  */
 export function resolveBoundText(cv, bind, { separator = ' ' } = {}) {

--- a/frontend/src/lib/headerComposerPresets.js
+++ b/frontend/src/lib/headerComposerPresets.js
@@ -135,7 +135,12 @@ export function mergeHeaderComposerCv(cv, values, fields) {
   const next = cv && typeof cv === 'object' ? { ...cv } : {};
   for (const key of HEADER_COMPOSER_FIELD_KEYS) {
     if (!fields?.[key]) continue;
-    next[key] = String(values?.[key] ?? '').trim();
+    const val = String(values?.[key] ?? '').trim();
+    next[key] = val;
+    // Écrire les miroirs EN en même temps pour que syncCvDualKeys
+    // ne ressuscite pas un ancien first_name/last_name après clear FR.
+    if (key === 'prenom') next.first_name = val;
+    if (key === 'nom') next.last_name = val;
   }
   return syncCvDualKeys(next);
 }

--- a/frontend/src/lib/headerComposerPresets.js
+++ b/frontend/src/lib/headerComposerPresets.js
@@ -1,0 +1,250 @@
+/**
+ * Composer En-tête (AXE-334 P0) — variants design + champs → blocs canvas liés au CV.
+ */
+
+import { syncCvDualKeys } from './cvDualKey.js';
+import {
+  PAGE_MARGIN_MM,
+  PAGE_USABLE_WIDTH_MM,
+  addBlockToPage,
+  listAllBlocks,
+  removeBlocks,
+} from './cvLayoutModelV3.js';
+
+const W = PAGE_USABLE_WIDTH_MM;
+
+/** @typedef {'prenom'|'nom'|'titre_professionnel'|'email'|'telephone'|'linkedin'} HeaderComposerFieldKey */
+
+/** @type {ReadonlyArray<HeaderComposerFieldKey>} */
+export const HEADER_COMPOSER_IDENTITY_FIELDS = Object.freeze([
+  'prenom',
+  'nom',
+  'titre_professionnel',
+]);
+
+/** @type {ReadonlyArray<HeaderComposerFieldKey>} */
+export const HEADER_COMPOSER_CONTACT_FIELDS = Object.freeze([
+  'email',
+  'telephone',
+  'linkedin',
+]);
+
+/** @type {ReadonlyArray<HeaderComposerFieldKey>} */
+export const HEADER_COMPOSER_FIELD_KEYS = Object.freeze([
+  ...HEADER_COMPOSER_IDENTITY_FIELDS,
+  ...HEADER_COMPOSER_CONTACT_FIELDS,
+]);
+
+export const HEADER_COMPOSER_FIELD_LABELS = Object.freeze({
+  prenom: 'Prénom',
+  nom: 'Nom',
+  titre_professionnel: 'Titre professionnel',
+  email: 'Email',
+  telephone: 'Téléphone',
+  linkedin: 'LinkedIn',
+});
+
+/** @type {ReadonlyArray<{ id: string, label: string, description: string }>} */
+export const HEADER_COMPOSER_VARIANTS = Object.freeze([
+  {
+    id: 'stacked',
+    label: 'Classique',
+    description: 'Nom empilé, contact en dessous',
+  },
+  {
+    id: 'inline_title',
+    label: 'Titre inline',
+    description: 'Nom et titre sur une ligne, accent',
+  },
+  {
+    id: 'header_bar',
+    label: 'Barre contact',
+    description: 'Identité + bandeau contact horizontal',
+  },
+]);
+
+/**
+ * @param {string} variantId
+ * @returns {{ id: string, label: string, description: string }}
+ */
+export function resolveHeaderComposerVariant(variantId) {
+  return (
+    HEADER_COMPOSER_VARIANTS.find((v) => v.id === variantId)
+    || HEADER_COMPOSER_VARIANTS[0]
+  );
+}
+
+/**
+ * Prefill valeurs + cases depuis le CV (guider sans forcer).
+ * @param {object|null|undefined} cv
+ * @returns {{ values: Record<HeaderComposerFieldKey, string>, fields: Record<HeaderComposerFieldKey, boolean> }}
+ */
+export function defaultHeaderComposerState(cv) {
+  /** @type {Record<HeaderComposerFieldKey, string>} */
+  const values = {
+    prenom: String(cv?.prenom || cv?.first_name || '').trim(),
+    nom: String(cv?.nom || cv?.last_name || '').trim(),
+    titre_professionnel: String(cv?.titre_professionnel || '').trim(),
+    email: String(cv?.email || '').trim(),
+    telephone: String(cv?.telephone || '').trim(),
+    linkedin: String(cv?.linkedin || '').trim(),
+  };
+
+  /** @type {Record<HeaderComposerFieldKey, boolean>} */
+  const fields = {
+    prenom: true,
+    nom: true,
+    titre_professionnel: true,
+    email: Boolean(values.email),
+    telephone: Boolean(values.telephone),
+    linkedin: Boolean(values.linkedin),
+  };
+
+  // Au moins un contact coché si des données existent ; sinon proposer email.
+  if (!fields.email && !fields.telephone && !fields.linkedin) {
+    fields.email = true;
+  }
+
+  return { values, fields };
+}
+
+/**
+ * @param {Record<HeaderComposerFieldKey, boolean>} fields
+ * @returns {HeaderComposerFieldKey[]}
+ */
+export function selectedIdentityBinds(fields) {
+  return HEADER_COMPOSER_IDENTITY_FIELDS.filter((key) => fields?.[key]);
+}
+
+/**
+ * @param {Record<HeaderComposerFieldKey, boolean>} fields
+ * @returns {HeaderComposerFieldKey[]}
+ */
+export function selectedContactBinds(fields) {
+  return HEADER_COMPOSER_CONTACT_FIELDS.filter((key) => fields?.[key]);
+}
+
+/**
+ * Écrit uniquement les champs cochés dans le CV (masquer ≠ supprimer).
+ * @param {object|null|undefined} cv
+ * @param {Record<string, string>} values
+ * @param {Record<string, boolean>} fields
+ * @returns {object}
+ */
+export function mergeHeaderComposerCv(cv, values, fields) {
+  const next = cv && typeof cv === 'object' ? { ...cv } : {};
+  for (const key of HEADER_COMPOSER_FIELD_KEYS) {
+    if (!fields?.[key]) continue;
+    next[key] = String(values?.[key] ?? '').trim();
+  }
+  return syncCvDualKeys(next);
+}
+
+/**
+ * @param {object|null|undefined} layout
+ * @returns {string[]}
+ */
+export function collectHeaderBlockIds(layout) {
+  return listAllBlocks(layout)
+    .filter((b) => b?.type === 'identity' || b?.type === 'contact')
+    .map((b) => b.id)
+    .filter(Boolean);
+}
+
+/**
+ * Construit les blocs partiels (avec x/y) pour une variante.
+ * @param {{ variantId?: string, fields?: Record<string, boolean> }} options
+ * @returns {object[]}
+ */
+export function buildHeaderComposerBlocks({ variantId = 'stacked', fields = {} } = {}) {
+  const variant = resolveHeaderComposerVariant(variantId);
+  const identityBind = selectedIdentityBinds(fields);
+  const contactBind = selectedContactBinds(fields);
+  const blocks = [];
+
+  if (!identityBind.length && !contactBind.length) {
+    return blocks;
+  }
+
+  let y = PAGE_MARGIN_MM;
+
+  if (identityBind.length) {
+    /** @type {Record<string, unknown>} */
+    const style = { align: 'left' };
+    if (variant.id === 'inline_title') {
+      style.header_layout = 'inline-title';
+      style.title_accent = true;
+      style.identity_divider = true;
+    } else if (variant.id === 'header_bar') {
+      style.identity_divider = true;
+    } else {
+      style.identity_divider = false;
+    }
+
+    blocks.push({
+      type: 'identity',
+      bind: [...identityBind],
+      x: PAGE_MARGIN_MM,
+      y,
+      w: W,
+      h: 28,
+      style,
+    });
+    y += 28 + 4;
+  }
+
+  if (contactBind.length) {
+    /** @type {Record<string, unknown>} */
+    const style = {
+      contact_icons: variant.id === 'header_bar',
+      contact_uppercase: false,
+    };
+    if (variant.id === 'header_bar') {
+      style.contact_layout = 'header-bar';
+      style.contact_divider = true;
+    }
+
+    blocks.push({
+      type: 'contact',
+      bind: [...contactBind],
+      x: PAGE_MARGIN_MM,
+      y,
+      w: W,
+      h: variant.id === 'header_bar' ? 14 : 18,
+      style,
+    });
+  }
+
+  return blocks;
+}
+
+/**
+ * Remplace l’en-tête existant (1 instance) et place les nouveaux blocs.
+ * @param {object} layout
+ * @param {number} pageIndex
+ * @param {{ variantId?: string, fields?: Record<string, boolean> }} options
+ * @returns {{ layout: object, placedIds: string[] }}
+ */
+export function applyHeaderComposerToLayout(layout, pageIndex, options = {}) {
+  const blocks = buildHeaderComposerBlocks(options);
+  let next = removeBlocks(layout, collectHeaderBlockIds(layout));
+  const placedIds = [];
+
+  if (!blocks.length) {
+    return { layout: next, placedIds };
+  }
+
+  const safePage =
+    typeof pageIndex === 'number' && pageIndex >= 0 && pageIndex < (next?.pages?.length || 0)
+      ? pageIndex
+      : 0;
+
+  for (const partial of blocks) {
+    next = addBlockToPage(next, safePage, partial);
+    const page = next.pages?.[safePage];
+    const last = page?.blocks?.[page.blocks.length - 1];
+    if (last?.id) placedIds.push(last.id);
+  }
+
+  return { layout: next, placedIds };
+}

--- a/frontend/src/styles/EditorCanvaSidebar.css
+++ b/frontend/src/styles/EditorCanvaSidebar.css
@@ -146,6 +146,43 @@
   line-height: 1.4;
 }
 
+.editor-canva-composer-cta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  width: 100%;
+  margin: 0 0 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--color-primary, #17171c);
+  border-radius: 8px;
+  background: var(--color-primary, #17171c);
+  color: var(--color-on-dark, #fff);
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.editor-canva-composer-cta:hover:not(:disabled) {
+  background: var(--color-ink, #212121);
+}
+
+.editor-canva-composer-cta:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.editor-canva-composer-cta__label {
+  font-size: 0.88rem;
+  font-weight: 500;
+}
+
+.editor-canva-composer-cta__hint {
+  font-size: 0.72rem;
+  opacity: 0.85;
+  line-height: 1.35;
+}
+
 .editor-canva-drawer__actions,
 .editor-canva-drawer__grid {
   display: flex;

--- a/frontend/src/styles/HeaderComposerModal.css
+++ b/frontend/src/styles/HeaderComposerModal.css
@@ -1,0 +1,280 @@
+.header-composer-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(7, 24, 41, 0.55);
+}
+
+.header-composer-modal {
+  width: min(640px, 100%);
+  max-height: min(92vh, 860px);
+  overflow: auto;
+  background: var(--color-canvas, #fff);
+  border-radius: 16px;
+  border: 1px solid var(--color-hairline, #d9d9dd);
+  padding: 1.25rem 1.35rem 1.35rem;
+  font-family: var(--app-font-family);
+}
+
+.header-composer-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.header-composer-eyebrow {
+  display: inline-flex;
+  margin-bottom: 0.35rem;
+  padding: 0.15rem 0.55rem;
+  border-radius: 30px;
+  background: var(--color-pale-green, #edfce9);
+  color: var(--color-deep-green, #003c33);
+  font-size: 0.68rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.header-composer-head h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1.2rem;
+  font-weight: 500;
+  color: var(--color-ink, #212121);
+}
+
+.header-composer-head p {
+  margin: 0;
+  font-size: 0.84rem;
+  line-height: 1.45;
+  color: var(--color-body-muted, #616161);
+}
+
+.header-composer-close {
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid var(--color-hairline, #d9d9dd);
+  border-radius: 8px;
+  background: var(--color-canvas, #fff);
+  color: var(--color-ink, #212121);
+  font-size: 1.35rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.header-composer-close:hover {
+  background: var(--color-soft-stone, #eeece7);
+}
+
+.header-composer-section {
+  margin-bottom: 1rem;
+}
+
+.header-composer-section__title {
+  margin: 0 0 0.55rem;
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-slate, #75758a);
+}
+
+.header-composer-variants {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.55rem;
+}
+
+.header-composer-variant {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.55rem;
+  border: 1px solid var(--color-hairline, #d9d9dd);
+  border-radius: 8px;
+  background: var(--color-canvas, #fff);
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  color: var(--color-ink, #212121);
+}
+
+.header-composer-variant:hover {
+  background: var(--color-soft-stone, #eeece7);
+}
+
+.header-composer-variant.is-selected {
+  border-color: var(--color-primary, #17171c);
+  background: var(--color-pale-blue, #f1f5ff);
+}
+
+.header-composer-variant strong {
+  font-size: 0.82rem;
+  font-weight: 500;
+}
+
+.header-composer-variant > span:last-child {
+  font-size: 0.72rem;
+  line-height: 1.35;
+  color: var(--color-body-muted, #616161);
+}
+
+.header-composer-variant__preview {
+  display: block;
+  height: 44px;
+  border-radius: 4px;
+  background: var(--color-soft-stone, #eeece7);
+  margin-bottom: 0.2rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.header-composer-variant__preview--stacked::before,
+.header-composer-variant__preview--stacked::after,
+.header-composer-variant__preview--inline_title::before,
+.header-composer-variant__preview--inline_title::after,
+.header-composer-variant__preview--header_bar::before,
+.header-composer-variant__preview--header_bar::after {
+  content: '';
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  border-radius: 2px;
+  background: var(--color-ink, #212121);
+}
+
+.header-composer-variant__preview--stacked::before {
+  top: 10px;
+  height: 6px;
+  right: 28px;
+}
+
+.header-composer-variant__preview--stacked::after {
+  top: 22px;
+  height: 4px;
+  background: var(--color-muted, #93939f);
+}
+
+.header-composer-variant__preview--inline_title::before {
+  top: 14px;
+  height: 6px;
+  right: 40%;
+}
+
+.header-composer-variant__preview--inline_title::after {
+  top: 14px;
+  left: 62%;
+  height: 6px;
+  background: var(--color-action-blue, #1863dc);
+}
+
+.header-composer-variant__preview--header_bar::before {
+  top: 8px;
+  height: 6px;
+  right: 24px;
+}
+
+.header-composer-variant__preview--header_bar::after {
+  top: 24px;
+  height: 8px;
+  background: var(--color-dark-navy, #071829);
+  opacity: 0.85;
+}
+
+.header-composer-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.header-composer-field {
+  display: grid;
+  grid-template-columns: minmax(140px, 180px) 1fr;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.header-composer-field__check {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.84rem;
+  color: var(--color-ink, #212121);
+  cursor: pointer;
+}
+
+.header-composer-field__input {
+  width: 100%;
+  min-height: 36px;
+  padding: 0.4rem 0.65rem;
+  border: 1px solid var(--color-hairline, #d9d9dd);
+  border-radius: 8px;
+  background: var(--color-canvas, #fff);
+  color: var(--color-ink, #212121);
+  font: inherit;
+  font-size: 0.88rem;
+}
+
+.header-composer-field__input:focus {
+  outline: none;
+  border-color: var(--color-form-focus, #9b60aa);
+}
+
+.header-composer-field__hint {
+  margin: 0;
+  font-size: 0.72rem;
+  color: var(--color-muted, #93939f);
+}
+
+.header-composer-warn {
+  margin: 0 0 0.75rem;
+  font-size: 0.8rem;
+  color: var(--color-error, #b30000);
+}
+
+.header-composer-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.55rem;
+  padding-top: 0.35rem;
+}
+
+.header-composer-actions button {
+  min-height: 40px;
+  padding: 0.45rem 1rem;
+  border-radius: 32px;
+  border: 1px solid var(--color-hairline, #d9d9dd);
+  background: var(--color-canvas, #fff);
+  color: var(--color-ink, #212121);
+  font: inherit;
+  font-size: 0.88rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.header-composer-primary {
+  border-color: var(--color-primary, #17171c) !important;
+  background: var(--color-primary, #17171c) !important;
+  color: var(--color-on-dark, #fff) !important;
+}
+
+.header-composer-primary:disabled,
+.header-composer-actions button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+@media (max-width: 640px) {
+  .header-composer-variants {
+    grid-template-columns: 1fr;
+  }
+
+  .header-composer-field {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/tests/unit/freeCanvasContent.test.js
+++ b/frontend/tests/unit/freeCanvasContent.test.js
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import {
   getByPath,
   normalizeBind,
+  bindIncludesPath,
   resolveBoundText,
   resolveBoundStringList,
   resolveCompetenceList,
@@ -34,6 +35,15 @@ test('normalizeBind', () => {
   assert.deepEqual(normalizeBind('resume'), ['resume']);
   assert.deepEqual(normalizeBind(['a', 'b']), ['a', 'b']);
   assert.deepEqual(normalizeBind(null), []);
+});
+
+test('bindIncludesPath : legacy vide = tout ; sinon filtre', () => {
+  assert.equal(bindIncludesPath(undefined, 'prenom'), true);
+  assert.equal(bindIncludesPath([], 'prenom'), true);
+  assert.equal(bindIncludesPath(['prenom', 'nom'], 'prenom'), true);
+  assert.equal(bindIncludesPath(['prenom', 'nom'], 'titre_professionnel'), false);
+  assert.equal(bindIncludesPath('email', 'email'), true);
+  assert.equal(bindIncludesPath('email', 'telephone'), false);
 });
 
 test('resolveBoundText : identity', () => {

--- a/frontend/tests/unit/freeCanvasContent.test.js
+++ b/frontend/tests/unit/freeCanvasContent.test.js
@@ -5,6 +5,7 @@ import {
   getByPath,
   normalizeBind,
   bindIncludesPath,
+  identityNameEmptyLabel,
   resolveBoundText,
   resolveBoundStringList,
   resolveCompetenceList,
@@ -44,6 +45,13 @@ test('bindIncludesPath : legacy vide = tout ; sinon filtre', () => {
   assert.equal(bindIncludesPath(['prenom', 'nom'], 'titre_professionnel'), false);
   assert.equal(bindIncludesPath('email', 'email'), true);
   assert.equal(bindIncludesPath('email', 'telephone'), false);
+});
+
+test('identityNameEmptyLabel suit le bind (pas de label hors champs)', () => {
+  assert.equal(identityNameEmptyLabel(['prenom', 'nom']), 'Prénom Nom');
+  assert.equal(identityNameEmptyLabel(['prenom']), 'Prénom');
+  assert.equal(identityNameEmptyLabel(['nom']), 'Nom');
+  assert.equal(identityNameEmptyLabel(['titre_professionnel']), '');
 });
 
 test('resolveBoundText : identity', () => {

--- a/frontend/tests/unit/headerComposerPresets.test.js
+++ b/frontend/tests/unit/headerComposerPresets.test.js
@@ -81,6 +81,25 @@ test('merges checked fields into cv with dual-key sync (does not clear unchecked
   assert.equal(next.telephone, '010203');
 });
 
+test('clearing FR name also clears EN dual-key (no resurrection)', () => {
+  const next = mergeHeaderComposerCv(
+    { prenom: 'Ada', first_name: 'Ada', nom: 'Lovelace', last_name: 'Lovelace' },
+    { prenom: '', nom: 'Lovelace' },
+    {
+      prenom: true,
+      nom: true,
+      titre_professionnel: false,
+      email: false,
+      telephone: false,
+      linkedin: false,
+    },
+  );
+  assert.equal(next.prenom, '');
+  assert.equal(next.first_name, '');
+  assert.equal(next.nom, 'Lovelace');
+  assert.equal(next.last_name, 'Lovelace');
+});
+
 test('replaces existing identity/contact (one instance) when applying', () => {
   const layout = createBlankLayoutV3();
   const first = applyHeaderComposerToLayout(layout, 0, {

--- a/frontend/tests/unit/headerComposerPresets.test.js
+++ b/frontend/tests/unit/headerComposerPresets.test.js
@@ -1,0 +1,115 @@
+/**
+ * Tests unitaires composer En-tête (AXE-334 P0).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createBlankLayoutV3 } from '../../src/lib/cvLayoutModelV3.js';
+import {
+  HEADER_COMPOSER_VARIANTS,
+  applyHeaderComposerToLayout,
+  buildHeaderComposerBlocks,
+  collectHeaderBlockIds,
+  defaultHeaderComposerState,
+  mergeHeaderComposerCv,
+  resolveHeaderComposerVariant,
+  selectedContactBinds,
+  selectedIdentityBinds,
+} from '../../src/lib/headerComposerPresets.js';
+
+test('exposes at least 2 design variants', () => {
+  assert.ok(HEADER_COMPOSER_VARIANTS.length >= 2);
+  assert.equal(resolveHeaderComposerVariant('inline_title').id, 'inline_title');
+  assert.equal(
+    resolveHeaderComposerVariant('unknown').id,
+    HEADER_COMPOSER_VARIANTS[0].id,
+  );
+});
+
+test('prefills from cv and checks contact only when present', () => {
+  const { values, fields } = defaultHeaderComposerState({
+    prenom: 'Ada',
+    nom: 'Lovelace',
+    email: 'ada@example.com',
+  });
+  assert.equal(values.prenom, 'Ada');
+  assert.equal(fields.prenom, true);
+  assert.equal(fields.email, true);
+  assert.equal(fields.telephone, false);
+});
+
+test('builds identity (+ contact) with variant styles and filtered binds', () => {
+  const fields = {
+    prenom: true,
+    nom: true,
+    titre_professionnel: false,
+    email: true,
+    telephone: false,
+    linkedin: false,
+  };
+  const blocks = buildHeaderComposerBlocks({ variantId: 'header_bar', fields });
+  assert.equal(blocks.length, 2);
+  assert.equal(blocks[0].type, 'identity');
+  assert.deepEqual(blocks[0].bind, ['prenom', 'nom']);
+  assert.equal(blocks[0].style.identity_divider, true);
+  assert.equal(blocks[1].type, 'contact');
+  assert.deepEqual(blocks[1].bind, ['email']);
+  assert.equal(blocks[1].style.contact_layout, 'header-bar');
+  assert.deepEqual(selectedIdentityBinds(fields), ['prenom', 'nom']);
+  assert.deepEqual(selectedContactBinds(fields), ['email']);
+});
+
+test('merges checked fields into cv with dual-key sync (does not clear unchecked)', () => {
+  const next = mergeHeaderComposerCv(
+    { prenom: 'Old', email: 'keep@example.com', telephone: '010203' },
+    { prenom: 'New', nom: 'Name', email: 'x@y.z', telephone: '999' },
+    {
+      prenom: true,
+      nom: true,
+      titre_professionnel: false,
+      email: false,
+      telephone: false,
+      linkedin: false,
+    },
+  );
+  assert.equal(next.prenom, 'New');
+  assert.equal(next.first_name, 'New');
+  assert.equal(next.nom, 'Name');
+  assert.equal(next.last_name, 'Name');
+  assert.equal(next.email, 'keep@example.com');
+  assert.equal(next.telephone, '010203');
+});
+
+test('replaces existing identity/contact (one instance) when applying', () => {
+  const layout = createBlankLayoutV3();
+  const first = applyHeaderComposerToLayout(layout, 0, {
+    variantId: 'stacked',
+    fields: {
+      prenom: true,
+      nom: true,
+      titre_professionnel: true,
+      email: true,
+      telephone: false,
+      linkedin: false,
+    },
+  });
+  assert.equal(collectHeaderBlockIds(first.layout).length, 2);
+  assert.equal(first.placedIds.length, 2);
+
+  const second = applyHeaderComposerToLayout(first.layout, 0, {
+    variantId: 'inline_title',
+    fields: {
+      prenom: true,
+      nom: false,
+      titre_professionnel: true,
+      email: false,
+      telephone: false,
+      linkedin: false,
+    },
+  });
+  assert.equal(collectHeaderBlockIds(second.layout).length, 1);
+  const identity = second.layout.pages[0].blocks.find((b) => b.type === 'identity');
+  assert.deepEqual(identity.bind, ['prenom', 'titre_professionnel']);
+  assert.equal(identity.style.header_layout, 'inline-title');
+});


### PR DESCRIPTION
## Summary
- Composer **En-tête** : 3 variants design, checkboxes champs, inputs préremplies depuis le CV, place identity (+ contact) avec binds filtrés
- **1 instance** : remplace identity/contact existants ; champ décoché = omit bind (pas delete CV)
- Entrée démarrage priorisée **Import / Modèle** ; empty state + sidebar CTA « Composer l’en-tête »
- Sections actuelles restent en secondaire

Fixes AXE-334
Closes #97

## Test plan
- [ ] Beta sans layout → startup : Import / Modèle / Générer / blank avancé
- [ ] Sections CV → Composer l’en-tête → 3 designs, cocher/décocher, placer
- [ ] Vérifier sync `cv` (prenom/nom dual-key) + free-edit ensuite
- [ ] Re-ouvrir composer → remplace l’ancien en-tête (pas de doublon)
- [ ] Page vide → CTA Composer l’en-tête
- [ ] Blocs Identité/Contact individuels toujours placables


Made with [Cursor](https://cursor.com)