### PR TITLE
fix(AXE-333): corrections ATS coach actionnables

### DIFF
--- a/docs/ats-coach-actionable-fixes.md
+++ b/docs/ats-coach-actionable-fixes.md
@@ -1,0 +1,28 @@
+# Coach ATS — corrections actionnables (AXE-333)
+
+Le panneau coach (`EditorAtsScoreBadge`) propose **Corriger** uniquement quand
+une règle a un `fixKind` qui **modifie vraiment** le layout.
+
+## FixKinds
+
+| fixKind | Effet |
+|---------|--------|
+| `contact-up` | Remonte le bloc contact |
+| `reading-order` | Empile les blocs sémantiques (y) + calques |
+| `add-missing-sections` | Insère les sections du profil absentes du canvas |
+| `hide-photo` | `theme.show_photo=false` + retire blocs photo |
+| `fix-font` | Polices → Arial |
+| `fix-body-font-size` | Corps → 10 pt |
+| `single-column` | Free : même `x` ; template : `sidebar_ratio=0` |
+
+Si `fixKind` est `null`, l’UI affiche **`notApplicableReason`**
+(ex. « À remplir dans le contenu du profil »).
+
+## Garde-fou
+
+Avant preview / apply : si le layout après fix est identique, pas d’action
+trompeuse (`didAtsCoachFixChangeLayout`).
+
+## Tests
+
+`frontend/tests/unit/atsCoachAdvice.test.js` — mapping + chaque fix critique.

--- a/frontend/src/components/editor/EditorAtsScoreBadge.jsx
+++ b/frontend/src/components/editor/EditorAtsScoreBadge.jsx
@@ -8,7 +8,7 @@ import {
   isAtsCoachRuleFixable,
   summarizeAtsCoachStatus,
 } from '../../lib/atsCoachAdvice.js';
-import { applyAtsCoachFix, formatAtsScoreImpact } from '../../lib/atsCoachFixes.js';
+import { applyAtsCoachFix, didAtsCoachFixChangeLayout, formatAtsScoreImpact } from '../../lib/atsCoachFixes.js';
 
 const IGNORED_STORAGE_KEY = 'axeljob.atsCoach.ignoredRules';
 
@@ -129,7 +129,11 @@ export default function EditorAtsScoreBadge({
   const ensureImpactPreview = async (rule) => {
     if (!layout || !isAtsCoachRuleFixable(rule.id)) return null;
     if (previewByRule[rule.id]) return previewByRule[rule.id];
-    const nextLayout = applyAtsCoachFix(layout, rule.id);
+    const nextLayout = applyAtsCoachFix(layout, rule.id, { cv });
+    if (!didAtsCoachFixChangeLayout(layout, nextLayout)) {
+      setActionError('Cette correction ne modifie pas le layout actuel.');
+      return null;
+    }
     setPreviewLoadingId(rule.id);
     setActionError('');
     try {
@@ -152,8 +156,8 @@ export default function EditorAtsScoreBadge({
   const handleFix = async (rule) => {
     if (!onApplyLayout || !layout) return;
     const impact = await ensureImpactPreview(rule);
-    const nextLayout = impact?.nextLayout || applyAtsCoachFix(layout, rule.id);
-    onApplyLayout(nextLayout, { groupKey: `ats:coach:${rule.id}` });
+    if (!impact?.nextLayout) return;
+    onApplyLayout(impact.nextLayout, { groupKey: `ats:coach:${rule.id}` });
   };
 
   if (status === 'idle') {
@@ -302,6 +306,9 @@ export default function EditorAtsScoreBadge({
                         <span className="ats-coach-rule-expl">{advice.explanation}</span>
                         {soft && (
                           <span className="ats-coach-rule-note">Choix design acceptable — impact ATS limité.</span>
+                        )}
+                        {!canFix && advice.notApplicableReason && (
+                          <span className="ats-coach-rule-note">{advice.notApplicableReason}</span>
                         )}
                         {preview && (
                           <span className="ats-coach-impact" role="status">

--- a/frontend/src/lib/atsCoachAdvice.js
+++ b/frontend/src/lib/atsCoachAdvice.js
@@ -1,11 +1,13 @@
 /**
- * Mapping règle ATS → messages coach (AXE-36).
+ * Mapping règle ATS → messages coach (AXE-36 / AXE-333).
  *
  * Les `label` API restent la source courte ; ce module fournit le texte
  * pédagogique stable (tests) + le type d'action « Corriger » possible.
  */
 
-/** @typedef {'reading-order' | 'contact-up' | null} AtsCoachFixKind */
+/**
+ * @typedef {'reading-order' | 'contact-up' | 'add-missing-sections' | 'hide-photo' | 'fix-font' | 'fix-body-font-size' | 'single-column' | null} AtsCoachFixKind
+ */
 
 /**
  * @typedef {object} AtsCoachAdvice
@@ -13,6 +15,7 @@
  * @property {string} explanation
  * @property {AtsCoachFixKind} fixKind
  * @property {boolean} designTradeoff - en mode design, conseil atténué
+ * @property {string} [notApplicableReason] - si fixKind null : pourquoi pas de Corriger
  */
 
 /** @type {Record<string, AtsCoachAdvice>} */
@@ -49,7 +52,14 @@ export const ATS_COACH_ADVICE = {
     title: 'Contenu du profil absent du canvas',
     explanation:
       'Des infos du profil ne sont pas affichées. Ajoute les blocs manquants depuis la sidebar.',
-    fixKind: null,
+    fixKind: 'add-missing-sections',
+    designTradeoff: false,
+  },
+  malus_free_canvas_no_semantic_blocks: {
+    title: 'Aucun bloc sémantique sur le canvas',
+    explanation:
+      'Ajoute au moins identité / contact / expériences pour qu’un ATS reconnaisse la structure.',
+    fixKind: 'add-missing-sections',
     designTradeoff: false,
   },
   malus_free_canvas_text_blocks: {
@@ -59,26 +69,27 @@ export const ATS_COACH_ADVICE = {
       'Seuls l’ordre de lecture, les sections manquantes ou un verify-PDF faible restent scorés.',
     fixKind: null,
     designTradeoff: true,
+    notApplicableReason: 'Non applicable — pénalité retirée (AXE-336).',
   },
   malus_two_columns: {
     title: 'Layout sur 2 colonnes',
     explanation:
       'Les colonnes perturbent souvent la lecture linéaire des ATS. Préfère une colonne pour une version ATS-safe.',
-    fixKind: null,
+    fixKind: 'single-column',
     designTradeoff: true,
   },
   malus_three_or_more_columns: {
     title: 'Trop de colonnes',
     explanation:
       'Plus de deux colonnes dégrade fortement la lecture machine. Simplifie la structure.',
-    fixKind: null,
+    fixKind: 'single-column',
     designTradeoff: true,
   },
   malus_sidebar_present: {
     title: 'Sidebar présente',
     explanation:
       'Une sidebar crée un ordre de lecture ambigu (gauche/droite). Utile en design, risqué pour les ATS.',
-    fixKind: null,
+    fixKind: 'single-column',
     designTradeoff: true,
   },
   malus_table_layout: {
@@ -87,26 +98,27 @@ export const ATS_COACH_ADVICE = {
       'Les tableaux sont souvent lus ligne par ligne et mélangent les colonnes pour les ATS.',
     fixKind: null,
     designTradeoff: false,
+    notApplicableReason: 'Non applicable auto — change de modèle ou de structure HTML.',
   },
   malus_photo_present: {
     title: 'Photo sur le CV',
     explanation:
       'Une photo n’améliore pas le score ATS et peut être ignorée. Choix design acceptable.',
-    fixKind: null,
+    fixKind: 'hide-photo',
     designTradeoff: true,
   },
   malus_exotic_font: {
     title: 'Police atypique',
     explanation:
       'Certaines polices se transforment mal chez les ATS. Préfère Arial, Calibri, Helvetica…',
-    fixKind: null,
+    fixKind: 'fix-font',
     designTradeoff: true,
   },
   malus_body_font_size_out_of_range: {
     title: 'Taille de corps hors plage',
     explanation:
       'Une taille trop petite ou trop grande nuit à l’extraction. Vise ~10–12 pt.',
-    fixKind: null,
+    fixKind: 'fix-body-font-size',
     designTradeoff: false,
   },
   malus_inconsistent_dates: {
@@ -115,30 +127,70 @@ export const ATS_COACH_ADVICE = {
       'Harmonise le format des dates (ex. MM/YYYY) pour faciliter le parsing.',
     fixKind: null,
     designTradeoff: false,
+    notApplicableReason: 'À corriger dans le contenu (dates des expériences / formations).',
+  },
+  malus_missing_identity: {
+    title: 'Identité absente',
+    explanation: 'Ajoute prénom et nom pour que les ATS te reconnaissent.',
+    fixKind: null,
+    designTradeoff: false,
+    notApplicableReason: 'À remplir dans le contenu du profil (identité).',
+  },
+  malus_missing_contact: {
+    title: 'Contact absent',
+    explanation: 'Ajoute un email ou un téléphone exploitable.',
+    fixKind: null,
+    designTradeoff: false,
+    notApplicableReason: 'À remplir dans le contenu du profil (contact).',
+  },
+  malus_missing_experiences: {
+    title: 'Aucune expérience renseignée',
+    explanation: 'Renseigne au moins une expérience avec poste ou entreprise.',
+    fixKind: null,
+    designTradeoff: false,
+    notApplicableReason: 'À remplir dans le contenu du profil (expériences).',
+  },
+  malus_missing_formations: {
+    title: 'Aucune formation renseignée',
+    explanation: 'Ajoute au moins une formation.',
+    fixKind: null,
+    designTradeoff: false,
+    notApplicableReason: 'À remplir dans le contenu du profil (formations).',
+  },
+  malus_missing_skills: {
+    title: 'Compétences absentes',
+    explanation: 'Ajoute des compétences techniques ou logiciels.',
+    fixKind: null,
+    designTradeoff: false,
+    notApplicableReason: 'À remplir dans le contenu du profil (compétences).',
   },
   bonus_mono_column: {
     title: 'Layout mono-colonne',
     explanation: 'Bonne pratique : une seule colonne facilite la lecture ATS.',
     fixKind: null,
     designTradeoff: false,
+    notApplicableReason: 'Bonus — rien à corriger.',
   },
   bonus_standard_section_titles: {
     title: 'Titres de sections standards',
     explanation: 'Les titres classiques aident les parsers à reconnaître les sections.',
     fixKind: null,
     designTradeoff: false,
+    notApplicableReason: 'Bonus — rien à corriger.',
   },
   bonus_contact_top_of_page: {
     title: 'Contact en haut de page',
     explanation: 'Le contact est bien placé pour la lecture machine.',
     fixKind: null,
     designTradeoff: false,
+    notApplicableReason: 'Bonus — rien à corriger.',
   },
   bonus_dates_format_consistent: {
     title: 'Dates cohérentes',
     explanation: 'Le format des dates est homogène — bon signal pour les ATS.',
     fixKind: null,
     designTradeoff: false,
+    notApplicableReason: 'Bonus — rien à corriger.',
   },
 };
 
@@ -168,6 +220,7 @@ export function getAtsCoachAdvice(rule) {
     explanation: advice,
     fixKind: null,
     designTradeoff: false,
+    notApplicableReason: 'Pas de correction auto pour cette règle.',
   };
 }
 

--- a/frontend/src/lib/atsCoachAdvice.js
+++ b/frontend/src/lib/atsCoachAdvice.js
@@ -58,7 +58,8 @@ export const ATS_COACH_ADVICE = {
   malus_free_canvas_no_semantic_blocks: {
     title: 'Aucun bloc sémantique sur le canvas',
     explanation:
-      'Ajoute au moins identité / contact / expériences pour qu’un ATS reconnaisse la structure.',
+      'Ajoute au moins identité / contact pour qu’un ATS reconnaisse la structure. ' +
+      'Si le profil est vide, un starter identity+contact est posé ; complète ensuite le contenu.',
     fixKind: 'add-missing-sections',
     designTradeoff: false,
   },

--- a/frontend/src/lib/atsCoachFixes.js
+++ b/frontend/src/lib/atsCoachFixes.js
@@ -1,10 +1,16 @@
 /**
- * Corrections ATS par règle (AXE-36) — pures, réversibles via undo layout.
+ * Corrections ATS par règle (AXE-36 / AXE-333) — pures, réversibles via undo layout.
  */
 
 import {
+  applyAtsLayoutOptimizations,
+  optimizeAddMissingProfileSections,
+  optimizeBodyFontSize,
   optimizeContactVerticalPosition,
-  optimizeLayoutSpatialOrder,
+  optimizeHidePhoto,
+  optimizeRemoveSidebar,
+  optimizeSafeFonts,
+  optimizeSingleColumnFreeCanvas,
 } from './atsLayoutOptimize.js';
 import { getAtsCoachAdvice } from './atsCoachAdvice.js';
 
@@ -12,18 +18,51 @@ import { getAtsCoachAdvice } from './atsCoachAdvice.js';
  * Applique la correction associée à une règle, ou retourne le layout inchangé.
  * @param {object} layout
  * @param {string} ruleId
+ * @param {{ cv?: object }} [options]
  * @returns {object}
  */
-export function applyAtsCoachFix(layout, ruleId) {
+export function applyAtsCoachFix(layout, ruleId, options = {}) {
   if (!layout) return layout;
   const { fixKind } = getAtsCoachAdvice({ id: ruleId });
   if (fixKind === 'contact-up') {
     return optimizeContactVerticalPosition(layout);
   }
   if (fixKind === 'reading-order') {
-    return optimizeLayoutSpatialOrder(layout);
+    return applyAtsLayoutOptimizations(layout);
+  }
+  if (fixKind === 'add-missing-sections') {
+    return optimizeAddMissingProfileSections(layout, options.cv);
+  }
+  if (fixKind === 'hide-photo') {
+    return optimizeHidePhoto(layout);
+  }
+  if (fixKind === 'fix-font') {
+    return optimizeSafeFonts(layout);
+  }
+  if (fixKind === 'fix-body-font-size') {
+    return optimizeBodyFontSize(layout);
+  }
+  if (fixKind === 'single-column') {
+    if (layout.grid === 'free') {
+      return optimizeSingleColumnFreeCanvas(layout);
+    }
+    return optimizeRemoveSidebar(layout);
   }
   return layout;
+}
+
+/**
+ * True si le layout a réellement changé (JSON stable).
+ * @param {object} before
+ * @param {object} after
+ */
+export function didAtsCoachFixChangeLayout(before, after) {
+  if (!before || !after || before === after) return false;
+  try {
+    return JSON.stringify(before) !== JSON.stringify(after);
+  } catch {
+    return before !== after;
+  }
 }
 
 /**

--- a/frontend/src/lib/atsLayoutOptimize.js
+++ b/frontend/src/lib/atsLayoutOptimize.js
@@ -9,8 +9,13 @@ import {
   listAllBlocks,
   PAGE_HEIGHT_MM,
   PAGE_MARGIN_MM,
+  PAGE_USABLE_WIDTH_MM,
+  addBlockToPage,
+  removeBlocks,
 } from './cvLayoutModelV3.js';
 import { isVectorShapeType } from './canvasShapePresets.js';
+import { createCvSectionBlockPreset } from './canvasCvSectionPresets.js';
+import { generateItemId } from './cvSectionOps.js';
 
 /** Ordre aligné sur `free_canvas._CANONICAL_READ_ORDER` (scorer ATS). */
 export const SEMANTIC_READ_ORDER = [
@@ -28,6 +33,8 @@ export const SEMANTIC_READ_ORDER = [
 
 const CONTENT_GAP_MM = 6;
 const CONTACT_TOP_Y_MM = 40;
+const ATS_SAFE_FALLBACK_FONT = 'Arial';
+const ATS_SAFE_BODY_FONT_SIZE = 10;
 
 function semanticRank(type) {
   const i = SEMANTIC_READ_ORDER.indexOf(type);
@@ -146,6 +153,181 @@ export function applyAtsLayoutOptimizations(layout) {
   next = optimizeLayoutSpatialOrder(next);
   next = optimizeLayoutReadingOrder(next);
   return next;
+}
+
+function cvText(value) {
+  if (value == null) return '';
+  return String(value).trim();
+}
+
+function cvHasIdentity(cv) {
+  return Boolean(
+    cvText(cv?.prenom) || cvText(cv?.first_name) || cvText(cv?.nom) || cvText(cv?.last_name),
+  );
+}
+
+function cvHasContact(cv) {
+  return Boolean(cvText(cv?.email) || cvText(cv?.telephone) || cvText(cv?.phone));
+}
+
+function cvHasExperiences(cv) {
+  for (const exp of cv?.experiences || []) {
+    if (!exp || typeof exp !== 'object') continue;
+    if (cvText(exp.poste) || cvText(exp.title) || cvText(exp.entreprise) || cvText(exp.company)) {
+      return true;
+    }
+    if ((exp.bullet_points || []).some((b) => cvText(b))) return true;
+  }
+  return false;
+}
+
+function cvHasFormations(cv) {
+  for (const form of cv?.formations || []) {
+    if (!form || typeof form !== 'object') continue;
+    if (cvText(form.diplome) || cvText(form.degree) || cvText(form.etablissement) || cvText(form.school)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function cvHasSkills(cv) {
+  const competences = cv?.competences;
+  if (!competences || typeof competences !== 'object') return false;
+  for (const key of ['techniques', 'logiciels', 'autres']) {
+    if ((competences[key] || []).some((x) => cvText(x))) return true;
+  }
+  return false;
+}
+
+function cvHasLanguages(cv) {
+  const langues = cv?.competences?.langues || [];
+  return langues.some((item) => {
+    if (item && typeof item === 'object') return Boolean(cvText(item.langue));
+    return Boolean(cvText(item));
+  });
+}
+
+/** Types de sections attendus sur le canvas d’après le JSON sémantique (miroir backend). */
+export function expectedProfileSectionTypesFromCv(cv) {
+  const expected = [];
+  if (cvHasIdentity(cv)) expected.push('identity');
+  if (cvHasContact(cv)) expected.push('contact');
+  if (cvHasExperiences(cv)) expected.push('experiences');
+  if (cvHasFormations(cv)) expected.push('formations');
+  if (cvHasSkills(cv)) expected.push('skills');
+  if (cvHasLanguages(cv)) expected.push('languages');
+  return expected;
+}
+
+/**
+ * Ajoute les blocs sémantiques manquants (profil non affiché) puis restacke.
+ * Free canvas uniquement.
+ */
+export function optimizeAddMissingProfileSections(layout, cv) {
+  if (!layout?.pages?.length || layout.grid !== 'free') return layout;
+  const expected = expectedProfileSectionTypesFromCv(cv || {});
+  if (expected.length === 0) return layout;
+  const displayed = new Set(
+    listAllBlocks(layout).map((b) => b?.type).filter(Boolean),
+  );
+  const missing = expected.filter((type) => !displayed.has(type));
+  if (missing.length === 0) return layout;
+
+  let next = layout;
+  const pageIndex = 0;
+  const existing = listAllBlocks(next);
+  let maxY = PAGE_MARGIN_MM;
+  for (const block of existing) {
+    const bottom = asNumber(block.y) + Math.max(asNumber(block.h, 10), 3);
+    if (bottom > maxY) maxY = bottom;
+  }
+  let cursorY = maxY + CONTENT_GAP_MM;
+
+  for (const type of missing) {
+    const preset = createCvSectionBlockPreset(type);
+    if (!preset) continue;
+    const partial = {
+      ...preset,
+      id: generateItemId(`ats_${type}`),
+      x: PAGE_MARGIN_MM,
+      y: cursorY,
+      w: preset.w || PAGE_USABLE_WIDTH_MM,
+      h: preset.h || 20,
+      z: existing.length + missing.indexOf(type) + 1,
+    };
+    next = addBlockToPage(next, pageIndex, partial);
+    cursorY += asNumber(partial.h, 20) + CONTENT_GAP_MM;
+  }
+
+  return applyAtsLayoutOptimizations(next);
+}
+
+/** Masque la photo (theme + retire les blocs photo). */
+export function optimizeHidePhoto(layout) {
+  if (!layout) return layout;
+  const photoIds = listAllBlocks(layout)
+    .filter((b) => b?.type === 'photo')
+    .map((b) => b.id)
+    .filter(Boolean);
+  let next = {
+    ...layout,
+    theme: { ...(layout.theme || {}), show_photo: false },
+  };
+  if (photoIds.length) {
+    next = removeBlocks(next, photoIds);
+  }
+  return next;
+}
+
+/** Remplace les polices exotiques par une police ATS-safe. */
+export function optimizeSafeFonts(layout) {
+  if (!layout) return layout;
+  return {
+    ...layout,
+    theme: {
+      ...(layout.theme || {}),
+      font_heading: ATS_SAFE_FALLBACK_FONT,
+      font_body: ATS_SAFE_FALLBACK_FONT,
+    },
+  };
+}
+
+/** Ramène la taille de corps dans la plage ATS (10 pt). */
+export function optimizeBodyFontSize(layout) {
+  if (!layout) return layout;
+  return {
+    ...layout,
+    theme: {
+      ...(layout.theme || {}),
+      font_size_body: ATS_SAFE_BODY_FONT_SIZE,
+    },
+  };
+}
+
+/** Force une seule colonne sur free canvas (même x) puis restacke. */
+export function optimizeSingleColumnFreeCanvas(layout) {
+  if (!layout?.pages?.length || layout.grid !== 'free') return layout;
+  const pages = layout.pages.map((page) => {
+    const blocks = (page.blocks || []).map((block) => {
+      if (!isAtsReadingContentBlock(block)) return block;
+      return {
+        ...block,
+        x: PAGE_MARGIN_MM,
+        w: Math.min(asNumber(block.w, PAGE_USABLE_WIDTH_MM), PAGE_USABLE_WIDTH_MM),
+      };
+    });
+    return { ...page, blocks };
+  });
+  return applyAtsLayoutOptimizations({ ...layout, pages });
+}
+
+/** Désactive la sidebar (templates figés) pour une lecture ATS linéaire. */
+export function optimizeRemoveSidebar(layout) {
+  if (!layout) return layout;
+  const ratio = Number(layout.sidebar_ratio);
+  if (!Number.isFinite(ratio) || ratio <= 0) return layout;
+  return { ...layout, sidebar_ratio: 0 };
 }
 
 /**

--- a/frontend/src/lib/atsLayoutOptimize.js
+++ b/frontend/src/lib/atsLayoutOptimize.js
@@ -223,14 +223,22 @@ export function expectedProfileSectionTypesFromCv(cv) {
 /**
  * Ajoute les blocs sémantiques manquants (profil non affiché) puis restacke.
  * Free canvas uniquement.
+ *
+ * Si le CV n’a rien à afficher mais le canvas n’a aucun bloc sémantique
+ * (`malus_free_canvas_no_semantic_blocks`), on pose un starter identity+contact
+ * pour que « Corriger » change vraiment le layout (Bugbot AXE-333).
  */
 export function optimizeAddMissingProfileSections(layout, cv) {
   if (!layout?.pages?.length || layout.grid !== 'free') return layout;
-  const expected = expectedProfileSectionTypesFromCv(cv || {});
-  if (expected.length === 0) return layout;
   const displayed = new Set(
     listAllBlocks(layout).map((b) => b?.type).filter(Boolean),
   );
+  const hasSemantic = [...displayed].some((type) => SEMANTIC_READ_ORDER.includes(type));
+  let expected = expectedProfileSectionTypesFromCv(cv || {});
+  if (expected.length === 0) {
+    if (hasSemantic) return layout;
+    expected = ['identity', 'contact'];
+  }
   const missing = expected.filter((type) => !displayed.has(type));
   if (missing.length === 0) return layout;
 

--- a/frontend/tests/unit/atsCoachAdvice.test.js
+++ b/frontend/tests/unit/atsCoachAdvice.test.js
@@ -1,5 +1,5 @@
 /**
- * Tests mapping rule → messages coach (AXE-36).
+ * Tests mapping rule → messages coach + corrections actionnables (AXE-36 / AXE-333).
  */
 
 import { test } from 'node:test';
@@ -12,12 +12,26 @@ import {
   isAtsCoachRuleFixable,
   summarizeAtsCoachStatus,
 } from '../../src/lib/atsCoachAdvice.js';
-import { applyAtsCoachFix, formatAtsScoreImpact } from '../../src/lib/atsCoachFixes.js';
+import {
+  applyAtsCoachFix,
+  didAtsCoachFixChangeLayout,
+  formatAtsScoreImpact,
+} from '../../src/lib/atsCoachFixes.js';
 
 test('chaque entrée ATS_COACH_ADVICE a title + explanation', () => {
   for (const [id, advice] of Object.entries(ATS_COACH_ADVICE)) {
     assert.ok(advice.title?.trim(), `title manquant pour ${id}`);
     assert.ok(advice.explanation?.trim(), `explanation manquante pour ${id}`);
+  }
+});
+
+test('chaque règle non fixable a une raison explicite', () => {
+  for (const [id, advice] of Object.entries(ATS_COACH_ADVICE)) {
+    if (advice.fixKind) continue;
+    assert.ok(
+      advice.notApplicableReason?.trim(),
+      `notApplicableReason manquant pour ${id}`,
+    );
   }
 });
 
@@ -44,10 +58,12 @@ test('getAtsCoachAdvice préfère advice API si fourni', () => {
   assert.equal(advice.explanation, 'Message backend prioritaire.');
 });
 
-test('isAtsCoachRuleFixable pour contact et ordre', () => {
+test('isAtsCoachRuleFixable pour contact, ordre, sections, photo', () => {
   assert.equal(isAtsCoachRuleFixable('malus_contact_low_on_page'), true);
   assert.equal(isAtsCoachRuleFixable('malus_identity_not_first'), true);
-  assert.equal(isAtsCoachRuleFixable('malus_photo_present'), false);
+  assert.equal(isAtsCoachRuleFixable('malus_free_canvas_missing_profile_sections'), true);
+  assert.equal(isAtsCoachRuleFixable('malus_photo_present'), true);
+  assert.equal(isAtsCoachRuleFixable('malus_missing_identity'), false);
 });
 
 test('filterRulesForCoachMode masque les bonus en mode design', () => {
@@ -91,4 +107,94 @@ test('applyAtsCoachFix remonte un contact trop bas', () => {
   };
   const next = applyAtsCoachFix(layout, 'malus_contact_low_on_page');
   assert.ok(next.pages[0].blocks[0].y <= 40);
+  assert.equal(didAtsCoachFixChangeLayout(layout, next), true);
+});
+
+test('applyAtsCoachFix reading-order empile identity avant experiences', () => {
+  const layout = {
+    version: 3,
+    format: 'A4',
+    grid: 'free',
+    unit: 'mm',
+    theme: {},
+    pages: [{
+      id: 'page-1',
+      blocks: [
+        { id: 'exp', type: 'experiences', x: 10, y: 10, w: 180, h: 40, z: 2, style: {} },
+        { id: 'id', type: 'identity', x: 10, y: 80, w: 180, h: 20, z: 1, style: {} },
+      ],
+    }],
+  };
+  const next = applyAtsCoachFix(layout, 'malus_identity_not_first');
+  const identity = next.pages[0].blocks.find((b) => b.id === 'id');
+  const experiences = next.pages[0].blocks.find((b) => b.id === 'exp');
+  assert.ok(identity.y < experiences.y);
+});
+
+test('applyAtsCoachFix ajoute les sections manquantes du profil', () => {
+  const cv = {
+    prenom: 'Alice',
+    nom: 'Martin',
+    email: 'a@b.fr',
+    experiences: [{ poste: 'Dev', entreprise: 'Acme' }],
+  };
+  const layout = {
+    version: 3,
+    format: 'A4',
+    grid: 'free',
+    unit: 'mm',
+    theme: {},
+    pages: [{ id: 'page-1', blocks: [] }],
+  };
+  const next = applyAtsCoachFix(layout, 'malus_free_canvas_missing_profile_sections', { cv });
+  const types = new Set(next.pages[0].blocks.map((b) => b.type));
+  assert.ok(types.has('identity'));
+  assert.ok(types.has('contact'));
+  assert.ok(types.has('experiences'));
+  assert.equal(didAtsCoachFixChangeLayout(layout, next), true);
+});
+
+test('applyAtsCoachFix hide-photo masque theme et retire le bloc', () => {
+  const layout = {
+    version: 3,
+    format: 'A4',
+    grid: 'free',
+    unit: 'mm',
+    theme: { show_photo: true },
+    pages: [{
+      id: 'page-1',
+      blocks: [
+        { id: 'ph', type: 'photo', x: 10, y: 10, w: 28, h: 28, z: 1, style: {} },
+        { id: 'id', type: 'identity', x: 50, y: 10, w: 100, h: 20, z: 2, style: {} },
+      ],
+    }],
+  };
+  const next = applyAtsCoachFix(layout, 'malus_photo_present');
+  assert.equal(next.theme.show_photo, false);
+  assert.equal(next.pages[0].blocks.some((b) => b.type === 'photo'), false);
+});
+
+test('applyAtsCoachFix fix-font et body size changent le theme', () => {
+  const layout = {
+    version: 3,
+    grid: 'single-or-sidebar',
+    theme: { font_heading: 'Papyrus', font_body: 'Comic Sans', font_size_body: 7 },
+    pages: [{ id: 'p1', blocks: [] }],
+  };
+  const fonts = applyAtsCoachFix(layout, 'malus_exotic_font');
+  assert.equal(fonts.theme.font_heading, 'Arial');
+  assert.equal(fonts.theme.font_body, 'Arial');
+  const size = applyAtsCoachFix(layout, 'malus_body_font_size_out_of_range');
+  assert.equal(size.theme.font_size_body, 10);
+});
+
+test('applyAtsCoachFix single-column retire la sidebar template', () => {
+  const layout = {
+    grid: 'single-or-sidebar',
+    sidebar_ratio: 0.35,
+    theme: {},
+    pages: [{ id: 'p1', blocks: [] }],
+  };
+  const next = applyAtsCoachFix(layout, 'malus_sidebar_present');
+  assert.equal(next.sidebar_ratio, 0);
 });

--- a/frontend/tests/unit/atsCoachAdvice.test.js
+++ b/frontend/tests/unit/atsCoachAdvice.test.js
@@ -154,6 +154,23 @@ test('applyAtsCoachFix ajoute les sections manquantes du profil', () => {
   assert.equal(didAtsCoachFixChangeLayout(layout, next), true);
 });
 
+test('applyAtsCoachFix no-semantic pose un starter même si CV vide', () => {
+  // Bugbot : ne plus no-op quand canvas vide + profil vide.
+  const layout = {
+    version: 3,
+    format: 'A4',
+    grid: 'free',
+    unit: 'mm',
+    theme: {},
+    pages: [{ id: 'page-1', blocks: [] }],
+  };
+  const next = applyAtsCoachFix(layout, 'malus_free_canvas_no_semantic_blocks', { cv: {} });
+  const types = new Set(next.pages[0].blocks.map((b) => b.type));
+  assert.ok(types.has('identity'));
+  assert.ok(types.has('contact'));
+  assert.equal(didAtsCoachFixChangeLayout(layout, next), true);
+});
+
 test('applyAtsCoachFix hide-photo masque theme et retire le bloc', () => {
   const layout = {
     version: 3,


### PR DESCRIPTION
## Summary
- Nouveaux fixKinds : `add-missing-sections`, `hide-photo`, `fix-font`, `fix-body-font-size`, `single-column`
- UI : raison **non applicable** explicite quand pas de Corriger (contenu profil, bonus, etc.)
- Garde-fou : pas de preview/apply si le layout ne change pas
- Doc `docs/ats-coach-actionable-fixes.md` + tests unitaires

## Linear
Fixes AXE-333

## GitHub issue
Closes #103

## Test plan
- [x] Unit tests coach / optimize OK
- [x] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks` OK
- [ ] Smoke UI : « Contenu du profil absent » → Voir l’impact → Corriger ajoute les blocs
- [ ] Smoke : contact trop bas → score remonte
- [ ] Smoke : règle contenu manquant montre « À remplir dans le profil »

Made with [Cursor](https://cursor.com)