### PR TITLE
fix(AXE-338): score ATS accurate — CV pauvre → bas

### DIFF
--- a/backend/services/ats_score/rules/__init__.py
+++ b/backend/services/ats_score/rules/__init__.py
@@ -26,6 +26,7 @@ parsing_rules: tuple = (
     layout.rule_multi_column,
     layout.rule_sidebar_present,
     layout.rule_free_canvas_text_positions,
+    free_canvas.rule_free_canvas_no_semantic_blocks,
     free_canvas.rule_free_canvas_missing_profile_sections,
     free_canvas.rule_free_canvas_reading_order,
     free_canvas.rule_identity_not_first_in_reading,
@@ -33,6 +34,12 @@ parsing_rules: tuple = (
     free_canvas.rule_contact_far_from_top,
     typography.rule_exotic_font,
     typography.rule_body_font_size_out_of_range,
+    # --- Completude semantique (JSON cv, dual-key)
+    content.rule_missing_identity,
+    content.rule_missing_contact,
+    content.rule_missing_experiences,
+    content.rule_missing_formations,
+    content.rule_missing_skills,
     # --- Penalites legeres
     meta.rule_photo_present,
     content.rule_inconsistent_dates,

--- a/backend/services/ats_score/rules/_helpers.py
+++ b/backend/services/ats_score/rules/_helpers.py
@@ -210,9 +210,7 @@ def cv_first_text(cv: dict[str, Any], *keys: str) -> str:
 
 def cv_has_identity(cv: dict[str, Any]) -> bool:
     """Vrai si prenom/first_name ou nom/last_name est renseigne."""
-    return bool(
-        cv_first_text(cv, "prenom", "first_name") or cv_first_text(cv, "nom", "last_name")
-    )
+    return bool(cv_first_text(cv, "prenom", "first_name") or cv_first_text(cv, "nom", "last_name"))
 
 
 def cv_has_contact(cv: dict[str, Any]) -> bool:

--- a/backend/services/ats_score/rules/_helpers.py
+++ b/backend/services/ats_score/rules/_helpers.py
@@ -188,3 +188,84 @@ def normalize_font_name(raw: Any) -> str:
     if not isinstance(raw, str):
         return ""
     return raw.strip().strip("'\"")
+
+
+def cv_nonempty_str(value: Any) -> str:
+    """Retourne une chaine strippee si non vide, sinon ``\"\"``."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    return str(value).strip()
+
+
+def cv_first_text(cv: dict[str, Any], *keys: str) -> str:
+    """Premier champ texte non vide parmi ``keys`` (dual-key FR/EN)."""
+    for key in keys:
+        text = cv_nonempty_str(cv.get(key))
+        if text:
+            return text
+    return ""
+
+
+def cv_has_identity(cv: dict[str, Any]) -> bool:
+    """Vrai si prenom/first_name ou nom/last_name est renseigne."""
+    return bool(
+        cv_first_text(cv, "prenom", "first_name") or cv_first_text(cv, "nom", "last_name")
+    )
+
+
+def cv_has_contact(cv: dict[str, Any]) -> bool:
+    """Vrai si email ou telephone/phone est renseigne."""
+    return bool(cv_first_text(cv, "email") or cv_first_text(cv, "telephone", "phone"))
+
+
+def cv_has_experiences(cv: dict[str, Any]) -> bool:
+    """Vrai si au moins une experience a un contenu utile (pas un shell vide)."""
+    for exp in cv.get("experiences", []) or []:
+        if not isinstance(exp, dict):
+            continue
+        if cv_first_text(exp, "poste", "title") or cv_first_text(exp, "entreprise", "company"):
+            return True
+        bullets = exp.get("bullet_points") or []
+        if any(cv_nonempty_str(b) for b in bullets):
+            return True
+    return False
+
+
+def cv_has_formations(cv: dict[str, Any]) -> bool:
+    """Vrai si au moins une formation a un diplome / etablissement."""
+    for form in cv.get("formations", []) or []:
+        if not isinstance(form, dict):
+            continue
+        if cv_first_text(form, "diplome", "degree") or cv_first_text(
+            form, "etablissement", "school"
+        ):
+            return True
+    return False
+
+
+def cv_has_skills(cv: dict[str, Any]) -> bool:
+    """Vrai si competences techniques/logiciels/autres non vides."""
+    competences = cv.get("competences") or {}
+    if not isinstance(competences, dict):
+        return False
+    for list_key in ("techniques", "logiciels", "autres"):
+        items = competences.get(list_key) or []
+        if any(cv_nonempty_str(x) for x in items):
+            return True
+    return False
+
+
+def cv_has_languages(cv: dict[str, Any]) -> bool:
+    """Vrai si au moins une langue non vide est declaree."""
+    competences = cv.get("competences") or {}
+    if not isinstance(competences, dict):
+        return False
+    for item in competences.get("langues") or []:
+        if isinstance(item, dict):
+            if cv_nonempty_str(item.get("langue")):
+                return True
+        elif cv_nonempty_str(item):
+            return True
+    return False

--- a/backend/services/ats_score/rules/content.py
+++ b/backend/services/ats_score/rules/content.py
@@ -11,6 +11,12 @@ import re
 from typing import Any
 
 from backend.services.ats_score.rules._helpers import (
+    cv_has_contact,
+    cv_has_experiences,
+    cv_has_formations,
+    cv_has_identity,
+    cv_has_languages,
+    cv_has_skills,
     free_canvas_block_types,
     get_grid,
     get_pages,
@@ -26,6 +32,14 @@ STANDARD_SECTIONS: frozenset[str] = frozenset(
     {"identity", "experiences", "formations", "skills", "languages"}
 )
 STANDARD_SECTIONS_BONUS_CAP: int = 3
+
+# Completude semantique (AXE-338) : un CV pauvre ne doit plus rester ~100.
+# Les deltas sont calibre pour : vide/minimal clairement bas ; riche + ATS-safe haut.
+MALUS_MISSING_IDENTITY: int = -25
+MALUS_MISSING_CONTACT: int = -20
+MALUS_MISSING_EXPERIENCES: int = -25
+MALUS_MISSING_FORMATIONS: int = -12
+MALUS_MISSING_SKILLS: int = -12
 
 # Formats de dates "propres" reconnaissables. On verifie que **toutes** les
 # dates suivent un meme format pour donner le bonus, et on identifie les
@@ -69,6 +83,76 @@ def _classify_date(raw: str) -> str:
     return "exotic"
 
 
+def rule_missing_identity(cv: dict[str, Any], layout: dict[str, Any]) -> Rule | None:
+    """Penalite si aucune identite semantique (dual-key FR/EN)."""
+    del layout
+    if cv_has_identity(cv):
+        return None
+    return Rule(
+        id="malus_missing_identity",
+        label="Identite absente (prenom/nom)",
+        delta=MALUS_MISSING_IDENTITY,
+        severity=RuleSeverity.ERROR,
+        advice="Ajoute prenom et nom (ou first_name / last_name) pour que les ATS te reconnaissent.",
+    )
+
+
+def rule_missing_contact(cv: dict[str, Any], layout: dict[str, Any]) -> Rule | None:
+    """Penalite si aucun moyen de contact exploitable."""
+    del layout
+    if cv_has_contact(cv):
+        return None
+    return Rule(
+        id="malus_missing_contact",
+        label="Contact absent (email/telephone)",
+        delta=MALUS_MISSING_CONTACT,
+        severity=RuleSeverity.ERROR,
+        advice="Ajoute un email ou un telephone : les ATS et recruteurs en ont besoin.",
+    )
+
+
+def rule_missing_experiences(cv: dict[str, Any], layout: dict[str, Any]) -> Rule | None:
+    """Penalite si aucune experience avec contenu utile (ignore les shells vides)."""
+    del layout
+    if cv_has_experiences(cv):
+        return None
+    return Rule(
+        id="malus_missing_experiences",
+        label="Aucune experience renseignee",
+        delta=MALUS_MISSING_EXPERIENCES,
+        severity=RuleSeverity.ERROR,
+        advice="Renseigne au moins une experience (poste, entreprise ou bullets).",
+    )
+
+
+def rule_missing_formations(cv: dict[str, Any], layout: dict[str, Any]) -> Rule | None:
+    """Penalite si aucune formation renseignee."""
+    del layout
+    if cv_has_formations(cv):
+        return None
+    return Rule(
+        id="malus_missing_formations",
+        label="Aucune formation renseignee",
+        delta=MALUS_MISSING_FORMATIONS,
+        severity=RuleSeverity.WARNING,
+        advice="Ajoute au moins une formation (diplome ou etablissement).",
+    )
+
+
+def rule_missing_skills(cv: dict[str, Any], layout: dict[str, Any]) -> Rule | None:
+    """Penalite si aucune competence technique/logiciel exploitable."""
+    del layout
+    if cv_has_skills(cv):
+        return None
+    return Rule(
+        id="malus_missing_skills",
+        label="Competences absentes",
+        delta=MALUS_MISSING_SKILLS,
+        severity=RuleSeverity.WARNING,
+        advice="Ajoute des competences (techniques ou logiciels) dans le profil.",
+    )
+
+
 def rule_standard_section_titles(cv: dict[str, Any], layout: dict[str, Any]) -> Rule | None:
     """Bonus +1 par section standard visible (plafond +5).
 
@@ -87,18 +171,16 @@ def rule_standard_section_titles(cv: dict[str, Any], layout: dict[str, Any]) -> 
         visible_ids = free_canvas_block_types(layout) & STANDARD_SECTIONS
     else:
         visible_ids = set()
-        if cv.get("prenom") or cv.get("nom"):
+        if cv_has_identity(cv):
             visible_ids.add("identity")
-        if any((e or {}).get("poste") for e in cv.get("experiences", []) or []):
+        if cv_has_experiences(cv):
             visible_ids.add("experiences")
-        if any((f or {}).get("diplome") for f in cv.get("formations", []) or []):
+        if cv_has_formations(cv):
             visible_ids.add("formations")
-        comp = cv.get("competences") or {}
-        if isinstance(comp, dict):
-            if any(comp.get("techniques") or []):
-                visible_ids.add("skills")
-            if any(comp.get("langues") or []):
-                visible_ids.add("languages")
+        if cv_has_skills(cv):
+            visible_ids.add("skills")
+        if cv_has_languages(cv):
+            visible_ids.add("languages")
     bonus = min(len(visible_ids), STANDARD_SECTIONS_BONUS_CAP)
     if bonus <= 0:
         return None
@@ -119,7 +201,7 @@ def rule_contact_top_of_page(cv: dict[str, Any], layout: dict[str, Any]) -> Rule
     ``identity`` / ``contact``.
     """
     has_email = bool((cv.get("email") or "").strip())
-    has_phone = bool((cv.get("telephone") or "").strip())
+    has_phone = bool((cv.get("telephone") or cv.get("phone") or "").strip())
     if not (has_email or has_phone):
         return None
 

--- a/backend/services/ats_score/rules/content.py
+++ b/backend/services/ats_score/rules/content.py
@@ -200,9 +200,9 @@ def rule_contact_top_of_page(cv: dict[str, Any], layout: dict[str, Any]) -> Rule
     Pour un layout ``free``, on inspecte la position ``y`` des blocs
     ``identity`` / ``contact``.
     """
-    has_email = bool((cv.get("email") or "").strip())
-    has_phone = bool((cv.get("telephone") or cv.get("phone") or "").strip())
-    if not (has_email or has_phone):
+    # Dual-key via cv_has_contact (strip avant or) — un telephone=" " ne doit
+    # pas masquer un phone valide (Bugbot PR #100).
+    if not cv_has_contact(cv):
         return None
 
     sections = get_sections_order(layout)

--- a/backend/services/ats_score/rules/free_canvas.py
+++ b/backend/services/ats_score/rules/free_canvas.py
@@ -79,9 +79,7 @@ def _count_inversions(ranks: list[int]) -> int:
     return inv
 
 
-def rule_free_canvas_no_semantic_blocks(
-    cv: dict[str, Any], layout: dict[str, Any]
-) -> Rule | None:
+def rule_free_canvas_no_semantic_blocks(cv: dict[str, Any], layout: dict[str, Any]) -> Rule | None:
     """Penalise un canvas libre sans aucun bloc semantique affiche."""
     del cv
     if get_grid(layout) != "free":

--- a/backend/services/ats_score/rules/free_canvas.py
+++ b/backend/services/ats_score/rules/free_canvas.py
@@ -10,7 +10,16 @@ from __future__ import annotations
 
 from typing import Any
 
-from backend.services.ats_score.rules._helpers import get_grid, iter_blocks
+from backend.services.ats_score.rules._helpers import (
+    cv_has_contact,
+    cv_has_experiences,
+    cv_has_formations,
+    cv_has_identity,
+    cv_has_languages,
+    cv_has_skills,
+    get_grid,
+    iter_blocks,
+)
 from backend.services.ats_score.types import Rule, RuleSeverity
 
 # Ordre canonique recommande pour un CV ATS (sections semantiques).
@@ -37,6 +46,11 @@ _MISSING_SECTION_LABELS: dict[str, str] = {
     "skills": "competences",
     "languages": "langues",
 }
+
+# Canvas libre sans aucun bloc semantique : score bas meme si le JSON est vide
+# (sinon aucune regle free_canvas ne matchait → ~100 trompeur).
+MALUS_FREE_CANVAS_NO_SEMANTIC: int = -20
+_SEMANTIC_BLOCK_TYPES: frozenset[str] = frozenset(_CANONICAL_READ_ORDER)
 
 
 def _reading_position(block: dict[str, Any]) -> tuple[float, float]:
@@ -65,17 +79,26 @@ def _count_inversions(ranks: list[int]) -> int:
     return inv
 
 
-def _cv_has_identity(cv: dict[str, Any]) -> bool:
-    return bool((cv.get("prenom") or "").strip() or (cv.get("nom") or "").strip())
-
-
-def _cv_has_contact(cv: dict[str, Any]) -> bool:
-    return bool((cv.get("email") or "").strip() or (cv.get("telephone") or "").strip())
-
-
-def _cv_has_skills(cv: dict[str, Any], key: str) -> bool:
-    competences = cv.get("competences") or {}
-    return isinstance(competences, dict) and bool(competences.get(key) or [])
+def rule_free_canvas_no_semantic_blocks(
+    cv: dict[str, Any], layout: dict[str, Any]
+) -> Rule | None:
+    """Penalise un canvas libre sans aucun bloc semantique affiche."""
+    del cv
+    if get_grid(layout) != "free":
+        return None
+    displayed = {str(block.get("type")) for block in iter_blocks(layout) if block.get("type")}
+    if displayed & _SEMANTIC_BLOCK_TYPES:
+        return None
+    return Rule(
+        id="malus_free_canvas_no_semantic_blocks",
+        label="Canvas libre : aucun bloc semantique affiche",
+        delta=MALUS_FREE_CANVAS_NO_SEMANTIC,
+        severity=RuleSeverity.ERROR,
+        advice=(
+            "Le canvas n'affiche aucune section reconnue (identite, contact, "
+            "experiences…). Ajoute des blocs sémantiques pour un score ATS crédible."
+        ),
+    )
 
 
 def rule_free_canvas_missing_profile_sections(
@@ -86,22 +109,25 @@ def rule_free_canvas_missing_profile_sections(
     En mode libre, le score doit juger le CV réellement visible, pas les champs
     stockes dans le profil. Une page blanche doit donc perdre des points pour
     contenu non affiche, pas pour une photo ou des dates qui n'apparaissent pas.
+
+    Ne compte que le contenu **rempli** du JSON (ignore les shells vides du
+    profil par defaut) — dual-key FR/EN inclus.
     """
     if get_grid(layout) != "free":
         return None
     displayed_types = {str(block.get("type")) for block in iter_blocks(layout) if block.get("type")}
     expected: list[str] = []
-    if _cv_has_identity(cv):
+    if cv_has_identity(cv):
         expected.append("identity")
-    if _cv_has_contact(cv):
+    if cv_has_contact(cv):
         expected.append("contact")
-    if any(isinstance(exp, dict) for exp in cv.get("experiences", []) or []):
+    if cv_has_experiences(cv):
         expected.append("experiences")
-    if any(isinstance(form, dict) for form in cv.get("formations", []) or []):
+    if cv_has_formations(cv):
         expected.append("formations")
-    if _cv_has_skills(cv, "techniques"):
+    if cv_has_skills(cv):
         expected.append("skills")
-    if _cv_has_skills(cv, "langues"):
+    if cv_has_languages(cv):
         expected.append("languages")
 
     missing = [section for section in expected if section not in displayed_types]
@@ -234,8 +260,7 @@ def rule_contact_far_from_top(cv: dict[str, Any], layout: dict[str, Any]) -> Rul
     """
     if get_grid(layout) != "free":
         return None
-    has_contact = bool((cv.get("email") or "").strip() or (cv.get("telephone") or "").strip())
-    if not has_contact:
+    if not cv_has_contact(cv):
         return None
     threshold_mm = 89.1
     for block in iter_blocks(layout):

--- a/backend/services/ats_score/version.py
+++ b/backend/services/ats_score/version.py
@@ -9,4 +9,4 @@ les scores produits. Permet de :
 Format : ``YYYY.MM`` ou ``YYYY.MM.patch`` pour les corrections mineures.
 """
 
-SCORING_VERSION = "2026.05.2"
+SCORING_VERSION = "2026.08"

--- a/docs/ats-score-cv-vs-layout.md
+++ b/docs/ats-score-cv-vs-layout.md
@@ -1,0 +1,41 @@
+# Score ATS — `cv` vs `layout`
+
+Le **Score Parsing** (`score_parsing`) part de **100**, applique des règles
+déterministes, puis clampe à ``[0, 100]``. Version : `SCORING_VERSION`
+(`backend/services/ats_score/version.py`).
+
+## Deux sources, deux jobs
+
+| Source | Rôle |
+|--------|------|
+| **`cv`** (JSON sémantique) | Contenu : identité (dual-key FR/EN), contact, expériences, formations, compétences, dates… |
+| **`layout`** | Présentation : colonnes, sidebar, canvas libre, positions, typo, sections affichées |
+
+Un CV **pauvre** (peu de champs remplis dans `cv`) doit scorer **bas**, même
+si le layout est ATS-safe (mono-colonne). Un canvas libre **vide** ne doit pas
+rester ~100 parce qu’aucune règle layout n’a matché.
+
+## Règles contenu (JSON)
+
+Dans `backend/services/ats_score/rules/content.py` :
+
+- Malus si identité / contact / expériences / formations / skills **manquants**
+  (shells vides du profil par défaut = manquants).
+- Dual-key : `prenom`↔`first_name`, `nom`↔`last_name` (et `phone` toléré).
+- Bonus sections / contact haut de page / dates cohérentes.
+
+## Règles layout / free canvas
+
+- Templates figés : colonnes, sidebar, photo, typo…
+- Canvas `grid == "free"` : blocs sémantiques absents, profil non affiché,
+  ordre de lecture, contact trop bas, positions texte libres…
+
+Le JSON peut être riche **et** le canvas incomplet → malus « profil non
+affiché ». L’inverse (canvas + JSON vide) → malus contenu + « aucun bloc
+sémantique ».
+
+## Verify PDF
+
+Le check ground-truth PDF (`ats_parsing_check`) ajuste ensuite le score quand
+le PDF réel ne contient pas de texte extractible, etc. Le score JSON reste la
+base « structure + contenu » ; le PDF valide ce qui est réellement exporté.

--- a/docs/editor-vision.md
+++ b/docs/editor-vision.md
@@ -464,6 +464,19 @@ Base : **100**. Plancher : **0**. Plafond : **100**.
 | Émojis dans le texte | −2 | Regex Unicode |
 | Liens en image plutôt qu'en texte | −1 | `block.type == "image" && block.target_url` |
 
+#### 9.2.3bis Complétude sémantique (`cv`) — AXE-338
+
+Un CV pauvre ne doit plus rester ~100. Voir aussi `docs/ats-score-cv-vs-layout.md`.
+
+| Règle | Delta | Détection |
+| --- | --- | --- |
+| Identité absente | −25 | ni `prenom`/`first_name` ni `nom`/`last_name` |
+| Contact absent | −20 | ni email ni téléphone |
+| Aucune expérience utile | −25 | pas de poste/entreprise/bullets (ignore shells vides) |
+| Aucune formation | −12 | pas de diplôme/établissement |
+| Compétences absentes | −12 | techniques/logiciels/autres vides |
+| Canvas libre sans bloc sémantique | −20 | `grid == "free"` et aucun type section standard |
+
 #### 9.2.4 Bonus (design ATS-friendly)
 
 | Règle | Delta | Détection |

--- a/tests/fixtures/ats_score/README.md
+++ b/tests/fixtures/ats_score/README.md
@@ -1,6 +1,6 @@
-# Fixtures du scoring ATS
-
 Fixtures partagees pour les tests du module `backend.services.ats_score`.
+
+Voir aussi `docs/ats-score-cv-vs-layout.md` (role de `cv` vs `layout`, AXE-338).
 
 ## Convention
 
@@ -8,7 +8,9 @@ Chaque fixture est un fichier JSON autonome. Les fichiers se classent en
 trois groupes :
 
 - `cv_*.json`     : exemples de CV semantiques (cf. `frontend/src/data/cvDefault.js`).
+  Cas AXE-338 : `cv_empty.json`, `cv_minimal_name_only.json`, `cv_standard.json`.
 - `layout_*.json` : exemples de layouts (cf. annexe 16.2 de `docs/editor-vision.md`).
+  Cas AXE-338 : `layout_free_empty.json`.
 - `score_*.json`  : *snapshots* attendus (un par couple ``(cv, layout)``) versionnes
                     par ``SCORING_VERSION``.
 
@@ -19,7 +21,7 @@ Le snapshot comporte au minimum :
 
 ```json
 {
-  "scoring_version": "2026.05",
+  "scoring_version": "2026.08",
   "total": 92,
   "rule_ids": ["bonus_mono_column", "bonus_standard_section_titles", "..."]
 }

--- a/tests/fixtures/ats_score/cv_empty.json
+++ b/tests/fixtures/ats_score/cv_empty.json
@@ -1,0 +1,17 @@
+{
+  "_doc": "AXE-338 — CV sémantique vide : le score parsing doit être clairement bas.",
+  "prenom": "",
+  "nom": "",
+  "first_name": "",
+  "last_name": "",
+  "email": "",
+  "telephone": "",
+  "experiences": [],
+  "formations": [],
+  "competences": {
+    "techniques": [],
+    "logiciels": [],
+    "langues": [],
+    "autres": []
+  }
+}

--- a/tests/fixtures/ats_score/cv_minimal_name_only.json
+++ b/tests/fixtures/ats_score/cv_minimal_name_only.json
@@ -1,0 +1,15 @@
+{
+  "_doc": "AXE-338 — CV minimal (identité seule, dual-key EN) : score bas, pas ~90+.",
+  "first_name": "Jean",
+  "last_name": "Dupont",
+  "email": "",
+  "telephone": "",
+  "experiences": [],
+  "formations": [],
+  "competences": {
+    "techniques": [],
+    "logiciels": [],
+    "langues": [],
+    "autres": []
+  }
+}

--- a/tests/fixtures/ats_score/layout_free_empty.json
+++ b/tests/fixtures/ats_score/layout_free_empty.json
@@ -1,0 +1,6 @@
+{
+  "_doc": "AXE-338 — Canvas libre vide (aucun bloc).",
+  "version": 3,
+  "grid": "free",
+  "pages": [{ "id": "p1", "blocks": [] }]
+}

--- a/tests/test_api_ats_route.py
+++ b/tests/test_api_ats_route.py
@@ -34,7 +34,7 @@ class TestRouteHappyPath(unittest.TestCase):
         self.assertEqual(payload["kind"], "parsing")
         self.assertIn("total", payload)
         self.assertIn("rules", payload)
-        self.assertEqual(payload["version"], "2026.05.2")
+        self.assertEqual(payload["version"], "2026.08")
 
     def test_route_returns_payload_for_explicit_layout(self):
         body = ScoreParsingBody(layout={"grid": "single-or-sidebar", "sidebar_ratio": 0.0})

--- a/tests/test_ats_score_content_completeness.py
+++ b/tests/test_ats_score_content_completeness.py
@@ -1,0 +1,102 @@
+"""AXE-338 — completude semantique : CV pauvre → score bas ; riche → haut."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from backend.services.ats_score import score_parsing
+from backend.services.ats_score.rules import content as content_rules
+from backend.services.ats_score.rules import free_canvas as fc_rules
+from backend.services.ats_score.template_layout import template_meta_to_layout
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "ats_score"
+TEMPLATES = Path(__file__).resolve().parents[1] / "templates"
+
+
+def _load(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+class TestContentCompletenessRules(unittest.TestCase):
+    def test_empty_cv_triggers_all_missing_rules(self):
+        for fn in (
+            content_rules.rule_missing_identity,
+            content_rules.rule_missing_contact,
+            content_rules.rule_missing_experiences,
+            content_rules.rule_missing_formations,
+            content_rules.rule_missing_skills,
+        ):
+            with self.subTest(rule=fn.__name__):
+                rule = fn({}, {})
+                self.assertIsNotNone(rule)
+                self.assertLess(rule.delta, 0)
+
+    def test_dual_key_en_identity_avoids_identity_malus(self):
+        cv = {"first_name": "Jean", "last_name": "Dupont"}
+        self.assertIsNone(content_rules.rule_missing_identity(cv, {}))
+
+    def test_empty_experience_shell_still_missing(self):
+        cv = {"experiences": [{"id": "exp_1", "poste": "", "bullet_points": ["", ""]}]}
+        rule = content_rules.rule_missing_experiences(cv, {})
+        self.assertIsNotNone(rule)
+
+    def test_filled_experience_clears_malus(self):
+        cv = {"experiences": [{"poste": "Dev", "entreprise": "Acme"}]}
+        self.assertIsNone(content_rules.rule_missing_experiences(cv, {}))
+
+
+class TestPoorVsRichScores(unittest.TestCase):
+    def test_empty_cv_score_clearly_low(self):
+        cv = _load("cv_empty.json")
+        result = score_parsing(cv, {"grid": "single-or-sidebar", "sidebar_ratio": 0.0})
+        self.assertLessEqual(result.total, 40)
+        ids = {r.id for r in result.rules}
+        self.assertIn("malus_missing_identity", ids)
+        self.assertIn("malus_missing_experiences", ids)
+
+    def test_minimal_name_only_score_clearly_low(self):
+        cv = _load("cv_minimal_name_only.json")
+        result = score_parsing(cv, {"grid": "single-or-sidebar", "sidebar_ratio": 0.0})
+        self.assertLessEqual(result.total, 50)
+        self.assertNotIn("malus_missing_identity", {r.id for r in result.rules})
+
+    def test_free_empty_canvas_score_at_floor(self):
+        cv = _load("cv_empty.json")
+        layout = _load("layout_free_empty.json")
+        result = score_parsing(cv, layout)
+        self.assertEqual(result.total, 0)
+        ids = {r.id for r in result.rules}
+        self.assertIn("malus_free_canvas_no_semantic_blocks", ids)
+
+    def test_rich_cv_ats_safe_template_stays_high(self):
+        cv = _load("cv_standard.json")
+        meta = json.loads((TEMPLATES / "minimal" / "meta.json").read_text(encoding="utf-8"))
+        layout = template_meta_to_layout(meta)
+        result = score_parsing(cv, layout)
+        self.assertGreaterEqual(result.total, 95)
+        ids = {r.id for r in result.rules}
+        self.assertNotIn("malus_missing_identity", ids)
+        self.assertNotIn("malus_missing_experiences", ids)
+
+
+class TestFreeCanvasSparse(unittest.TestCase):
+    def test_no_semantic_blocks_penalized(self):
+        rule = fc_rules.rule_free_canvas_no_semantic_blocks({}, _load("layout_free_empty.json"))
+        self.assertIsNotNone(rule)
+        self.assertEqual(rule.id, "malus_free_canvas_no_semantic_blocks")
+
+    def test_empty_shells_do_not_expect_displayed_sections(self):
+        cv = {
+            "experiences": [{"id": "exp_1", "poste": ""}],
+            "formations": [{"id": "form_1", "diplome": ""}],
+            "competences": {"techniques": [""], "langues": [{"langue": ""}]},
+        }
+        self.assertIsNone(
+            fc_rules.rule_free_canvas_missing_profile_sections(cv, _load("layout_free_empty.json"))
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ats_score_rules_content.py
+++ b/tests/test_ats_score_rules_content.py
@@ -64,6 +64,14 @@ class TestContactTopOfPage(unittest.TestCase):
     def test_no_contact_no_bonus(self):
         self.assertIsNone(content_rules.rule_contact_top_of_page({}, {}))
 
+    def test_whitespace_telephone_does_not_block_phone_dual_key(self):
+        # Bugbot PR #100 : telephone=" " ne doit pas masquer phone.
+        cv = {"telephone": "   ", "phone": "+33 6 00 00 00 00"}
+        layout = {"sections_order": [{"id": "identity", "visible": True, "in": "header"}]}
+        rule = content_rules.rule_contact_top_of_page(cv, layout)
+        self.assertIsNotNone(rule)
+        self.assertEqual(rule.delta, 5)
+
     def test_sections_order_identity_in_header_gives_bonus(self):
         cv = {"email": "a@b.fr"}
         layout = {"sections_order": [{"id": "identity", "visible": True, "in": "header"}]}

--- a/tests/test_ats_score_templates_golden.py
+++ b/tests/test_ats_score_templates_golden.py
@@ -42,7 +42,7 @@ def _load_template_meta(template_id: str) -> dict:
     return _load_json(TEMPLATES_DIR / template_id / "meta.json")
 
 
-# Snapshot des scores attendus pour SCORING_VERSION="2026.05".
+# Snapshot des scores attendus pour SCORING_VERSION="2026.08".
 # Recalibrer ces valeurs **uniquement** en bumpant SCORING_VERSION dans
 # ``backend/services/ats_score/version.py`` et en commitant ensemble.
 EXPECTED: dict[str, dict] = {


### PR DESCRIPTION
## Summary
- Malus de complétude sémantique (identité, contact, expériences, formations, skills) avec dual-key FR/EN — un CV vide/minimal ne reste plus ~100
- Canvas libre sans bloc sémantique : malus dédié ; shells vides du profil ne faussent plus « profil non affiché »
- `SCORING_VERSION` → `2026.08` ; fixtures + tests ; doc `docs/ats-score-cv-vs-layout.md`

## Linear
Fixes AXE-338

## GitHub issue
Closes #99

## Test plan
- [x] `pytest` fixtures vide / minimal / riche + free empty
- [x] Templates golden (CV standard) restent hauts
- [x] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks` OK
- [ ] Smoke UI : badge ATS sur canvas vide vs CV rempli

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Le score ATS évalue désormais la complétude de l’identité, des coordonnées, des expériences, des formations et des compétences.
  * Les CV incomplets et les canevas libres sans contenu sémantique reçoivent des pénalités dédiées.
  * La détection prend en charge les variantes françaises et anglaises des champs.

* **Documentation**
  * Documentation ajoutée sur le calcul du score ATS et l’analyse de la complétude.

* **Tests**
  * Couverture ajoutée pour les CV vides, minimaux, complets et les canevas libres sans contenu.

* **Mise à jour**
  * Version du scoring ATS actualisée vers 2026.08.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->