### PR TITLE
improve(AXE-331): Optimiser ATS en UI légère (popover)

### DIFF
--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -1372,23 +1372,26 @@ function CvEditorBeta({
   useEffect(() => {
     if (!atsOptimizePreview) return undefined;
     const onKeyDown = (event) => {
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        handleCancelAtsOptimizePreview();
-      }
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      // Empêche le handler canvas (window) de vider la sélection en même temps.
+      event.stopPropagation();
+      handleCancelAtsOptimizePreview();
     };
     const onPointerDown = (event) => {
       const wrap = atsOptimizeWrapRef.current;
       const panel = atsOptimizePanelRef.current;
       const target = event.target;
       if (wrap?.contains(target) || panel?.contains(target)) return;
+      // Capture + pointerdown : le canvas fait preventDefault sur pointerdown,
+      // ce qui empêche mousedown d’arriver (Bugbot PR #106).
       handleCancelAtsOptimizePreview();
     };
-    document.addEventListener('keydown', onKeyDown);
-    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown, true);
+    document.addEventListener('pointerdown', onPointerDown, true);
     return () => {
-      document.removeEventListener('keydown', onKeyDown);
-      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown, true);
+      document.removeEventListener('pointerdown', onPointerDown, true);
     };
   }, [atsOptimizePreview, handleCancelAtsOptimizePreview]);
 
@@ -1815,7 +1818,13 @@ function CvEditorBeta({
                   ✕
                 </button>
               </div>
-              <p className="cv-editor-beta-ats-preview__impact" role="status">
+              <p
+                className={[
+                  'cv-editor-beta-ats-preview__impact',
+                  atsOptimizePreview.error ? 'cv-editor-beta-ats-preview__impact--error' : '',
+                ].filter(Boolean).join(' ')}
+                role="status"
+              >
                 {atsOptimizePreviewLoading && 'Calcul de l’impact score…'}
                 {!atsOptimizePreviewLoading && atsOptimizePreview.error && atsOptimizePreview.error}
                 {!atsOptimizePreviewLoading && !atsOptimizePreview.error && (

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 import {
   apiGet,
@@ -201,6 +202,8 @@ function CvEditorBeta({
   const [atsOptimizeUndoAfter, setAtsOptimizeUndoAfter] = useState(null);
   const atsOptimizePreviewReqRef = useRef(0);
   const atsOptimizeWrapRef = useRef(null);
+  const atsOptimizePanelRef = useRef(null);
+  const [atsOptimizePanelPos, setAtsOptimizePanelPos] = useState({ top: 0, right: 12 });
   const autoHeightPendingRef = useRef(new Map());
   const autoHeightTimerRef = useRef(null);
   const suppressAutoHeightUntilRef = useRef(0);
@@ -1356,6 +1359,16 @@ function CvEditorBeta({
     setAtsOptimizePreviewLoading(false);
   }, []);
 
+  const updateAtsOptimizePanelPos = useCallback(() => {
+    const anchor = atsOptimizeWrapRef.current;
+    if (!anchor) return;
+    const rect = anchor.getBoundingClientRect();
+    setAtsOptimizePanelPos({
+      top: Math.round(rect.bottom + 8),
+      right: Math.max(12, Math.round(window.innerWidth - rect.right)),
+    });
+  }, []);
+
   useEffect(() => {
     if (!atsOptimizePreview) return undefined;
     const onKeyDown = (event) => {
@@ -1365,10 +1378,11 @@ function CvEditorBeta({
       }
     };
     const onPointerDown = (event) => {
-      const root = atsOptimizeWrapRef.current;
-      if (root && !root.contains(event.target)) {
-        handleCancelAtsOptimizePreview();
-      }
+      const wrap = atsOptimizeWrapRef.current;
+      const panel = atsOptimizePanelRef.current;
+      const target = event.target;
+      if (wrap?.contains(target) || panel?.contains(target)) return;
+      handleCancelAtsOptimizePreview();
     };
     document.addEventListener('keydown', onKeyDown);
     document.addEventListener('mousedown', onPointerDown);
@@ -1420,6 +1434,21 @@ function CvEditorBeta({
   const atsOptimizeUndoVisible = Boolean(
     atsOptimizeUndoAfter && layout && sameLayout(layout, atsOptimizeUndoAfter),
   );
+
+  const atsOptimizeSheetOpen = Boolean(atsOptimizePreview);
+  const atsOptimizeToastOpen = Boolean(atsOptimizeMessage || atsOptimizeUndoVisible);
+
+  useLayoutEffect(() => {
+    if (!atsOptimizeSheetOpen && !atsOptimizeToastOpen) return undefined;
+    updateAtsOptimizePanelPos();
+    const onReposition = () => updateAtsOptimizePanelPos();
+    window.addEventListener('resize', onReposition);
+    window.addEventListener('scroll', onReposition, true);
+    return () => {
+      window.removeEventListener('resize', onReposition);
+      window.removeEventListener('scroll', onReposition, true);
+    };
+  }, [atsOptimizeSheetOpen, atsOptimizeToastOpen, updateAtsOptimizePanelPos]);
 
   useEffect(() => {
     if (!atsOptimizeMessage || atsOptimizeUndoVisible) return undefined;
@@ -1724,65 +1753,6 @@ function CvEditorBeta({
             >
               {atsOptimizePreviewLoading ? 'Analyse ATS…' : 'Optimiser ATS'}
             </button>
-            {atsOptimizePreview && (
-              <div
-                className="cv-editor-beta-ats-preview"
-                role="dialog"
-                aria-modal="true"
-                aria-label="Aperçu optimisation ATS"
-              >
-                <div className="cv-editor-beta-ats-preview__header">
-                  <strong>Optimiser ATS</strong>
-                  <button
-                    type="button"
-                    className="cv-editor-beta-ats-preview__close"
-                    onClick={handleCancelAtsOptimizePreview}
-                    aria-label="Fermer l’aperçu"
-                  >
-                    ✕
-                  </button>
-                </div>
-                <p className="cv-editor-beta-ats-preview__impact" role="status">
-                  {atsOptimizePreviewLoading && 'Calcul de l’impact score…'}
-                  {!atsOptimizePreviewLoading && atsOptimizePreview.error && atsOptimizePreview.error}
-                  {!atsOptimizePreviewLoading && !atsOptimizePreview.error && (
-                    formatAtsScoreImpact(
-                      atsOptimizePreview.beforeScore,
-                      atsOptimizePreview.afterScore,
-                    )
-                  )}
-                </p>
-                {atsOptimizePreview.changes?.length > 0 ? (
-                  <ul className="cv-editor-beta-ats-preview__changes">
-                    {atsOptimizePreview.changes.slice(0, 5).map((change) => (
-                      <li key={change.id}>{change.label}</li>
-                    ))}
-                    {atsOptimizePreview.changes.length > 5 && (
-                      <li>+ {atsOptimizePreview.changes.length - 5} autre(s)</li>
-                    )}
-                  </ul>
-                ) : (
-                  <p className="cv-editor-beta-ats-preview__empty">Aucun déplacement détecté.</p>
-                )}
-                <div className="cv-editor-beta-ats-preview__actions">
-                  <button
-                    type="button"
-                    className="cv-editor-beta-ats-preview__btn"
-                    onClick={handleCancelAtsOptimizePreview}
-                  >
-                    Annuler
-                  </button>
-                  <button
-                    type="button"
-                    className="cv-editor-beta-ats-preview__btn cv-editor-beta-ats-preview__btn--primary"
-                    onClick={handleApplyAtsOptimizePreview}
-                    disabled={atsOptimizePreviewLoading}
-                  >
-                    Appliquer
-                  </button>
-                </div>
-              </div>
-            )}
           </div>
           <button
             type="button"
@@ -1813,20 +1783,105 @@ function CvEditorBeta({
           Survole le badge « PDF » sur le canvas pour le détail.
         </div>
       )}
-      {(atsOptimizeMessage || atsOptimizeUndoVisible) && (
-        <div className="cv-editor-beta-info cv-editor-beta-ats-toast" role="status">
-          <span>{atsOptimizeMessage || 'Réorganisation spatiale ATS appliquée.'}</span>
-          {atsOptimizeUndoVisible && (
+
+      {atsOptimizePreview
+        && createPortal(
+          <>
             <button
               type="button"
-              className="cv-editor-beta-ats-toast__undo"
-              onClick={handleUndoAtsOptimize}
+              className="cv-editor-beta-ats-preview-backdrop"
+              aria-label="Fermer l’aperçu ATS"
+              onClick={handleCancelAtsOptimizePreview}
+            />
+            <div
+              ref={atsOptimizePanelRef}
+              className="cv-editor-beta-ats-preview"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Aperçu optimisation ATS"
+              style={{
+                top: `${atsOptimizePanelPos.top}px`,
+                right: `${atsOptimizePanelPos.right}px`,
+              }}
             >
-              Annuler
-            </button>
-          )}
-        </div>
-      )}
+              <div className="cv-editor-beta-ats-preview__header">
+                <strong>Optimiser ATS</strong>
+                <button
+                  type="button"
+                  className="cv-editor-beta-ats-preview__close"
+                  onClick={handleCancelAtsOptimizePreview}
+                  aria-label="Fermer l’aperçu"
+                >
+                  ✕
+                </button>
+              </div>
+              <p className="cv-editor-beta-ats-preview__impact" role="status">
+                {atsOptimizePreviewLoading && 'Calcul de l’impact score…'}
+                {!atsOptimizePreviewLoading && atsOptimizePreview.error && atsOptimizePreview.error}
+                {!atsOptimizePreviewLoading && !atsOptimizePreview.error && (
+                  formatAtsScoreImpact(
+                    atsOptimizePreview.beforeScore,
+                    atsOptimizePreview.afterScore,
+                  )
+                )}
+              </p>
+              {atsOptimizePreview.changes?.length > 0 ? (
+                <ul className="cv-editor-beta-ats-preview__changes">
+                  {atsOptimizePreview.changes.slice(0, 5).map((change) => (
+                    <li key={change.id}>{change.label}</li>
+                  ))}
+                  {atsOptimizePreview.changes.length > 5 && (
+                    <li>+ {atsOptimizePreview.changes.length - 5} autre(s)</li>
+                  )}
+                </ul>
+              ) : (
+                <p className="cv-editor-beta-ats-preview__empty">Aucun déplacement détecté.</p>
+              )}
+              <div className="cv-editor-beta-ats-preview__actions">
+                <button
+                  type="button"
+                  className="cv-editor-beta-ats-preview__btn"
+                  onClick={handleCancelAtsOptimizePreview}
+                >
+                  Annuler
+                </button>
+                <button
+                  type="button"
+                  className="cv-editor-beta-ats-preview__btn cv-editor-beta-ats-preview__btn--primary"
+                  onClick={handleApplyAtsOptimizePreview}
+                  disabled={atsOptimizePreviewLoading}
+                >
+                  Appliquer
+                </button>
+              </div>
+            </div>
+          </>,
+          document.body,
+        )}
+
+      {(atsOptimizeMessage || atsOptimizeUndoVisible)
+        && createPortal(
+          <div
+            className="cv-editor-beta-ats-toast"
+            role="status"
+            style={{
+              top: `${atsOptimizePanelPos.top}px`,
+              right: `${atsOptimizePanelPos.right}px`,
+            }}
+          >
+            <span>{atsOptimizeMessage || 'Réorganisation spatiale ATS appliquée.'}</span>
+            {atsOptimizeUndoVisible && (
+              <button
+                type="button"
+                className="cv-editor-beta-ats-toast__undo"
+                onClick={handleUndoAtsOptimize}
+              >
+                Annuler
+              </button>
+            )}
+          </div>,
+          document.body,
+        )}
 
       <div className="cv-editor-beta-subchrome">
         {editHintOpen && selectedBlock && blockSupportsEditHint(selectedBlock) && (

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -200,6 +200,7 @@ function CvEditorBeta({
   /** Layout post-apply : Annuler n'est visible que tant que le canvas === ce snapshot. */
   const [atsOptimizeUndoAfter, setAtsOptimizeUndoAfter] = useState(null);
   const atsOptimizePreviewReqRef = useRef(0);
+  const atsOptimizeWrapRef = useRef(null);
   const autoHeightPendingRef = useRef(new Map());
   const autoHeightTimerRef = useRef(null);
   const suppressAutoHeightUntilRef = useRef(0);
@@ -1355,6 +1356,28 @@ function CvEditorBeta({
     setAtsOptimizePreviewLoading(false);
   }, []);
 
+  useEffect(() => {
+    if (!atsOptimizePreview) return undefined;
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        handleCancelAtsOptimizePreview();
+      }
+    };
+    const onPointerDown = (event) => {
+      const root = atsOptimizeWrapRef.current;
+      if (root && !root.contains(event.target)) {
+        handleCancelAtsOptimizePreview();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    document.addEventListener('mousedown', onPointerDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('mousedown', onPointerDown);
+    };
+  }, [atsOptimizePreview, handleCancelAtsOptimizePreview]);
+
   const handleApplyAtsOptimizePreview = useCallback(() => {
     if (!atsOptimizePreview?.afterLayout || !atsOptimizePreview?.beforeLayout) return;
     if (!sameLayout(layout, atsOptimizePreview.beforeLayout)) {
@@ -1689,15 +1712,78 @@ function CvEditorBeta({
               if (cv) autoSave.schedule(cv);
             }}
           />
-          <button
-            type="button"
-            className="cv-editor-beta-history-btn"
-            onClick={handleOptimizeAtsLayout}
-            disabled={loading || !layout || atsOptimizePreviewLoading}
-            title="Réorganiser spatialement les blocs pour la lecture ATS (aperçu avant application)"
-          >
-            {atsOptimizePreviewLoading ? 'Analyse ATS…' : 'Optimiser ATS'}
-          </button>
+          <div className="cv-editor-beta-ats-optimize-wrap" ref={atsOptimizeWrapRef}>
+            <button
+              type="button"
+              className="cv-editor-beta-history-btn"
+              onClick={handleOptimizeAtsLayout}
+              disabled={loading || !layout || atsOptimizePreviewLoading}
+              aria-expanded={Boolean(atsOptimizePreview)}
+              aria-haspopup="dialog"
+              title="Réorganiser spatialement les blocs pour la lecture ATS (aperçu avant application)"
+            >
+              {atsOptimizePreviewLoading ? 'Analyse ATS…' : 'Optimiser ATS'}
+            </button>
+            {atsOptimizePreview && (
+              <div
+                className="cv-editor-beta-ats-preview"
+                role="dialog"
+                aria-modal="true"
+                aria-label="Aperçu optimisation ATS"
+              >
+                <div className="cv-editor-beta-ats-preview__header">
+                  <strong>Optimiser ATS</strong>
+                  <button
+                    type="button"
+                    className="cv-editor-beta-ats-preview__close"
+                    onClick={handleCancelAtsOptimizePreview}
+                    aria-label="Fermer l’aperçu"
+                  >
+                    ✕
+                  </button>
+                </div>
+                <p className="cv-editor-beta-ats-preview__impact" role="status">
+                  {atsOptimizePreviewLoading && 'Calcul de l’impact score…'}
+                  {!atsOptimizePreviewLoading && atsOptimizePreview.error && atsOptimizePreview.error}
+                  {!atsOptimizePreviewLoading && !atsOptimizePreview.error && (
+                    formatAtsScoreImpact(
+                      atsOptimizePreview.beforeScore,
+                      atsOptimizePreview.afterScore,
+                    )
+                  )}
+                </p>
+                {atsOptimizePreview.changes?.length > 0 ? (
+                  <ul className="cv-editor-beta-ats-preview__changes">
+                    {atsOptimizePreview.changes.slice(0, 5).map((change) => (
+                      <li key={change.id}>{change.label}</li>
+                    ))}
+                    {atsOptimizePreview.changes.length > 5 && (
+                      <li>+ {atsOptimizePreview.changes.length - 5} autre(s)</li>
+                    )}
+                  </ul>
+                ) : (
+                  <p className="cv-editor-beta-ats-preview__empty">Aucun déplacement détecté.</p>
+                )}
+                <div className="cv-editor-beta-ats-preview__actions">
+                  <button
+                    type="button"
+                    className="cv-editor-beta-ats-preview__btn"
+                    onClick={handleCancelAtsOptimizePreview}
+                  >
+                    Annuler
+                  </button>
+                  <button
+                    type="button"
+                    className="cv-editor-beta-ats-preview__btn cv-editor-beta-ats-preview__btn--primary"
+                    onClick={handleApplyAtsOptimizePreview}
+                    disabled={atsOptimizePreviewLoading}
+                  >
+                    Appliquer
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
           <button
             type="button"
             className="cv-editor-beta-history-btn"
@@ -1725,60 +1811,6 @@ function CvEditorBeta({
           Certains blocs ne seront pas exportés à l&apos;identique dans le PDF
           {pdfFidelitySummary ? ` (${pdfFidelitySummary})` : ''}.
           Survole le badge « PDF » sur le canvas pour le détail.
-        </div>
-      )}
-      {atsOptimizePreview && (
-        <div className="cv-editor-beta-ats-preview" role="dialog" aria-label="Aperçu optimisation ATS">
-          <div className="cv-editor-beta-ats-preview__header">
-            <strong>Aperçu — réorganisation spatiale ATS</strong>
-            <button
-              type="button"
-              className="cv-editor-beta-ats-preview__close"
-              onClick={handleCancelAtsOptimizePreview}
-              aria-label="Fermer l’aperçu"
-            >
-              ✕
-            </button>
-          </div>
-          <p className="cv-editor-beta-ats-preview__impact" role="status">
-            {atsOptimizePreviewLoading && 'Calcul de l’impact score…'}
-            {!atsOptimizePreviewLoading && atsOptimizePreview.error && atsOptimizePreview.error}
-            {!atsOptimizePreviewLoading && !atsOptimizePreview.error && (
-              formatAtsScoreImpact(
-                atsOptimizePreview.beforeScore,
-                atsOptimizePreview.afterScore,
-              )
-            )}
-          </p>
-          {atsOptimizePreview.changes?.length > 0 ? (
-            <ul className="cv-editor-beta-ats-preview__changes">
-              {atsOptimizePreview.changes.slice(0, 8).map((change) => (
-                <li key={change.id}>{change.label}</li>
-              ))}
-              {atsOptimizePreview.changes.length > 8 && (
-                <li>+ {atsOptimizePreview.changes.length - 8} autre(s) déplacement(s)</li>
-              )}
-            </ul>
-          ) : (
-            <p className="cv-editor-beta-ats-preview__empty">Aucun déplacement détecté.</p>
-          )}
-          <div className="cv-editor-beta-ats-preview__actions">
-            <button
-              type="button"
-              className="cv-editor-beta-ats-preview__btn"
-              onClick={handleCancelAtsOptimizePreview}
-            >
-              Annuler
-            </button>
-            <button
-              type="button"
-              className="cv-editor-beta-ats-preview__btn cv-editor-beta-ats-preview__btn--primary"
-              onClick={handleApplyAtsOptimizePreview}
-              disabled={atsOptimizePreviewLoading}
-            >
-              Appliquer
-            </button>
-          </div>
         </div>
       )}
       {(atsOptimizeMessage || atsOptimizeUndoVisible) && (

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -1378,20 +1378,12 @@ function CvEditorBeta({
       event.stopPropagation();
       handleCancelAtsOptimizePreview();
     };
-    const onPointerDown = (event) => {
-      const wrap = atsOptimizeWrapRef.current;
-      const panel = atsOptimizePanelRef.current;
-      const target = event.target;
-      if (wrap?.contains(target) || panel?.contains(target)) return;
-      // Capture + pointerdown : le canvas fait preventDefault sur pointerdown,
-      // ce qui empêche mousedown d’arriver (Bugbot PR #106).
-      handleCancelAtsOptimizePreview();
-    };
+    // Pas de dismiss document-level en pointerdown : ça démonte le backdrop
+    // avant le click et laisse le click « passer » sur Télécharger / etc. (Bugbot).
+    // Le backdrop plein écran ferme au click ; Esc reste ici.
     document.addEventListener('keydown', onKeyDown, true);
-    document.addEventListener('pointerdown', onPointerDown, true);
     return () => {
       document.removeEventListener('keydown', onKeyDown, true);
-      document.removeEventListener('pointerdown', onPointerDown, true);
     };
   }, [atsOptimizePreview, handleCancelAtsOptimizePreview]);
 

--- a/frontend/src/styles/CvEditorBeta.css
+++ b/frontend/src/styles/CvEditorBeta.css
@@ -301,40 +301,30 @@
   font-weight: 500;
 }
 
-.cv-editor-beta-ats-toast {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-}
-
-.cv-editor-beta-ats-toast__undo {
-  border: none;
-  background: transparent;
-  color: var(--color-action-blue);
-  font-weight: 500;
-  font-size: 0.82rem;
-  text-decoration: underline;
-  cursor: pointer;
-  font-family: inherit;
-  padding: 0;
-  flex-shrink: 0;
-}
-
-/* AXE-331 — Optimiser ATS : popover compact ancré au bouton (pas bannière pleine largeur). */
+/* AXE-331 — Optimiser ATS : sheet flottant (portal fixed), jamais bande pleine largeur. */
 .cv-editor-beta-ats-optimize-wrap {
   position: relative;
   display: inline-flex;
   align-items: center;
 }
 
+.cv-editor-beta-ats-preview-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1090;
+  border: none;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  cursor: default;
+}
+
 .cv-editor-beta-ats-preview {
-  position: absolute;
-  top: calc(100% + 0.4rem);
-  right: 0;
-  z-index: 60;
-  width: 320px;
-  max-width: min(320px, calc(100vw - 1.5rem));
+  position: fixed;
+  z-index: 1100;
+  box-sizing: border-box;
+  width: 300px;
+  max-width: calc(100vw - 24px);
   background: var(--color-canvas);
   border: 1px solid var(--color-hairline);
   border-radius: 8px;
@@ -415,6 +405,39 @@
 .cv-editor-beta-ats-preview__btn:disabled {
   opacity: 0.55;
   cursor: wait;
+}
+
+.cv-editor-beta-ats-toast {
+  position: fixed;
+  z-index: 1100;
+  box-sizing: border-box;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.65rem;
+  width: 300px;
+  max-width: calc(100vw - 24px);
+  padding: 0.65rem 0.8rem;
+  background: var(--color-pale-blue);
+  color: var(--color-action-blue);
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  font-size: 0.78rem;
+  font-weight: 500;
+  line-height: 1.35;
+}
+
+.cv-editor-beta-ats-toast__undo {
+  border: none;
+  background: transparent;
+  color: var(--color-action-blue);
+  font-weight: 500;
+  font-size: 0.78rem;
+  text-decoration: underline;
+  cursor: pointer;
+  font-family: inherit;
+  padding: 0;
+  flex-shrink: 0;
 }
 
 .cv-editor-beta-pdf-fidelity {

--- a/frontend/src/styles/CvEditorBeta.css
+++ b/frontend/src/styles/CvEditorBeta.css
@@ -363,6 +363,10 @@
   line-height: 1.35;
 }
 
+.cv-editor-beta-ats-preview__impact--error {
+  color: var(--color-error);
+}
+
 .cv-editor-beta-ats-preview__changes {
   margin: 0 0 0.65rem;
   padding-left: 1.05rem;

--- a/frontend/src/styles/CvEditorBeta.css
+++ b/frontend/src/styles/CvEditorBeta.css
@@ -321,10 +321,25 @@
   flex-shrink: 0;
 }
 
+/* AXE-331 — Optimiser ATS : popover compact ancré au bouton (pas bannière pleine largeur). */
+.cv-editor-beta-ats-optimize-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
 .cv-editor-beta-ats-preview {
-  border-bottom: 1px solid var(--color-hairline);
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  right: 0;
+  z-index: 60;
+  width: 320px;
+  max-width: min(320px, calc(100vw - 1.5rem));
   background: var(--color-canvas);
-  padding: 0.75rem 1rem 0.85rem;
+  border: 1px solid var(--color-hairline);
+  border-radius: 8px;
+  padding: 0.7rem 0.8rem 0.8rem;
+  color: var(--color-ink);
 }
 
 .cv-editor-beta-ats-preview__header {
@@ -333,6 +348,11 @@
   align-items: center;
   gap: 0.5rem;
   margin-bottom: 0.35rem;
+}
+
+.cv-editor-beta-ats-preview__header strong {
+  font-size: 0.82rem;
+  font-weight: 500;
 }
 
 .cv-editor-beta-ats-preview__close {
@@ -347,31 +367,32 @@
 
 .cv-editor-beta-ats-preview__impact {
   margin: 0 0 0.45rem;
-  font-size: 0.82rem;
+  font-size: 0.78rem;
   color: var(--color-deep-green);
   font-weight: 500;
+  line-height: 1.35;
 }
 
 .cv-editor-beta-ats-preview__changes {
   margin: 0 0 0.65rem;
-  padding-left: 1.1rem;
-  font-size: 0.78rem;
+  padding-left: 1.05rem;
+  font-size: 0.74rem;
   color: var(--color-body-muted);
   line-height: 1.4;
-  max-height: 7.5rem;
+  max-height: 5.5rem;
   overflow-y: auto;
 }
 
 .cv-editor-beta-ats-preview__empty {
   margin: 0 0 0.65rem;
-  font-size: 0.78rem;
+  font-size: 0.74rem;
   color: var(--color-muted);
 }
 
 .cv-editor-beta-ats-preview__actions {
   display: flex;
   justify-content: flex-end;
-  gap: 0.5rem;
+  gap: 0.45rem;
 }
 
 .cv-editor-beta-ats-preview__btn {
@@ -379,8 +400,8 @@
   background: transparent;
   color: var(--color-primary);
   border-radius: 30px;
-  padding: 0.35rem 0.9rem;
-  font-size: 0.78rem;
+  padding: 0.32rem 0.85rem;
+  font-size: 0.74rem;
   font-weight: 500;
   cursor: pointer;
   font-family: inherit;


### PR DESCRIPTION
## Summary
- Remplace la bannière pleine largeur « Optimiser ATS » par un **popover compact** ancré au bouton (~320px).
- Fermeture : ✕, Annuler, **Esc**, clic hors panneau.
- Logique spatiale inchangée (`atsLayoutOptimize.js`) ; toast undo inchangé.

## Linear
Fixes AXE-331

## GitHub issue
Closes #105

## Test plan
- [ ] Ouvrir Beta éditeur avec un layout non ATS-optimal → **Optimiser ATS**
- [ ] Vérifier popover sous le bouton (pas de bande pleine largeur)
- [ ] Esc / clic extérieur / ✕ ferment le popover
- [ ] Appliquer → layout change + toast Annuler fonctionne
- [ ] Cas déjà optimisé → message inline, pas de popover vide


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout d’un aperçu ATS compact et accessible, affiché sous le bouton « Optimiser ATS ».
  * L’aperçu se ferme automatiquement avec la touche « Échap » ou en cliquant à l’extérieur.
  * Les cinq principaux changements sont affichés avant un résumé des éléments supplémentaires.

* **Améliorations visuelles**
  * Réduction des espacements, tailles de texte et dimensions des boutons pour une présentation plus compacte.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->