### PR TITLE
feat(AXE-336): sans pénalité ATS « positions libres »

### DIFF
--- a/backend/services/ats_score/rules/__init__.py
+++ b/backend/services/ats_score/rules/__init__.py
@@ -25,7 +25,8 @@ parsing_rules: tuple = (
     # --- Penalites moyennes (design risque)
     layout.rule_multi_column,
     layout.rule_sidebar_present,
-    layout.rule_free_canvas_text_positions,
+    # AXE-336 : plus de malus systematique « positions libres »
+    # (layout.rule_free_canvas_text_positions est un no-op conserve pour API).
     free_canvas.rule_free_canvas_no_semantic_blocks,
     free_canvas.rule_free_canvas_missing_profile_sections,
     free_canvas.rule_free_canvas_reading_order,

--- a/backend/services/ats_score/rules/free_canvas.py
+++ b/backend/services/ats_score/rules/free_canvas.py
@@ -1,9 +1,11 @@
 """Regles ATS specifiques au canvas libre (layout v3, ``grid == "free"``).
 
-Ces regles completent ``layout.rule_free_canvas_text_positions`` et
-``layout.rule_multi_column`` en ciblant l'ordre de lecture machine :
-les parsers ATS parcourent souvent la page de haut en bas, puis de
-gauche a droite, sans tenir compte du z-index visuel.
+Completent ``layout.rule_multi_column`` / ``rule_sidebar_present`` en ciblant
+l'ordre de lecture machine et la couverture sémantique affichee.
+
+AXE-336 : on ne penalise plus le simple fait d'utiliser des positions
+absolues (ancienne ``rule_free_canvas_text_positions``) — uniquement les
+vrais risques de lecture / contenu.
 """
 
 from __future__ import annotations

--- a/backend/services/ats_score/rules/layout.py
+++ b/backend/services/ats_score/rules/layout.py
@@ -19,9 +19,7 @@ from typing import Any
 
 from backend.services.ats_score.rules._helpers import (
     count_columns,
-    get_grid,
     get_sidebar_ratio,
-    iter_blocks,
 )
 from backend.services.ats_score.types import Rule, RuleSeverity
 
@@ -64,36 +62,20 @@ def rule_sidebar_present(cv: dict[str, Any], layout: dict[str, Any]) -> Rule | N
 
 
 def rule_free_canvas_text_positions(cv: dict[str, Any], layout: dict[str, Any]) -> Rule | None:
-    """Penalise les blocs textuels en positions absolues sur canvas libre.
+    """Ancienne penalite systematique « positions libres » — desactivee (AXE-336).
 
-    Ne s'applique que si ``grid == "free"``. Le total est plafonne a -10 pour
-    eviter qu'un CV avec beaucoup de blocs ne plonge sous zero a lui seul.
+    Le canvas libre est le produit Beta : pénaliser chaque bloc textuel en
+    absolu (-2, plafond -10) punissait tout design libre, y compris lisible.
+    Les garde-fous réels restent dans ``free_canvas.py`` (ordre de lecture,
+    identité en tête, sections manquantes, contact trop bas) + multi-colonnes
+    + verify-pdf.
+
+    La fonction reste exportée pour ne pas casser les imports / tests ; elle
+    ne retourne plus jamais de ``Rule``. Ne pas la réintroduire dans
+    ``parsing_rules`` sans bump ``SCORING_VERSION``.
     """
-    if get_grid(layout) != "free":
-        return None
-    text_like_types = {
-        "identity",
-        "contact",
-        "resume",
-        "experiences",
-        "formations",
-        "certifications",
-        "projets",
-        "skills",
-        "languages",
-        "text",
-        "title",
-    }
-    count = sum(1 for b in iter_blocks(layout) if b.get("type") in text_like_types)
-    if count == 0:
-        return None
-    delta = max(-10, -2 * count)
-    return Rule(
-        id="malus_free_canvas_text_blocks",
-        label=f"Canvas libre : {count} bloc(s) textuel(s) en position absolue",
-        delta=delta,
-        severity=RuleSeverity.WARNING,
-    )
+    del cv, layout
+    return None
 
 
 def rule_table_layout(cv: dict[str, Any], layout: dict[str, Any]) -> Rule | None:

--- a/backend/services/ats_score/version.py
+++ b/backend/services/ats_score/version.py
@@ -9,4 +9,4 @@ les scores produits. Permet de :
 Format : ``YYYY.MM`` ou ``YYYY.MM.patch`` pour les corrections mineures.
 """
 
-SCORING_VERSION = "2026.08"
+SCORING_VERSION = "2026.08.1"

--- a/docs/ats-score-cv-vs-layout.md
+++ b/docs/ats-score-cv-vs-layout.md
@@ -27,8 +27,12 @@ Dans `backend/services/ats_score/rules/content.py` :
 ## Règles layout / free canvas
 
 - Templates figés : colonnes, sidebar, photo, typo…
-- Canvas `grid == "free"` : blocs sémantiques absents, profil non affiché,
-  ordre de lecture, contact trop bas, positions texte libres…
+- Canvas `grid == "free"` : **pas** de malus pour le seul fait d'utiliser des
+  positions absolues (AXE-336). On score plutôt :
+  - aucun bloc sémantique / profil non affiché
+  - ordre de lecture ambigu, identité pas en tête, contact trop bas
+  - multi-colonnes détectées via clusters `x`
+- Verify-pdf reste le filet pour un export réellement illisible.
 
 Le JSON peut être riche **et** le canvas incomplet → malus « profil non
 affiché ». L’inverse (canvas + JSON vide) → malus contenu + « aucun bloc

--- a/docs/ats-score-cv-vs-layout.md
+++ b/docs/ats-score-cv-vs-layout.md
@@ -31,7 +31,7 @@ Dans `backend/services/ats_score/rules/content.py` :
   positions absolues (AXE-336). On score plutôt :
   - aucun bloc sémantique / profil non affiché
   - ordre de lecture ambigu, identité pas en tête, contact trop bas
-  - multi-colonnes détectées via clusters `x`
+  - multicolonnes détectées via clusters `x`
 - Verify-pdf reste le filet pour un export réellement illisible.
 
 Le JSON peut être riche **et** le canvas incomplet → malus « profil non

--- a/docs/editor-vision.md
+++ b/docs/editor-vision.md
@@ -448,7 +448,7 @@ Base : **100**. Plancher : **0**. Plafond : **100**.
 | Contenu sémantique fractionné multi-colonnes | −5 supplémentaire | `experiences` réparti sur ≥ 2 colonnes |
 | Présence d'une sidebar | −5 | `sidebar_ratio > 0` |
 | Tableau pour le layout | −10 | `<table>` dans le HTML rendu |
-| Positions absolues d'éléments textuels (L3) | −2 par bloc texte (plafond −10) | `layout.grid == "free"` |
+| ~~Positions absolues d'éléments textuels (L3)~~ | ~~−2 / bloc (plafond −10)~~ | **Retiré AXE-336** — le free canvas n'est plus pénalisé pour le seul fait d'être libre ; voir règles `free_canvas.*` + verify-pdf |
 | Texte sur image de fond | −5 | `block.style.background_image` présent |
 | Bullets non standards (▪ ★ ➜) | −1 | Regex sur le texte rendu |
 | Dates au format exotique | −1 par occurrence (plafond −5) | Regex stricte sur `cv.experiences[].date_*` |

--- a/frontend/src/lib/atsCoachAdvice.js
+++ b/frontend/src/lib/atsCoachAdvice.js
@@ -55,8 +55,9 @@ export const ATS_COACH_ADVICE = {
   malus_free_canvas_text_blocks: {
     title: 'Texte en positions libres',
     explanation:
-      'Beaucoup de blocs texte en absolu : les ATS peuvent les lire dans un ordre inattendu.',
-    fixKind: 'reading-order',
+      'Cette pénalité n’est plus appliquée (AXE-336) : le canvas libre est autorisé. ' +
+      'Seuls l’ordre de lecture, les sections manquantes ou un verify-PDF faible restent scorés.',
+    fixKind: null,
     designTradeoff: true,
   },
   malus_two_columns: {

--- a/tests/fixtures/ats_score/README.md
+++ b/tests/fixtures/ats_score/README.md
@@ -21,7 +21,7 @@ Le snapshot comporte au minimum :
 
 ```json
 {
-  "scoring_version": "2026.08",
+  "scoring_version": "2026.08.1",
   "total": 92,
   "rule_ids": ["bonus_mono_column", "bonus_standard_section_titles", "..."]
 }

--- a/tests/test_api_ats_route.py
+++ b/tests/test_api_ats_route.py
@@ -34,7 +34,7 @@ class TestRouteHappyPath(unittest.TestCase):
         self.assertEqual(payload["kind"], "parsing")
         self.assertIn("total", payload)
         self.assertIn("rules", payload)
-        self.assertEqual(payload["version"], "2026.08")
+        self.assertEqual(payload["version"], "2026.08.1")
 
     def test_route_returns_payload_for_explicit_layout(self):
         body = ScoreParsingBody(layout={"grid": "single-or-sidebar", "sidebar_ratio": 0.0})

--- a/tests/test_ats_score_rules_layout.py
+++ b/tests/test_ats_score_rules_layout.py
@@ -52,28 +52,50 @@ class TestSidebarPresent(unittest.TestCase):
 
 
 class TestFreeCanvasTextPositions(unittest.TestCase):
-    def test_only_applies_in_free_mode(self):
+    """AXE-336 : plus de pénalité systematique sur les positions libres."""
+
+    def test_disabled_even_with_many_text_blocks(self):
+        layout = {
+            "grid": "free",
+            "pages": [{"blocks": [{"type": "text", "x": i, "y": 10} for i in range(20)]}],
+        }
+        self.assertIsNone(layout_rules.rule_free_canvas_text_positions({}, layout))
+
+    def test_still_noop_outside_free_mode(self):
         layout = {
             "grid": "single-or-sidebar",
             "pages": [{"blocks": [{"type": "text", "x": 10, "y": 10}]}],
         }
         self.assertIsNone(layout_rules.rule_free_canvas_text_positions({}, layout))
 
-    def test_caps_penalty_at_minus_ten(self):
-        layout = {
-            "grid": "free",
-            "pages": [{"blocks": [{"type": "text", "x": i, "y": 10} for i in range(20)]}],
-        }
-        rule = layout_rules.rule_free_canvas_text_positions({}, layout)
-        self.assertIsNotNone(rule)
-        self.assertEqual(rule.delta, -10)
+    def test_score_parsing_does_not_emit_text_blocks_malus(self):
+        from backend.services.ats_score import score_parsing
 
-    def test_non_text_blocks_are_ignored(self):
+        cv = {
+            "prenom": "Alice",
+            "nom": "Martin",
+            "email": "a@b.fr",
+            "experiences": [{"poste": "Dev", "entreprise": "Acme"}],
+            "formations": [{"diplome": "Master"}],
+            "competences": {"techniques": ["Python"]},
+        }
         layout = {
             "grid": "free",
-            "pages": [{"blocks": [{"type": "shape:line", "x": 10, "y": 10}]}],
+            "pages": [
+                {
+                    "blocks": [
+                        {"type": "identity", "x": 10, "y": 10, "w": 80, "h": 20},
+                        {"type": "contact", "x": 10, "y": 35, "w": 80, "h": 15},
+                        {"type": "experiences", "x": 10, "y": 55, "w": 80, "h": 40},
+                        {"type": "formations", "x": 10, "y": 100, "w": 80, "h": 20},
+                        {"type": "skills", "x": 10, "y": 125, "w": 80, "h": 20},
+                    ]
+                }
+            ],
         }
-        self.assertIsNone(layout_rules.rule_free_canvas_text_positions({}, layout))
+        result = score_parsing(cv, layout)
+        ids = {r.id for r in result.rules}
+        self.assertNotIn("malus_free_canvas_text_blocks", ids)
 
 
 class TestTableLayout(unittest.TestCase):

--- a/tests/test_ats_score_rules_layout.py
+++ b/tests/test_ats_score_rules_layout.py
@@ -95,6 +95,7 @@ class TestFreeCanvasTextPositions(unittest.TestCase):
         }
         result = score_parsing(cv, layout)
         ids = {r.id for r in result.rules}
+        self.assertEqual(result.total, 100)
         self.assertNotIn("malus_free_canvas_text_blocks", ids)
 
 

--- a/tests/test_ats_score_rules_typography.py
+++ b/tests/test_ats_score_rules_typography.py
@@ -69,8 +69,9 @@ class TestMonoColumnBonus(unittest.TestCase):
         self.assertIsNone(typo_rules.rule_mono_column_bonus({}, layout))
 
     def test_free_canvas_no_bonus_even_if_one_column(self):
-        # Regression : meme avec un seul bloc, free_canvas ne doit jamais
-        # gagner le bonus mono-colonne (positions absolues = risque ATS).
+        # Free canvas : pas de bonus mono-colonne (grille libre ≠ template 1-col).
+        # AXE-336 : on ne pénalise plus les positions libres seules, mais le
+        # bonus mono reste reservé aux templates figes.
         layout = {
             "grid": "free",
             "pages": [{"blocks": [{"type": "identity", "x": 10, "y": 10}]}],

--- a/tests/test_ats_score_templates_golden.py
+++ b/tests/test_ats_score_templates_golden.py
@@ -42,7 +42,7 @@ def _load_template_meta(template_id: str) -> dict:
     return _load_json(TEMPLATES_DIR / template_id / "meta.json")
 
 
-# Snapshot des scores attendus pour SCORING_VERSION="2026.08".
+# Snapshot des scores attendus pour SCORING_VERSION="2026.08.1".
 # Recalibrer ces valeurs **uniquement** en bumpant SCORING_VERSION dans
 # ``backend/services/ats_score/version.py`` et en commitant ensemble.
 EXPECTED: dict[str, dict] = {


### PR DESCRIPTION
## Summary
- Neutralise `malus_free_canvas_text_blocks` : le canvas libre n’est plus pénalisé pour le seul fait d’utiliser des positions absolues
- Garde-fous conservés : ordre de lecture, identité en tête, sections manquantes, contact bas, multi-colonnes, verify-pdf
- Coach : plus de faux « Corriger » reading-order sur cette règle ; docs + `SCORING_VERSION` → `2026.08.1`

## Linear
Fixes AXE-336

## GitHub issue
Closes #101

## Test plan
- [x] Free canvas riche + ordre OK → plus de `malus_free_canvas_text_blocks` (score 100 sur fixture)
- [x] Règles free_canvas / golden templates toujours OK
- [x] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks` OK
- [ ] Smoke UI : badge ATS sur canvas libre ne montre plus « Texte en positions libres »

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * Les positions absolues des blocs de texte sur les mises en page libres ne sont plus pénalisées automatiquement.
  * L’évaluation ATS se concentre désormais sur l’ordre de lecture, les sections manquantes, la structure multi-colonnes et la lisibilité réelle des PDF.
  * Les conseils affichés indiquent plus clairement les contrôles encore pris en compte.

* **Documentation**
  * Les règles de scoring et leur impact sur les mises en page libres ont été actualisés.

* **Maintenance**
  * La version du scoring ATS passe à **2026.08.1**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->