### PR TITLE
feat(AXE-340): composers guidés pour toutes les sections CV

### DIFF
--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -122,10 +122,15 @@ import EditorCanvaTransferModal from './EditorCanvaTransferModal.jsx';
 import EditorCvImportModal from './EditorCvImportModal.jsx';
 import EditorOnboardingTour from './EditorOnboardingTour.jsx';
 import HeaderComposerModal from './HeaderComposerModal.jsx';
+import SectionComposerModal from './SectionComposerModal.jsx';
 import {
   applyHeaderComposerToLayout,
   mergeHeaderComposerCv,
 } from '../../lib/headerComposerPresets.js';
+import {
+  applySectionComposerToLayout,
+  mergeSectionComposerCv,
+} from '../../lib/sectionComposerPresets.js';
 import '../../styles/HeaderComposerModal.css';
 
 import {
@@ -191,6 +196,7 @@ function CvEditorBeta({
   const [imageEditBlockId, setImageEditBlockId] = useState(null);
   const [sidebarSection, setSidebarSection] = useState('sections');
   const [headerComposerOpen, setHeaderComposerOpen] = useState(false);
+  const [sectionComposerType, setSectionComposerType] = useState(null);
   const [placementPreset, setPlacementPreset] = useState(null);
   const [startupPromptOpen, setStartupPromptOpen] = useState(false);
   const [onboardingDismissed, setOnboardingDismissed] = useState(() => isEditorOnboardingDismissed());
@@ -452,7 +458,14 @@ function CvEditorBeta({
 
   const handleOpenHeaderComposer = useCallback(() => {
     setSidebarSection('sections');
+    setSectionComposerType(null);
     setHeaderComposerOpen(true);
+  }, []);
+
+  const handleOpenSectionComposer = useCallback((type) => {
+    setSidebarSection('sections');
+    setHeaderComposerOpen(false);
+    setSectionComposerType(type || null);
   }, []);
 
   const handleHeaderComposerConfirm = useCallback((payload) => {
@@ -472,6 +485,30 @@ function CvEditorBeta({
       setImageEditBlockId(null);
     }
     setHeaderComposerOpen(false);
+    setStartupPromptOpen(false);
+  }, [layout, cv, handleCvChange, commitLayout, autoSave, profileLoadError]);
+
+  const handleSectionComposerConfirm = useCallback((payload) => {
+    if (!layout || !payload?.sectionType || profileLoadError) return;
+    const nextCv = mergeSectionComposerCv(payload.sectionType, cv, payload);
+    handleCvChange(nextCv);
+    const { layout: nextLayout, placedIds } = applySectionComposerToLayout(
+      layout,
+      0,
+      payload.sectionType,
+      {
+        variantId: payload.variantId,
+        fields: payload.fields,
+      },
+    );
+    commitLayout(nextLayout);
+    if (nextCv) autoSave.schedule({ ...nextCv, layout: nextLayout });
+    if (placedIds.length) {
+      setSelectedBlockIds(placedIds);
+      setEditingBlockId(null);
+      setImageEditBlockId(null);
+    }
+    setSectionComposerType(null);
     setStartupPromptOpen(false);
   }, [layout, cv, handleCvChange, commitLayout, autoSave, profileLoadError]);
 
@@ -1976,6 +2013,7 @@ function CvEditorBeta({
           onSnapEnabledChange={setCanvasSnapEnabled}
           onBeginPlacement={handleBeginPlacement}
           onOpenHeaderComposer={handleOpenHeaderComposer}
+          onOpenSectionComposer={handleOpenSectionComposer}
           onCancelPlacement={handleCancelPlacement}
           onSelectBlock={handleSelectBlock}
           onBlockPatch={handleBlockPatchById}
@@ -2178,6 +2216,14 @@ function CvEditorBeta({
         cv={cv}
         onConfirm={handleHeaderComposerConfirm}
         onCancel={() => setHeaderComposerOpen(false)}
+      />
+
+      <SectionComposerModal
+        open={Boolean(sectionComposerType)}
+        sectionType={sectionComposerType}
+        cv={cv}
+        onConfirm={handleSectionComposerConfirm}
+        onCancel={() => setSectionComposerType(null)}
       />
 
     </div>

--- a/frontend/src/components/editor/EditorCanvaSidebar.jsx
+++ b/frontend/src/components/editor/EditorCanvaSidebar.jsx
@@ -207,6 +207,7 @@ export default function EditorCanvaSidebar({
   onSnapEnabledChange,
   onBeginPlacement,
   onOpenHeaderComposer,
+  onOpenSectionComposer,
   onCancelPlacement,
   onSelectBlock,
   onBlockPatch,
@@ -399,6 +400,29 @@ export default function EditorCanvaSidebar({
                   Design + champs + inputs — puis free-edit
                 </span>
               </button>
+              <div className="editor-canva-composer-grid" role="group" aria-label="Composers de sections">
+                {[
+                  { type: 'contact', label: 'Contact' },
+                  { type: 'resume', label: 'Profil' },
+                  { type: 'experiences', label: 'Expériences' },
+                  { type: 'formations', label: 'Formations' },
+                  { type: 'skills', label: 'Compétences' },
+                  { type: 'languages', label: 'Langues' },
+                  { type: 'certifications', label: 'Certifications' },
+                  { type: 'projets', label: 'Projets' },
+                  { type: 'photo', label: 'Photo' },
+                ].map((item) => (
+                  <button
+                    key={item.type}
+                    type="button"
+                    className="editor-canva-composer-cta editor-canva-composer-cta--compact"
+                    disabled={disabled}
+                    onClick={() => onOpenSectionComposer?.(item.type)}
+                  >
+                    <span className="editor-canva-composer-cta__label">{item.label}</span>
+                  </button>
+                ))}
+              </div>
               <p className="editor-canva-drawer__hint editor-canva-drawer__hint--subtle">
                 Blocs individuels (avancé) — liés à ton CV de base.
               </p>

--- a/frontend/src/components/editor/SectionComposerModal.jsx
+++ b/frontend/src/components/editor/SectionComposerModal.jsx
@@ -1,0 +1,356 @@
+import { useEffect, useState } from 'react';
+
+import {
+  CONTACT_COMPOSER_FIELDS,
+  CONTACT_COMPOSER_FIELD_LABELS,
+  SECTION_COMPOSER_META,
+  SECTION_COMPOSER_VARIANTS,
+  canPlaceSectionComposer,
+  createEmptyComposerItem,
+  defaultSectionComposerState,
+  getListItemFields,
+  resolveSectionComposerVariant,
+} from '../../lib/sectionComposerPresets.js';
+import '../../styles/HeaderComposerModal.css';
+
+/**
+ * Composer guidé pour une section CV (AXE-340) — même UX que l’en-tête.
+ */
+export default function SectionComposerModal({
+  open,
+  sectionType = null,
+  cv = null,
+  confirming = false,
+  onConfirm,
+  onCancel,
+}) {
+  const meta = sectionType ? SECTION_COMPOSER_META[sectionType] : null;
+  const variants = sectionType ? (SECTION_COMPOSER_VARIANTS[sectionType] || []) : [];
+
+  const [variantId, setVariantId] = useState(variants[0]?.id || 'classic');
+  const [fields, setFields] = useState({});
+  const [values, setValues] = useState({});
+  const [text, setText] = useState('');
+  const [skillsText, setSkillsText] = useState('');
+  const [items, setItems] = useState([]);
+
+  useEffect(() => {
+    if (!open || !sectionType) return;
+    const initial = defaultSectionComposerState(sectionType, cv);
+    setVariantId(initial.variantId);
+    setFields(initial.fields || {});
+    setValues(initial.values || {});
+    setText(initial.text || '');
+    setSkillsText(initial.skillsText || '');
+    setItems(Array.isArray(initial.items) ? initial.items : []);
+  }, [open, sectionType, cv]);
+
+  if (!open || !sectionType || !meta) return null;
+
+  const state = { variantId, fields, values, text, skillsText, items };
+  const canPlace = canPlaceSectionComposer(sectionType, state);
+
+  const toggleField = (key) => {
+    setFields((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const setValue = (key, next) => {
+    setValues((prev) => ({ ...prev, [key]: next }));
+  };
+
+  const updateItem = (index, key, next) => {
+    setItems((prev) => prev.map((row, i) => (
+      i === index ? { ...row, [key]: next } : row
+    )));
+  };
+
+  const addItem = () => {
+    setItems((prev) => [...prev, createEmptyComposerItem(sectionType)]);
+  };
+
+  const removeItem = (index) => {
+    setItems((prev) => (prev.length <= 1 ? prev : prev.filter((_, i) => i !== index)));
+  };
+
+  const handleConfirm = () => {
+    if (!canPlace || confirming) return;
+    onConfirm?.({
+      sectionType,
+      variantId: resolveSectionComposerVariant(sectionType, variantId).id,
+      fields: { ...fields },
+      values: { ...values },
+      text,
+      skillsText,
+      items: items.map((row) => ({ ...row })),
+    });
+  };
+
+  const renderContactFields = () => (
+    <section className="header-composer-section" aria-label="Champs contact">
+      <h3 className="header-composer-section__title">Champs</h3>
+      <div className="header-composer-fields">
+        {CONTACT_COMPOSER_FIELDS.map((key) => {
+          const checked = Boolean(fields[key]);
+          const label = CONTACT_COMPOSER_FIELD_LABELS[key] || key;
+          return (
+            <div key={key} className="header-composer-field">
+              <label className="header-composer-field__check">
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={() => toggleField(key)}
+                  disabled={confirming}
+                />
+                <span>{label}</span>
+              </label>
+              {checked ? (
+                <input
+                  type="text"
+                  className="header-composer-field__input"
+                  value={values[key] || ''}
+                  onChange={(e) => setValue(key, e.target.value)}
+                  placeholder={label}
+                  disabled={confirming}
+                  autoComplete="off"
+                />
+              ) : (
+                <p className="header-composer-field__hint">
+                  Masqué sur le canvas — reste dans ton CV
+                </p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+
+  const renderText = () => (
+    <section className="header-composer-section" aria-label="Contenu">
+      <h3 className="header-composer-section__title">Contenu</h3>
+      <textarea
+        className="header-composer-field__input"
+        rows={5}
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="Quelques lignes sur ton parcours…"
+        disabled={confirming}
+        style={{ width: '100%', resize: 'vertical', minHeight: '6rem' }}
+      />
+    </section>
+  );
+
+  const renderSkills = () => (
+    <section className="header-composer-section" aria-label="Compétences">
+      <h3 className="header-composer-section__title">Compétences (une par ligne)</h3>
+      <textarea
+        className="header-composer-field__input"
+        rows={6}
+        value={skillsText}
+        onChange={(e) => setSkillsText(e.target.value)}
+        placeholder={'React\nTypeScript\nSQL'}
+        disabled={confirming}
+        style={{ width: '100%', resize: 'vertical', minHeight: '7rem' }}
+      />
+    </section>
+  );
+
+  const renderLanguages = () => (
+    <section className="header-composer-section" aria-label="Langues">
+      <h3 className="header-composer-section__title">Langues</h3>
+      <div className="header-composer-fields">
+        {items.map((row, index) => (
+          <div key={row.id || index} className="header-composer-field" style={{ gap: '0.45rem' }}>
+            <input
+              type="text"
+              className="header-composer-field__input"
+              value={row.langue || ''}
+              onChange={(e) => updateItem(index, 'langue', e.target.value)}
+              placeholder="Langue"
+              disabled={confirming}
+            />
+            <input
+              type="text"
+              className="header-composer-field__input"
+              value={row.niveau || ''}
+              onChange={(e) => updateItem(index, 'niveau', e.target.value)}
+              placeholder="Niveau"
+              disabled={confirming}
+            />
+            <button
+              type="button"
+              onClick={() => removeItem(index)}
+              disabled={confirming || items.length <= 1}
+            >
+              Retirer
+            </button>
+          </div>
+        ))}
+        <button type="button" onClick={addItem} disabled={confirming}>
+          Ajouter une langue
+        </button>
+      </div>
+    </section>
+  );
+
+  const renderList = () => {
+    const itemFields = getListItemFields(sectionType);
+    return (
+      <section className="header-composer-section" aria-label="Éléments">
+        <h3 className="header-composer-section__title">Éléments</h3>
+        <div className="header-composer-fields">
+          {items.map((row, index) => (
+            <div
+              key={row.id || index}
+              className="header-composer-field"
+              style={{
+                flexDirection: 'column',
+                alignItems: 'stretch',
+                gap: '0.4rem',
+                paddingBottom: '0.65rem',
+                borderBottom: '1px solid var(--color-hairline, #d9d9dd)',
+              }}
+            >
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: '0.5rem' }}>
+                <strong style={{ fontSize: '0.78rem', fontWeight: 500 }}>
+                  #{index + 1}
+                </strong>
+                <button
+                  type="button"
+                  onClick={() => removeItem(index)}
+                  disabled={confirming || items.length <= 1}
+                >
+                  Retirer
+                </button>
+              </div>
+              {itemFields.map((field) => (
+                field.multiline ? (
+                  <textarea
+                    key={field.key}
+                    className="header-composer-field__input"
+                    rows={3}
+                    value={row[field.key] || ''}
+                    onChange={(e) => updateItem(index, field.key, e.target.value)}
+                    placeholder={field.label}
+                    disabled={confirming}
+                    style={{ width: '100%', resize: 'vertical' }}
+                  />
+                ) : (
+                  <input
+                    key={field.key}
+                    type="text"
+                    className="header-composer-field__input"
+                    value={row[field.key] || ''}
+                    onChange={(e) => updateItem(index, field.key, e.target.value)}
+                    placeholder={field.label}
+                    disabled={confirming}
+                  />
+                )
+              ))}
+            </div>
+          ))}
+          <button type="button" onClick={addItem} disabled={confirming}>
+            Ajouter
+          </button>
+        </div>
+      </section>
+    );
+  };
+
+  const renderPhotoNote = () => (
+    <section className="header-composer-section" aria-label="Photo">
+      <p className="header-composer-field__hint" style={{ margin: 0 }}>
+        Le cadre est placé avec le style choisi. Ajoute ou change la photo ensuite
+        en cliquant le bloc sur le canvas (champ photo du CV).
+      </p>
+    </section>
+  );
+
+  return (
+    <div
+      className="header-composer-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="section-composer-title"
+      onClick={() => {
+        if (!confirming) onCancel?.();
+      }}
+    >
+      <div
+        className="header-composer-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="header-composer-head">
+          <div>
+            <span className="header-composer-eyebrow">Composer</span>
+            <h2 id="section-composer-title">{meta.title}</h2>
+            <p>{meta.hint}</p>
+          </div>
+          <button
+            type="button"
+            className="header-composer-close"
+            onClick={() => onCancel?.()}
+            aria-label="Fermer"
+            disabled={confirming}
+          >
+            ×
+          </button>
+        </header>
+
+        <section className="header-composer-section" aria-label="Design">
+          <h3 className="header-composer-section__title">Design</h3>
+          <div className="header-composer-variants" role="listbox" aria-label={`Variantes ${meta.label}`}>
+            {variants.map((variant) => {
+              const selected = variant.id === variantId;
+              return (
+                <button
+                  key={variant.id}
+                  type="button"
+                  role="option"
+                  aria-selected={selected}
+                  className={`header-composer-variant${selected ? ' is-selected' : ''}`}
+                  onClick={() => setVariantId(variant.id)}
+                  disabled={confirming}
+                >
+                  <span
+                    className={`header-composer-variant__preview header-composer-variant__preview--${variant.id}`}
+                    aria-hidden
+                  />
+                  <strong>{variant.label}</strong>
+                  <span>{variant.description}</span>
+                </button>
+              );
+            })}
+          </div>
+        </section>
+
+        {meta.kind === 'fields' && renderContactFields()}
+        {meta.kind === 'text' && renderText()}
+        {meta.kind === 'skills' && renderSkills()}
+        {meta.kind === 'languages' && renderLanguages()}
+        {meta.kind === 'list' && renderList()}
+        {meta.kind === 'photo' && renderPhotoNote()}
+
+        {!canPlace ? (
+          <p className="header-composer-warn" role="status">
+            Complète au moins un élément pour placer la section.
+          </p>
+        ) : null}
+
+        <footer className="header-composer-actions">
+          <button type="button" onClick={() => onCancel?.()} disabled={confirming}>
+            Annuler
+          </button>
+          <button
+            type="button"
+            className="header-composer-primary"
+            onClick={handleConfirm}
+            disabled={!canPlace || confirming}
+          >
+            {confirming ? 'Placement…' : `Placer — ${meta.label}`}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/editor/SectionComposerModal.jsx
+++ b/frontend/src/components/editor/SectionComposerModal.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import {
   CONTACT_COMPOSER_FIELDS,
@@ -33,17 +33,24 @@ export default function SectionComposerModal({
   const [text, setText] = useState('');
   const [skillsText, setSkillsText] = useState('');
   const [items, setItems] = useState([]);
+  const cvRef = useRef(cv);
 
   useEffect(() => {
+    cvRef.current = cv;
+  }, [cv]);
+
+  // Prefill uniquement à l’ouverture / changement de section — pas à chaque
+  // sync CV (sinon la saisie en cours est écrasée).
+  useEffect(() => {
     if (!open || !sectionType) return;
-    const initial = defaultSectionComposerState(sectionType, cv);
+    const initial = defaultSectionComposerState(sectionType, cvRef.current);
     setVariantId(initial.variantId);
     setFields(initial.fields || {});
     setValues(initial.values || {});
     setText(initial.text || '');
     setSkillsText(initial.skillsText || '');
     setItems(Array.isArray(initial.items) ? initial.items : []);
-  }, [open, sectionType, cv]);
+  }, [open, sectionType]);
 
   if (!open || !sectionType || !meta) return null;
 

--- a/frontend/src/lib/sectionComposerPresets.js
+++ b/frontend/src/lib/sectionComposerPresets.js
@@ -1,0 +1,540 @@
+/**
+ * Composers guidés pour sections CV hors en-tête (AXE-340).
+ * Pattern : design variants + prefill `cv` → place 1 instance → free-edit.
+ */
+
+import { syncCvDualKeys } from './cvDualKey.js';
+import { generateItemId, findSectionSchema } from './cvSectionOps.js';
+import {
+  PAGE_MARGIN_MM,
+  PAGE_USABLE_WIDTH_MM,
+  addBlockToPage,
+  listAllBlocks,
+  removeBlocks,
+} from './cvLayoutModelV3.js';
+
+const W = PAGE_USABLE_WIDTH_MM;
+
+/** @typedef {'contact'|'resume'|'experiences'|'formations'|'skills'|'languages'|'certifications'|'projets'|'photo'} SectionComposerType */
+
+/** @type {ReadonlyArray<SectionComposerType>} */
+export const SECTION_COMPOSER_TYPES = Object.freeze([
+  'contact',
+  'resume',
+  'experiences',
+  'formations',
+  'skills',
+  'languages',
+  'certifications',
+  'projets',
+  'photo',
+]);
+
+export const SECTION_COMPOSER_META = Object.freeze({
+  contact: {
+    label: 'Contact',
+    title: 'Bloc contact',
+    hint: 'Email, téléphone, LinkedIn — design + champs, puis free-edit.',
+    kind: 'fields',
+  },
+  resume: {
+    label: 'Profil',
+    title: 'Profil / accroche',
+    hint: 'Rédige ton résumé, choisis un style, place le bloc.',
+    kind: 'text',
+  },
+  experiences: {
+    label: 'Expériences',
+    title: 'Expériences professionnelles',
+    hint: 'Renseigne tes postes, choisis un format, place la section.',
+    kind: 'list',
+  },
+  formations: {
+    label: 'Formations',
+    title: 'Formations',
+    hint: 'Diplômes et établissements — design + contenu.',
+    kind: 'list',
+  },
+  skills: {
+    label: 'Compétences',
+    title: 'Compétences techniques',
+    hint: 'Une compétence par ligne — chips ou liste.',
+    kind: 'skills',
+  },
+  languages: {
+    label: 'Langues',
+    title: 'Langues',
+    hint: 'Langue + niveau — place la section.',
+    kind: 'languages',
+  },
+  certifications: {
+    label: 'Certifications',
+    title: 'Certifications',
+    hint: 'Nom, organisme, date.',
+    kind: 'list',
+  },
+  projets: {
+    label: 'Projets',
+    title: 'Projets',
+    hint: 'Nom et description des projets mis en avant.',
+    kind: 'list',
+  },
+  photo: {
+    label: 'Photo',
+    title: 'Photo de profil',
+    hint: 'Place le cadre photo (upload ensuite sur le canvas).',
+    kind: 'photo',
+  },
+});
+
+/** @type {ReadonlyArray<'email'|'telephone'|'linkedin'>} */
+export const CONTACT_COMPOSER_FIELDS = Object.freeze(['email', 'telephone', 'linkedin']);
+
+export const CONTACT_COMPOSER_FIELD_LABELS = Object.freeze({
+  email: 'Email',
+  telephone: 'Téléphone',
+  linkedin: 'LinkedIn',
+});
+
+const LIST_ITEM_FIELDS = Object.freeze({
+  experiences: Object.freeze([
+    { key: 'poste', label: 'Poste' },
+    { key: 'entreprise', label: 'Entreprise' },
+    { key: 'date_debut', label: 'Début' },
+    { key: 'date_fin', label: 'Fin' },
+    { key: 'lieu', label: 'Lieu' },
+  ]),
+  formations: Object.freeze([
+    { key: 'diplome', label: 'Diplôme' },
+    { key: 'etablissement', label: 'Établissement' },
+    { key: 'date', label: 'Date' },
+  ]),
+  certifications: Object.freeze([
+    { key: 'nom', label: 'Nom' },
+    { key: 'organisme', label: 'Organisme' },
+    { key: 'date', label: 'Date' },
+  ]),
+  projets: Object.freeze([
+    { key: 'nom', label: 'Nom' },
+    { key: 'description', label: 'Description', multiline: true },
+  ]),
+});
+
+/** @type {Record<SectionComposerType, ReadonlyArray<{ id: string, label: string, description: string }>>} */
+export const SECTION_COMPOSER_VARIANTS = Object.freeze({
+  contact: Object.freeze([
+    { id: 'stacked', label: 'Empilé', description: 'Lignes contact classiques' },
+    { id: 'header_bar', label: 'Barre', description: 'Bandeau horizontal + icônes' },
+  ]),
+  resume: Object.freeze([
+    { id: 'classic', label: 'Classique', description: 'Titre + paragraphe' },
+    { id: 'italic', label: 'Italique', description: 'Accroche en italique' },
+  ]),
+  experiences: Object.freeze([
+    { id: 'compact', label: 'Compact', description: 'Format dense ATS-friendly' },
+    { id: 'detailed', label: 'Détaillé', description: 'Plus d’air, labels nets' },
+  ]),
+  formations: Object.freeze([
+    { id: 'classic', label: 'Classique', description: 'Liste standard' },
+    { id: 'compact', label: 'Compact', description: 'Hauteur réduite' },
+  ]),
+  skills: Object.freeze([
+    { id: 'chips', label: 'Chips', description: 'Puces / tags' },
+    { id: 'list', label: 'Liste', description: 'Une ligne par compétence' },
+  ]),
+  languages: Object.freeze([
+    { id: 'classic', label: 'Classique', description: 'Langue — niveau' },
+    { id: 'compact', label: 'Compact', description: 'Bloc court' },
+  ]),
+  certifications: Object.freeze([
+    { id: 'list', label: 'Liste', description: 'Lignes verticales' },
+    { id: 'classic', label: 'Classique', description: 'Format standard' },
+  ]),
+  projets: Object.freeze([
+    { id: 'classic', label: 'Classique', description: 'Nom + description' },
+    { id: 'compact', label: 'Compact', description: 'Hauteur réduite' },
+  ]),
+  photo: Object.freeze([
+    { id: 'circle', label: 'Ronde', description: 'Cadre circulaire' },
+    { id: 'square', label: 'Carrée', description: 'Cadre carré' },
+  ]),
+});
+
+/**
+ * @param {SectionComposerType} type
+ * @param {string} variantId
+ */
+export function resolveSectionComposerVariant(type, variantId) {
+  const list = SECTION_COMPOSER_VARIANTS[type] || [];
+  return list.find((v) => v.id === variantId) || list[0] || { id: 'classic', label: 'Classique', description: '' };
+}
+
+/**
+ * @param {SectionComposerType} type
+ */
+export function getListItemFields(type) {
+  return LIST_ITEM_FIELDS[type] || [];
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string[]}
+ */
+function asStringList(value) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => {
+      if (typeof item === 'string') return item.trim();
+      if (item && typeof item === 'object') {
+        return String(item.name || item.label || item.value || item.text || '').trim();
+      }
+      return '';
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Prefill state for a section composer.
+ * @param {SectionComposerType} type
+ * @param {object|null|undefined} cv
+ */
+export function defaultSectionComposerState(type, cv) {
+  const variantId = (SECTION_COMPOSER_VARIANTS[type] || [])[0]?.id || 'classic';
+
+  if (type === 'contact') {
+    const values = {
+      email: String(cv?.email || '').trim(),
+      telephone: String(cv?.telephone || '').trim(),
+      linkedin: String(cv?.linkedin || '').trim(),
+    };
+    const fields = {
+      email: Boolean(values.email),
+      telephone: Boolean(values.telephone),
+      linkedin: Boolean(values.linkedin),
+    };
+    if (!fields.email && !fields.telephone && !fields.linkedin) {
+      fields.email = true;
+    }
+    return { variantId, values, fields, items: [], skillsText: '', text: '' };
+  }
+
+  if (type === 'resume') {
+    return {
+      variantId,
+      text: String(cv?.resume || '').trim(),
+      values: {},
+      fields: {},
+      items: [],
+      skillsText: '',
+    };
+  }
+
+  if (type === 'skills') {
+    const skills = asStringList(cv?.competences?.techniques);
+    return {
+      variantId,
+      skillsText: skills.join('\n'),
+      text: '',
+      values: {},
+      fields: {},
+      items: [],
+    };
+  }
+
+  if (type === 'languages') {
+    const raw = Array.isArray(cv?.competences?.langues) ? cv.competences.langues : [];
+    const items = raw.length
+      ? raw.map((row) => ({
+        id: row?.id || generateItemId('lang'),
+        langue: String(row?.langue || '').trim(),
+        niveau: String(row?.niveau || '').trim(),
+      }))
+      : [{ id: generateItemId('lang'), langue: '', niveau: '' }];
+    return { variantId, items, text: '', values: {}, fields: {}, skillsText: '' };
+  }
+
+  if (type === 'photo') {
+    return { variantId, text: '', values: {}, fields: {}, items: [], skillsText: '' };
+  }
+
+  const schema = findSectionSchema(type);
+  const raw = Array.isArray(cv?.[type]) ? cv[type] : [];
+  const items = raw.length
+    ? raw.map((row) => ({ ...(row && typeof row === 'object' ? row : {}), id: row?.id || generateItemId(schema?.idPrefix || 'item') }))
+    : schema
+      ? [schema.createItem(generateItemId(schema.idPrefix))]
+      : [];
+
+  return { variantId, items, text: '', values: {}, fields: {}, skillsText: '' };
+}
+
+/**
+ * @param {SectionComposerType} type
+ * @param {object|null|undefined} cv
+ * @param {object} state
+ */
+export function mergeSectionComposerCv(type, cv, state) {
+  const next = cv && typeof cv === 'object' ? { ...cv } : {};
+
+  if (type === 'contact') {
+    for (const key of CONTACT_COMPOSER_FIELDS) {
+      if (!state?.fields?.[key]) continue;
+      next[key] = String(state?.values?.[key] ?? '').trim();
+    }
+    return syncCvDualKeys(next);
+  }
+
+  if (type === 'resume') {
+    next.resume = String(state?.text ?? '').trim();
+    return syncCvDualKeys(next);
+  }
+
+  if (type === 'skills') {
+    const lines = String(state?.skillsText || '')
+      .split(/\n+/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    next.competences = {
+      ...(next.competences && typeof next.competences === 'object' ? next.competences : {}),
+      techniques: lines.length ? lines : [''],
+    };
+    return syncCvDualKeys(next);
+  }
+
+  if (type === 'languages') {
+    const items = Array.isArray(state?.items) ? state.items : [];
+    next.competences = {
+      ...(next.competences && typeof next.competences === 'object' ? next.competences : {}),
+      langues: items.map((row) => ({
+        langue: String(row?.langue || '').trim(),
+        niveau: String(row?.niveau || '').trim(),
+      })),
+    };
+    return syncCvDualKeys(next);
+  }
+
+  if (type === 'photo') {
+    return syncCvDualKeys(next);
+  }
+
+  const schema = findSectionSchema(type);
+  if (!schema) return syncCvDualKeys(next);
+  const items = Array.isArray(state?.items) ? state.items : [];
+  next[type] = items.map((row) => {
+    const base = schema.createItem(row?.id || generateItemId(schema.idPrefix));
+    return { ...base, ...(row && typeof row === 'object' ? row : {}) };
+  });
+  return syncCvDualKeys(next);
+}
+
+/**
+ * @param {object|null|undefined} layout
+ * @param {string} blockType
+ */
+export function collectSectionBlockIds(layout, blockType) {
+  return listAllBlocks(layout)
+    .filter((b) => b?.type === blockType)
+    .map((b) => b.id)
+    .filter(Boolean);
+}
+
+/**
+ * @param {object|null|undefined} layout
+ * @param {string} blockType
+ * @param {number} fallbackH
+ */
+function resolvePlacementY(layout, blockType, fallbackH = 24) {
+  const existing = listAllBlocks(layout).filter((b) => b?.type === blockType);
+  if (existing.length) {
+    return Math.min(...existing.map((b) => (typeof b.y === 'number' ? b.y : PAGE_MARGIN_MM)));
+  }
+  const all = listAllBlocks(layout);
+  if (!all.length) return PAGE_MARGIN_MM;
+  const maxBottom = Math.max(
+    ...all.map((b) => (typeof b.y === 'number' ? b.y : 0) + (typeof b.h === 'number' ? b.h : fallbackH)),
+  );
+  return maxBottom + 4;
+}
+
+/**
+ * @param {SectionComposerType} type
+ * @param {{ variantId?: string, fields?: Record<string, boolean> }} options
+ */
+export function buildSectionComposerBlock(type, options = {}) {
+  const variant = resolveSectionComposerVariant(type, options.variantId);
+
+  if (type === 'contact') {
+    const bind = CONTACT_COMPOSER_FIELDS.filter((key) => options.fields?.[key]);
+    if (!bind.length) return null;
+    /** @type {Record<string, unknown>} */
+    const style = {
+      contact_icons: variant.id === 'header_bar',
+      contact_uppercase: false,
+      section_label: 'CONTACT',
+    };
+    if (variant.id === 'header_bar') {
+      style.contact_layout = 'header-bar';
+      style.contact_divider = true;
+    }
+    return {
+      type: 'contact',
+      bind: [...bind],
+      w: W,
+      h: variant.id === 'header_bar' ? 14 : 18,
+      style,
+    };
+  }
+
+  if (type === 'resume') {
+    return {
+      type: 'resume',
+      bind: 'resume',
+      w: W,
+      h: 28,
+      style: {
+        section_label: 'PROFIL',
+        font_style: variant.id === 'italic' ? 'italic' : undefined,
+        italic: variant.id === 'italic',
+      },
+    };
+  }
+
+  if (type === 'experiences') {
+    return {
+      type: 'experiences',
+      bind: 'experiences',
+      w: W,
+      h: variant.id === 'detailed' ? 96 : 80,
+      style: {
+        section_label: 'EXPÉRIENCE PROFESSIONNELLE',
+        format: 'compact',
+        exp_style: variant.id === 'detailed' ? 'bold' : undefined,
+      },
+    };
+  }
+
+  if (type === 'formations') {
+    return {
+      type: 'formations',
+      bind: 'formations',
+      w: W,
+      h: variant.id === 'compact' ? 24 : 30,
+      style: { section_label: 'FORMATION' },
+    };
+  }
+
+  if (type === 'skills') {
+    return {
+      type: 'skills',
+      bind: 'competences.techniques',
+      w: W,
+      h: 22,
+      style: {
+        section_label: 'COMPÉTENCES',
+        format: variant.id === 'list' ? 'list' : 'chips',
+        list_format: variant.id === 'list' ? 'list' : undefined,
+      },
+    };
+  }
+
+  if (type === 'languages') {
+    return {
+      type: 'languages',
+      bind: 'langues',
+      w: W,
+      h: variant.id === 'compact' ? 14 : 18,
+      style: { section_label: 'LANGUES' },
+    };
+  }
+
+  if (type === 'certifications') {
+    return {
+      type: 'certifications',
+      bind: 'certifications',
+      w: W,
+      h: 24,
+      style: {
+        section_label: 'CERTIFICATIONS',
+        list_format: variant.id === 'list' ? 'list' : undefined,
+      },
+    };
+  }
+
+  if (type === 'projets') {
+    return {
+      type: 'projets',
+      bind: 'projets',
+      w: W,
+      h: variant.id === 'compact' ? 22 : 28,
+      style: { section_label: 'PROJETS' },
+    };
+  }
+
+  if (type === 'photo') {
+    return {
+      type: 'photo',
+      w: 28,
+      h: 28,
+      style: { shape: variant.id === 'square' ? 'square' : 'circle' },
+    };
+  }
+
+  return null;
+}
+
+/**
+ * @param {SectionComposerType} type
+ * @param {object} state
+ */
+export function canPlaceSectionComposer(type, state) {
+  if (type === 'contact') {
+    return CONTACT_COMPOSER_FIELDS.some((key) => state?.fields?.[key]);
+  }
+  if (type === 'photo') return true;
+  if (type === 'resume') return true;
+  if (type === 'skills') return true;
+  if (type === 'languages') return Array.isArray(state?.items) && state.items.length > 0;
+  return Array.isArray(state?.items) && state.items.length > 0;
+}
+
+/**
+ * Remplace l’instance existante du type et place le nouveau bloc.
+ * @param {object} layout
+ * @param {number} pageIndex
+ * @param {SectionComposerType} type
+ * @param {{ variantId?: string, fields?: Record<string, boolean> }} options
+ */
+export function applySectionComposerToLayout(layout, pageIndex, type, options = {}) {
+  const partial = buildSectionComposerBlock(type, options);
+  let next = removeBlocks(layout, collectSectionBlockIds(layout, type));
+  const placedIds = [];
+  if (!partial) return { layout: next, placedIds };
+
+  const y = resolvePlacementY(next, type, partial.h || 24);
+  const safePage =
+    typeof pageIndex === 'number' && pageIndex >= 0 && pageIndex < (next?.pages?.length || 0)
+      ? pageIndex
+      : 0;
+
+  next = addBlockToPage(next, safePage, {
+    ...partial,
+    x: PAGE_MARGIN_MM,
+    y,
+  });
+  const page = next.pages?.[safePage];
+  const last = page?.blocks?.[page.blocks.length - 1];
+  if (last?.id) placedIds.push(last.id);
+  return { layout: next, placedIds };
+}
+
+/**
+ * @param {SectionComposerType} type
+ */
+export function createEmptyComposerItem(type) {
+  if (type === 'languages') {
+    return { id: generateItemId('lang'), langue: '', niveau: '' };
+  }
+  const schema = findSectionSchema(type);
+  if (!schema) return { id: generateItemId('item') };
+  return schema.createItem(generateItemId(schema.idPrefix));
+}

--- a/frontend/src/lib/sectionComposerPresets.js
+++ b/frontend/src/lib/sectionComposerPresets.js
@@ -147,8 +147,8 @@ export const SECTION_COMPOSER_VARIANTS = Object.freeze({
     { id: 'compact', label: 'Compact', description: 'Bloc court' },
   ]),
   certifications: Object.freeze([
-    { id: 'list', label: 'Liste', description: 'Lignes verticales' },
-    { id: 'classic', label: 'Classique', description: 'Format standard' },
+    { id: 'classic', label: 'Classique', description: 'Titre standard, bloc aéré' },
+    { id: 'underline', label: 'Souligné', description: 'Titre accent + hauteur compacte' },
   ]),
   projets: Object.freeze([
     { id: 'classic', label: 'Classique', description: 'Nom + description' },
@@ -341,13 +341,30 @@ export function collectSectionBlockIds(layout, blockType) {
 /**
  * @param {object|null|undefined} layout
  * @param {string} blockType
+ * @returns {{ pageIndex: number, x: number, y: number, w?: number }|null}
+ */
+function findExistingSectionPlacement(layout, blockType) {
+  if (!layout || !Array.isArray(layout.pages)) return null;
+  for (let pageIndex = 0; pageIndex < layout.pages.length; pageIndex += 1) {
+    const blocks = layout.pages[pageIndex]?.blocks || [];
+    for (const block of blocks) {
+      if (block?.type !== blockType) continue;
+      return {
+        pageIndex,
+        x: typeof block.x === 'number' ? block.x : PAGE_MARGIN_MM,
+        y: typeof block.y === 'number' ? block.y : PAGE_MARGIN_MM,
+        w: typeof block.w === 'number' ? block.w : undefined,
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * @param {object|null|undefined} layout
  * @param {number} fallbackH
  */
-function resolvePlacementY(layout, blockType, fallbackH = 24) {
-  const existing = listAllBlocks(layout).filter((b) => b?.type === blockType);
-  if (existing.length) {
-    return Math.min(...existing.map((b) => (typeof b.y === 'number' ? b.y : PAGE_MARGIN_MM)));
-  }
+function resolveAppendPlacementY(layout, fallbackH = 24) {
   const all = listAllBlocks(layout);
   if (!all.length) return PAGE_MARGIN_MM;
   const maxBottom = Math.max(
@@ -448,14 +465,15 @@ export function buildSectionComposerBlock(type, options = {}) {
   }
 
   if (type === 'certifications') {
+    const compact = variant.id === 'underline';
     return {
       type: 'certifications',
       bind: 'certifications',
       w: W,
-      h: 24,
+      h: compact ? 18 : 28,
       style: {
         section_label: 'CERTIFICATIONS',
-        list_format: variant.id === 'list' ? 'list' : undefined,
+        title_style: compact ? 'underline-accent' : 'classic-main',
       },
     };
   }
@@ -499,6 +517,7 @@ export function canPlaceSectionComposer(type, state) {
 
 /**
  * Remplace l’instance existante du type et place le nouveau bloc.
+ * Conserve x/y/page de l’instance précédente (1 instance, pas de jump).
  * @param {object} layout
  * @param {number} pageIndex
  * @param {SectionComposerType} type
@@ -506,20 +525,26 @@ export function canPlaceSectionComposer(type, state) {
  */
 export function applySectionComposerToLayout(layout, pageIndex, type, options = {}) {
   const partial = buildSectionComposerBlock(type, options);
-  let next = removeBlocks(layout, collectSectionBlockIds(layout, type));
   const placedIds = [];
-  if (!partial) return { layout: next, placedIds };
+  if (!partial) return { layout, placedIds };
 
-  const y = resolvePlacementY(next, type, partial.h || 24);
-  const safePage =
-    typeof pageIndex === 'number' && pageIndex >= 0 && pageIndex < (next?.pages?.length || 0)
-      ? pageIndex
-      : 0;
+  // Capturer la position AVANT remove — sinon resolvePlacementY ne voit plus le bloc.
+  const previous = findExistingSectionPlacement(layout, type);
+  let next = removeBlocks(layout, collectSectionBlockIds(layout, type));
+
+  const y = previous ? previous.y : resolveAppendPlacementY(next, partial.h || 24);
+  const x = previous ? previous.x : PAGE_MARGIN_MM;
+  const pageCount = next?.pages?.length || 0;
+  let safePage = previous ? previous.pageIndex : pageIndex;
+  if (typeof safePage !== 'number' || safePage < 0 || safePage >= pageCount) {
+    safePage = 0;
+  }
 
   next = addBlockToPage(next, safePage, {
     ...partial,
-    x: PAGE_MARGIN_MM,
+    x,
     y,
+    ...(typeof previous?.w === 'number' ? { w: previous.w } : {}),
   });
   const page = next.pages?.[safePage];
   const last = page?.blocks?.[page.blocks.length - 1];

--- a/frontend/src/lib/sectionComposerPresets.js
+++ b/frontend/src/lib/sectionComposerPresets.js
@@ -5,6 +5,7 @@
 
 import { syncCvDualKeys } from './cvDualKey.js';
 import { generateItemId, findSectionSchema } from './cvSectionOps.js';
+import { suggestNewBlockPlacement } from './freeCanvasBlockPresets.js';
 import {
   PAGE_MARGIN_MM,
   PAGE_USABLE_WIDTH_MM,
@@ -296,7 +297,7 @@ export function mergeSectionComposerCv(type, cv, state) {
       .filter(Boolean);
     next.competences = {
       ...(next.competences && typeof next.competences === 'object' ? next.competences : {}),
-      techniques: lines.length ? lines : [''],
+      techniques: lines,
     };
     return syncCvDualKeys(next);
   }
@@ -362,15 +363,13 @@ function findExistingSectionPlacement(layout, blockType) {
 
 /**
  * @param {object|null|undefined} layout
+ * @param {number} pageIndex
  * @param {number} fallbackH
  */
-function resolveAppendPlacementY(layout, fallbackH = 24) {
-  const all = listAllBlocks(layout);
-  if (!all.length) return PAGE_MARGIN_MM;
-  const maxBottom = Math.max(
-    ...all.map((b) => (typeof b.y === 'number' ? b.y : 0) + (typeof b.h === 'number' ? b.h : fallbackH)),
-  );
-  return maxBottom + 4;
+function resolveAppendPlacementY(layout, pageIndex, fallbackH = 24) {
+  // Coordonnées y sont par page — ne pas mélanger les pages (Bugbot).
+  const suggested = suggestNewBlockPlacement(layout, pageIndex, { w: W, h: fallbackH });
+  return typeof suggested?.y === 'number' ? suggested.y : PAGE_MARGIN_MM;
 }
 
 /**
@@ -532,13 +531,16 @@ export function applySectionComposerToLayout(layout, pageIndex, type, options = 
   const previous = findExistingSectionPlacement(layout, type);
   let next = removeBlocks(layout, collectSectionBlockIds(layout, type));
 
-  const y = previous ? previous.y : resolveAppendPlacementY(next, partial.h || 24);
-  const x = previous ? previous.x : PAGE_MARGIN_MM;
   const pageCount = next?.pages?.length || 0;
   let safePage = previous ? previous.pageIndex : pageIndex;
   if (typeof safePage !== 'number' || safePage < 0 || safePage >= pageCount) {
     safePage = 0;
   }
+
+  const y = previous
+    ? previous.y
+    : resolveAppendPlacementY(next, safePage, partial.h || 24);
+  const x = previous ? previous.x : PAGE_MARGIN_MM;
 
   next = addBlockToPage(next, safePage, {
     ...partial,

--- a/frontend/src/styles/EditorCanvaSidebar.css
+++ b/frontend/src/styles/EditorCanvaSidebar.css
@@ -183,6 +183,30 @@
   line-height: 1.35;
 }
 
+.editor-canva-composer-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  margin: 0 0 12px;
+}
+
+.editor-canva-composer-cta--compact {
+  margin: 0;
+  padding: 8px 10px;
+  border-color: var(--color-hairline, #d9d9dd);
+  background: var(--color-canvas, #fff);
+  color: var(--color-ink, #212121);
+}
+
+.editor-canva-composer-cta--compact:hover:not(:disabled) {
+  background: var(--color-soft-stone, #eeece7);
+  border-color: var(--color-primary, #17171c);
+}
+
+.editor-canva-composer-cta--compact .editor-canva-composer-cta__label {
+  font-size: 0.78rem;
+}
+
 .editor-canva-drawer__actions,
 .editor-canva-drawer__grid {
   display: flex;

--- a/frontend/tests/unit/sectionComposerPresets.test.js
+++ b/frontend/tests/unit/sectionComposerPresets.test.js
@@ -93,6 +93,41 @@ test('certifications variants differ in height and title_style', () => {
   assert.notEqual(classic.style.title_style, underline.style.title_style);
 });
 
+test('skills merge writes empty array when blank (not [""])', () => {
+  const next = mergeSectionComposerCv(
+    'skills',
+    { competences: { techniques: ['Old'], logiciels: ['Excel'] } },
+    { skillsText: '  \n  ' },
+  );
+  assert.deepEqual(next.competences.techniques, []);
+  assert.deepEqual(next.competences.logiciels, ['Excel']);
+});
+
+test('append placement uses only the target page y-coords', () => {
+  let layout = createBlankLayoutV3();
+  // Page 0 with a short block near the top.
+  layout = applySectionComposerToLayout(layout, 0, 'contact', {
+    variantId: 'stacked',
+    fields: { email: true, telephone: false, linkedin: false },
+  }).layout;
+  // Simulate content on page 2 with a high y (must not push page-0 append).
+  layout = {
+    ...layout,
+    pages: [
+      layout.pages[0],
+      { ...(layout.pages[0] || {}), blocks: [] },
+      {
+        ...(layout.pages[0] || {}),
+        blocks: [{ id: 'far', type: 'text', x: 10, y: 200, w: 40, h: 20, z: 1 }],
+      },
+    ],
+  };
+  const placed = applySectionComposerToLayout(layout, 0, 'resume', { variantId: 'classic' });
+  const resume = placed.layout.pages[0].blocks.find((b) => b.type === 'resume');
+  assert.ok(resume);
+  assert.ok(resume.y < 120, `expected page-0 append y, got ${resume.y}`);
+});
+
 test('canPlace requires at least one contact field', () => {
   assert.equal(canPlaceSectionComposer('contact', { fields: {} }), false);
   assert.equal(canPlaceSectionComposer('contact', { fields: { email: true } }), true);

--- a/frontend/tests/unit/sectionComposerPresets.test.js
+++ b/frontend/tests/unit/sectionComposerPresets.test.js
@@ -1,0 +1,100 @@
+/**
+ * Tests unitaires composers sections (AXE-340).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createBlankLayoutV3 } from '../../src/lib/cvLayoutModelV3.js';
+import {
+  SECTION_COMPOSER_TYPES,
+  SECTION_COMPOSER_VARIANTS,
+  applySectionComposerToLayout,
+  buildSectionComposerBlock,
+  canPlaceSectionComposer,
+  defaultSectionComposerState,
+  mergeSectionComposerCv,
+  resolveSectionComposerVariant,
+} from '../../src/lib/sectionComposerPresets.js';
+
+test('exposes all section composers with >= 2 variants', () => {
+  assert.ok(SECTION_COMPOSER_TYPES.includes('contact'));
+  assert.ok(SECTION_COMPOSER_TYPES.includes('experiences'));
+  for (const type of SECTION_COMPOSER_TYPES) {
+    assert.ok(
+      (SECTION_COMPOSER_VARIANTS[type] || []).length >= 2,
+      `${type} should have >= 2 variants`,
+    );
+    assert.equal(
+      resolveSectionComposerVariant(type, 'unknown').id,
+      SECTION_COMPOSER_VARIANTS[type][0].id,
+    );
+  }
+});
+
+test('contact: prefills and builds bind from checked fields', () => {
+  const state = defaultSectionComposerState('contact', {
+    email: 'a@b.c',
+    telephone: '',
+  });
+  assert.equal(state.values.email, 'a@b.c');
+  assert.equal(state.fields.email, true);
+  const block = buildSectionComposerBlock('contact', {
+    variantId: 'header_bar',
+    fields: { email: true, telephone: false, linkedin: false },
+  });
+  assert.equal(block.type, 'contact');
+  assert.deepEqual(block.bind, ['email']);
+  assert.equal(block.style.contact_layout, 'header-bar');
+});
+
+test('resume + skills merge into cv without wiping other fields', () => {
+  const withResume = mergeSectionComposerCv(
+    'resume',
+    { prenom: 'Ada', resume: 'old' },
+    { text: 'New pitch' },
+  );
+  assert.equal(withResume.prenom, 'Ada');
+  assert.equal(withResume.resume, 'New pitch');
+
+  const withSkills = mergeSectionComposerCv(
+    'skills',
+    { competences: { techniques: ['x'], logiciels: ['Excel'] } },
+    { skillsText: 'React\nSQL' },
+  );
+  assert.deepEqual(withSkills.competences.techniques, ['React', 'SQL']);
+  assert.deepEqual(withSkills.competences.logiciels, ['Excel']);
+});
+
+test('experiences: replaces existing block (one instance)', () => {
+  let layout = createBlankLayoutV3();
+  layout = applySectionComposerToLayout(layout, 0, 'experiences', { variantId: 'compact' }).layout;
+  const firstIds = layout.pages[0].blocks.filter((b) => b.type === 'experiences').map((b) => b.id);
+  assert.equal(firstIds.length, 1);
+
+  const second = applySectionComposerToLayout(layout, 0, 'experiences', { variantId: 'detailed' });
+  const nextIds = second.layout.pages[0].blocks.filter((b) => b.type === 'experiences').map((b) => b.id);
+  assert.equal(nextIds.length, 1);
+  assert.notEqual(nextIds[0], firstIds[0]);
+  assert.equal(second.placedIds[0], nextIds[0]);
+  assert.equal(
+    second.layout.pages[0].blocks.find((b) => b.id === nextIds[0]).style.exp_style,
+    'bold',
+  );
+});
+
+test('canPlace requires at least one contact field', () => {
+  assert.equal(canPlaceSectionComposer('contact', { fields: {} }), false);
+  assert.equal(canPlaceSectionComposer('contact', { fields: { email: true } }), true);
+  assert.equal(canPlaceSectionComposer('photo', {}), true);
+});
+
+test('languages merge writes competences.langues', () => {
+  const next = mergeSectionComposerCv(
+    'languages',
+    { competences: { techniques: ['Go'] } },
+    { items: [{ langue: 'Français', niveau: 'C2' }] },
+  );
+  assert.deepEqual(next.competences.langues, [{ langue: 'Français', niveau: 'C2' }]);
+  assert.deepEqual(next.competences.techniques, ['Go']);
+});

--- a/frontend/tests/unit/sectionComposerPresets.test.js
+++ b/frontend/tests/unit/sectionComposerPresets.test.js
@@ -69,18 +69,28 @@ test('resume + skills merge into cv without wiping other fields', () => {
 test('experiences: replaces existing block (one instance)', () => {
   let layout = createBlankLayoutV3();
   layout = applySectionComposerToLayout(layout, 0, 'experiences', { variantId: 'compact' }).layout;
-  const firstIds = layout.pages[0].blocks.filter((b) => b.type === 'experiences').map((b) => b.id);
-  assert.equal(firstIds.length, 1);
+  const first = layout.pages[0].blocks.find((b) => b.type === 'experiences');
+  assert.ok(first);
+  // Déplacer manuellement pour vérifier que le replace conserve x/y.
+  // x max = PAGE_WIDTH - w ; avec w pleine largeur, rester ≤ 20.
+  first.x = 15;
+  first.y = 64;
 
   const second = applySectionComposerToLayout(layout, 0, 'experiences', { variantId: 'detailed' });
-  const nextIds = second.layout.pages[0].blocks.filter((b) => b.type === 'experiences').map((b) => b.id);
-  assert.equal(nextIds.length, 1);
-  assert.notEqual(nextIds[0], firstIds[0]);
-  assert.equal(second.placedIds[0], nextIds[0]);
-  assert.equal(
-    second.layout.pages[0].blocks.find((b) => b.id === nextIds[0]).style.exp_style,
-    'bold',
-  );
+  const next = second.layout.pages[0].blocks.find((b) => b.type === 'experiences');
+  assert.ok(next);
+  assert.notEqual(next.id, first.id);
+  assert.equal(second.placedIds[0], next.id);
+  assert.equal(next.x, 15);
+  assert.equal(next.y, 64);
+  assert.equal(next.style.exp_style, 'bold');
+});
+
+test('certifications variants differ in height and title_style', () => {
+  const classic = buildSectionComposerBlock('certifications', { variantId: 'classic' });
+  const underline = buildSectionComposerBlock('certifications', { variantId: 'underline' });
+  assert.notEqual(classic.h, underline.h);
+  assert.notEqual(classic.style.title_style, underline.style.title_style);
 });
 
 test('canPlace requires at least one contact field', () => {


### PR DESCRIPTION
## Summary
- Ajoute un **composer guidé** (design + contenu + place) pour Contact, Profil, Expériences, Formations, Compétences, Langues, Certifications, Projets et Photo — même pattern que l’en-tête (AXE-334).
- Sidebar Contenu : grille de CTAs composers ; blocs individuels restent en secondaire.
- 1 instance par type ; prefill `cv` ; free-edit après placement.

## Linear
Fixes AXE-340

## GitHub issue
Closes #107

## Test plan
- [ ] Sidebar → Contenu : ouvrir chaque composer, placer, vérifier bind + free-edit
- [ ] Remplacer une section déjà placée (1 seule instance)
- [ ] Prefill depuis un CV rempli (expériences / skills / langues)
- [ ] En-tête (AXE-334) toujours OK
- [ ] `node --test tests/unit/sectionComposerPresets.test.js`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - Ajout d’un compositeur guidé pour créer et personnaliser les sections du CV.
  - Création facilitée des sections Contact, Profil, Expériences, Formations, Compétences, Langues, Certifications, Projets et Photo.
  - Choix de variantes visuelles, saisie des informations et gestion des éléments de liste.
  - Prévisualisation et placement des sections directement dans l’éditeur Canva.
  - Mise à jour automatique du CV et de sa mise en page après confirmation, avec sélection des blocs ajoutés.

- **Style**
  - Nouvelle grille compacte de boutons pour accéder rapidement aux sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->