### PR TITLE
feat(AXE-335): design Beta ↔ Stable interchangeable (opt-in)

### DIFF
--- a/frontend/src/components/ProfileView.jsx
+++ b/frontend/src/components/ProfileView.jsx
@@ -239,18 +239,18 @@ export default function ProfileView({ onSaveSuccess, session, refreshKey, usage,
     try {
       const templateChanged = offer.templateId !== templateId;
       const nextOptions = templateChanged ? {} : (templateOptions || {});
-      if (onTemplateIdChange) onTemplateIdChange(offer.templateId);
-      else setLocalTemplateId(offer.templateId);
-      // Ne wipe les options Stable que si le template change vraiment.
-      if (templateChanged) {
-        if (onTemplateOptionsChange) onTemplateOptionsChange({});
-        else setLocalTemplateOptions({});
-      }
+      // Persister d’abord — ne mettre à jour l’UI locale qu’après succès API.
       await apiPut('/api/cv', {
         ...cv,
         template_id: offer.templateId,
         template_options: nextOptions,
       });
+      if (onTemplateIdChange) onTemplateIdChange(offer.templateId);
+      else setLocalTemplateId(offer.templateId);
+      if (templateChanged) {
+        if (onTemplateOptionsChange) onTemplateOptionsChange({});
+        else setLocalTemplateOptions({});
+      }
       setMessage(
         templateChanged
           ? `Template Stable « ${offer.templateLabel || offer.templateId} » appliqué`

--- a/frontend/src/components/ProfileView.jsx
+++ b/frontend/src/components/ProfileView.jsx
@@ -237,16 +237,25 @@ export default function ProfileView({ onSaveSuccess, session, refreshKey, usage,
     setDesignBridgeConfirming(true);
     setError('');
     try {
+      const templateChanged = offer.templateId !== templateId;
+      const nextOptions = templateChanged ? {} : (templateOptions || {});
       if (onTemplateIdChange) onTemplateIdChange(offer.templateId);
       else setLocalTemplateId(offer.templateId);
-      if (onTemplateOptionsChange) onTemplateOptionsChange({});
-      else setLocalTemplateOptions({});
+      // Ne wipe les options Stable que si le template change vraiment.
+      if (templateChanged) {
+        if (onTemplateOptionsChange) onTemplateOptionsChange({});
+        else setLocalTemplateOptions({});
+      }
       await apiPut('/api/cv', {
         ...cv,
         template_id: offer.templateId,
-        template_options: {},
+        template_options: nextOptions,
       });
-      setMessage(`Template Stable « ${offer.templateLabel || offer.templateId} » appliqué`);
+      setMessage(
+        templateChanged
+          ? `Template Stable « ${offer.templateLabel || offer.templateId} » appliqué`
+          : 'Préférences Stable conservées',
+      );
       setTimeout(() => setMessage(''), 2500);
       setDesignBridgeOffer(null);
       onSaveSuccess?.();
@@ -255,7 +264,7 @@ export default function ProfileView({ onSaveSuccess, session, refreshKey, usage,
     } finally {
       setDesignBridgeConfirming(false);
     }
-  }, [cv, onTemplateIdChange, onTemplateOptionsChange, onSaveSuccess]);
+  }, [cv, templateId, templateOptions, onTemplateIdChange, onTemplateOptionsChange, onSaveSuccess]);
 
   const handleDismissDesignBridge = useCallback(() => {
     setDesignBridgeOffer(null);

--- a/frontend/src/components/ProfileView.jsx
+++ b/frontend/src/components/ProfileView.jsx
@@ -192,7 +192,10 @@ export default function ProfileView({ onSaveSuccess, session, refreshKey, usage,
           : (templateIdProp ?? localTemplateId);
         setDesignBridgeOffer(buildBetaToStableOffer(data?.layout, currentTid));
       })
-      .catch(() => setCv(defaultCv()))
+      .catch(() => {
+        setCv(defaultCv());
+        setDesignBridgeOffer(null);
+      })
       .finally(() => setLoading(false));
   }, [session?.user?.id, refreshKey]);
 

--- a/frontend/src/components/ProfileView.jsx
+++ b/frontend/src/components/ProfileView.jsx
@@ -16,10 +16,13 @@ import { supabase } from '../lib/supabase';
 import { defaultCv, newExpId, newFormId, newCertId, newProjId } from '../data/cvDefault';
 import TemplatePicker from './TemplatePicker';
 import ReauthModal from './ReauthModal';
+import DesignModeBridgeModal from './editor/DesignModeBridgeModal.jsx';
 import { applyA4PageFramesToDocument, syncCvPreviewIframeHeight } from '../lib/cvPreviewA4Pages';
+import { buildBetaToStableOffer } from '../lib/designModeBridge.js';
 import { HiArrowDownTray } from 'react-icons/hi2';
 import '../styles/ProfileView.css';
 import '../styles/TemplatePicker.css';
+import '../styles/DesignModeBridgeModal.css';
 
 /** Retourne un Blob JPEG recadré à partir de l’image et de la zone en pixels (pour react-easy-crop). */
 function getCroppedImg(imageSrc, pixelCrop) {
@@ -166,6 +169,8 @@ export default function ProfileView({ onSaveSuccess, session, refreshKey, usage,
   const importFinalisationTimerRef = useRef(null);
   const [cancelSubModalOpen, setCancelSubModalOpen] = useState(false);
   const [cancelSubLoading, setCancelSubLoading] = useState(false);
+  const [designBridgeOffer, setDesignBridgeOffer] = useState(null);
+  const [designBridgeConfirming, setDesignBridgeConfirming] = useState(false);
   const fileInputRef = useRef(null);
   const importFileRef = useRef(null);
   const skipNextAutoSaveRef = useRef(true);
@@ -182,6 +187,10 @@ export default function ProfileView({ onSaveSuccess, session, refreshKey, usage,
         setCv(merged);
         if (data?.template_id != null && onTemplateIdChange) onTemplateIdChange(data.template_id);
         if (data?.template_options != null && typeof data.template_options === 'object' && onTemplateOptionsChange) onTemplateOptionsChange(data.template_options);
+        const currentTid = data?.template_id != null
+          ? data.template_id
+          : (templateIdProp ?? localTemplateId);
+        setDesignBridgeOffer(buildBetaToStableOffer(data?.layout, currentTid));
       })
       .catch(() => setCv(defaultCv()))
       .finally(() => setLoading(false));
@@ -219,6 +228,38 @@ export default function ProfileView({ onSaveSuccess, session, refreshKey, usage,
       setSaving(false);
     }
   }, [cv, templateId, templateOptions, onSaveSuccess]);
+
+  const handleConfirmDesignBridge = useCallback(async (offer) => {
+    if (!offer?.templateId) {
+      setDesignBridgeOffer(null);
+      return;
+    }
+    setDesignBridgeConfirming(true);
+    setError('');
+    try {
+      if (onTemplateIdChange) onTemplateIdChange(offer.templateId);
+      else setLocalTemplateId(offer.templateId);
+      if (onTemplateOptionsChange) onTemplateOptionsChange({});
+      else setLocalTemplateOptions({});
+      await apiPut('/api/cv', {
+        ...cv,
+        template_id: offer.templateId,
+        template_options: {},
+      });
+      setMessage(`Template Stable « ${offer.templateLabel || offer.templateId} » appliqué`);
+      setTimeout(() => setMessage(''), 2500);
+      setDesignBridgeOffer(null);
+      onSaveSuccess?.();
+    } catch (e) {
+      setError(e.message || 'Impossible d’appliquer le template Stable.');
+    } finally {
+      setDesignBridgeConfirming(false);
+    }
+  }, [cv, onTemplateIdChange, onTemplateOptionsChange, onSaveSuccess]);
+
+  const handleDismissDesignBridge = useCallback(() => {
+    setDesignBridgeOffer(null);
+  }, []);
 
   const fetchLinkedInWithToken = useCallback(async (token) => {
     setLinkedinError('');
@@ -1205,6 +1246,16 @@ export default function ProfileView({ onSaveSuccess, session, refreshKey, usage,
           </div>
         </div>
       </div>
+
+      {designBridgeOffer && (
+        <DesignModeBridgeModal
+          offer={designBridgeOffer}
+          confirming={designBridgeConfirming}
+          variant="profile"
+          onConfirm={handleConfirmDesignBridge}
+          onDismiss={handleDismissDesignBridge}
+        />
+      )}
 
       {linkedinModalOpen && (
         <div className="linkedin-sync-overlay" onClick={() => setLinkedinModalOpen(false)} role="dialog" aria-modal="true">

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -119,10 +119,17 @@ import EditorBlockChromeToolbar from './EditorBlockChromeToolbar.jsx';
 import EditorFloatingTextToolbar from './EditorFloatingTextToolbar.jsx';
 import EditorImageEditPopover from './EditorImageEditPopover.jsx';
 import EditorCanvaTransferModal from './EditorCanvaTransferModal.jsx';
+import DesignModeBridgeModal from './DesignModeBridgeModal.jsx';
 import EditorCvImportModal from './EditorCvImportModal.jsx';
 import EditorOnboardingTour from './EditorOnboardingTour.jsx';
 import HeaderComposerModal from './HeaderComposerModal.jsx';
 import SectionComposerModal from './SectionComposerModal.jsx';
+import {
+  applyStableDesignToCanvas,
+  buildStableToBetaOffer,
+  canBuildCanvasForTemplate,
+  resolveTemplateFromList,
+} from '../../lib/designModeBridge.js';
 import {
   applyHeaderComposerToLayout,
   mergeHeaderComposerCv,
@@ -219,6 +226,8 @@ function CvEditorBeta({
   const [activeLayoutContextKey, setActiveLayoutContextKey] = useState(() => getActiveCanvasContext());
   const [canvasDrafts, setCanvasDrafts] = useState(() => listCanvasDrafts(templatesList));
   const [transferRequest, setTransferRequest] = useState(null);
+  const [designBridgeOffer, setDesignBridgeOffer] = useState(null);
+  const [designBridgeConfirming, setDesignBridgeConfirming] = useState(false);
   const [importModalOpen, setImportModalOpen] = useState(false);
   const [importLoading, setImportLoading] = useState(false);
   const [importChooser, setImportChooser] = useState(null);
@@ -236,11 +245,16 @@ function CvEditorBeta({
   const blocksClipboardRef = useRef([]);
   const [profileLoadAttempt, setProfileLoadAttempt] = useState(0);
   const templatesListRef = useRef(templatesList);
+  const templateIdRef = useRef(templateId);
   const blockHistoryShortcutsRef = useRef(false);
 
   useLayoutEffect(() => {
     templatesListRef.current = templatesList;
   }, [templatesList]);
+
+  useLayoutEffect(() => {
+    templateIdRef.current = templateId;
+  }, [templateId]);
 
   useLayoutEffect(() => {
     blockHistoryShortcutsRef.current = Boolean(editingBlockId);
@@ -406,6 +420,12 @@ function CvEditorBeta({
         }
         resetLayout(hydratedLayout);
         setStartupPromptOpen(!rawLayout);
+        const bridgeOffer = buildStableToBetaOffer(
+          hydratedLayout,
+          templateIdRef.current,
+          templatesListRef.current || [],
+        );
+        setDesignBridgeOffer(bridgeOffer);
         setLoading(false);
       })
       .catch((err) => {
@@ -554,6 +574,42 @@ function CvEditorBeta({
     openCanvasContext,
     buildTemplateCanvasLayout,
   ]);
+
+  const handleApplyStableDesignBridge = useCallback((offer) => {
+    const tid = offer?.templateId || templateId;
+    const template = resolveTemplateFromList(templatesList || [], tid);
+    if (!template || !cv) {
+      setDesignBridgeOffer(null);
+      return;
+    }
+    setDesignBridgeConfirming(true);
+    try {
+      const applied = applyStableDesignToCanvas(cv, template, { templatesList });
+      if (!applied.ok || !applied.layout) {
+        setDesignBridgeOffer(null);
+        return;
+      }
+      if (onTemplateIdChange) onTemplateIdChange(template.id);
+      openCanvasContext(templateCanvasContextKey(template.id), applied.layout);
+      setDesignBridgeOffer(null);
+      setStartupPromptOpen(false);
+    } finally {
+      setDesignBridgeConfirming(false);
+    }
+  }, [cv, templateId, templatesList, onTemplateIdChange, openCanvasContext]);
+
+  const handleDismissDesignBridge = useCallback(() => {
+    setDesignBridgeOffer(null);
+  }, []);
+
+  const handleApplyStableFromStartup = useCallback(() => {
+    const template = resolveTemplateFromList(templatesList || [], templateId);
+    if (!template) {
+      handleChooseAtsSafeTemplate();
+      return;
+    }
+    handleApplyStableDesignBridge({ templateId: template.id, templateLabel: template.name || template.id });
+  }, [templatesList, templateId, handleApplyStableDesignBridge, handleChooseAtsSafeTemplate]);
 
   const applyImportedCvToCanvas = useCallback(async (nextCv, {
     layoutHints = {},
@@ -2115,6 +2171,15 @@ function CvEditorBeta({
                     >
                       Importer mon CV
                     </button>
+                    {canBuildCanvasForTemplate(resolveTemplateFromList(templatesList || [], templateId)) && (
+                      <button
+                        type="button"
+                        className="cv-editor-beta-start-panel__secondary"
+                        onClick={handleApplyStableFromStartup}
+                      >
+                        Appliquer mon design Stable
+                      </button>
+                    )}
                     <button
                       type="button"
                       className="cv-editor-beta-start-panel__secondary"
@@ -2144,6 +2209,14 @@ function CvEditorBeta({
                   </p>
                 </div>
               </section>
+            )}
+            {designBridgeOffer && !startupPromptOpen && (
+              <DesignModeBridgeModal
+                offer={designBridgeOffer}
+                confirming={designBridgeConfirming}
+                onConfirm={handleApplyStableDesignBridge}
+                onDismiss={handleDismissDesignBridge}
+              />
             )}
             {transferRequest && (
               <EditorCanvaTransferModal

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -89,6 +89,7 @@ import {
   createStarterLayoutV3,
   duplicateBlocks,
   findBlock,
+  isEmptyLayoutV3,
   layoutPayloadForPersist,
   migrateLayoutToV3,
   moveBlocksBy,
@@ -458,6 +459,14 @@ function CvEditorBeta({
     designBridgeSeededRef.current = true;
     setDesignBridgeOffer(offer);
   }, [loading, profileLoadError, cv, templatesList, templateId]);
+
+  // Si le canvas n’est plus vide (import / générer / template), retirer l’offre stale.
+  useEffect(() => {
+    if (!designBridgeOffer || designBridgeOffer.direction !== 'stable_to_beta') return;
+    if (isEmptyLayoutV3(layout)) return;
+    setDesignBridgeOffer(null);
+    setDesignBridgeError('');
+  }, [layout, designBridgeOffer]);
 
   const handleCvChange = useCallback((nextCv) => {
     if (profileLoadError || !nextCv) return;

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -228,6 +228,9 @@ function CvEditorBeta({
   const [transferRequest, setTransferRequest] = useState(null);
   const [designBridgeOffer, setDesignBridgeOffer] = useState(null);
   const [designBridgeConfirming, setDesignBridgeConfirming] = useState(false);
+  const [designBridgeError, setDesignBridgeError] = useState('');
+  const profileTemplateIdRef = useRef('');
+  const designBridgeSeededRef = useRef(false);
   const [importModalOpen, setImportModalOpen] = useState(false);
   const [importLoading, setImportLoading] = useState(false);
   const [importChooser, setImportChooser] = useState(null);
@@ -397,6 +400,9 @@ function CvEditorBeta({
     let aborted = false;
     setLoading(true);
     setProfileLoadError(null);
+    designBridgeSeededRef.current = false;
+    setDesignBridgeOffer(null);
+    setDesignBridgeError('');
     apiGet('/api/cv?profile=1')
       .then((data) => {
         if (aborted) return;
@@ -405,6 +411,8 @@ function CvEditorBeta({
         const baseCv = typeof defaultCv === 'function' ? defaultCv() : defaultCv;
         const mergedCv = { ...baseCv, ...cvPayload };
         setCv(mergedCv);
+        // Source de vérité pour le pont : template du profil API (pas localStorage).
+        profileTemplateIdRef.current = String(mergedCv.template_id || '').trim();
         const hydratedLayout = rawLayout
           ? migrateLayoutToV3(rawLayout)
           : createBlankLayoutV3();
@@ -420,12 +428,6 @@ function CvEditorBeta({
         }
         resetLayout(hydratedLayout);
         setStartupPromptOpen(!rawLayout);
-        const bridgeOffer = buildStableToBetaOffer(
-          hydratedLayout,
-          templateIdRef.current,
-          templatesListRef.current || [],
-        );
-        setDesignBridgeOffer(bridgeOffer);
         setLoading(false);
       })
       .catch((err) => {
@@ -443,6 +445,19 @@ function CvEditorBeta({
     if (loading || profileLoadError || !cv) return;
     setCanvasDrafts(listCanvasDrafts(templatesList));
   }, [templatesList, loading, profileLoadError, cv]);
+
+  // Recompute l’offre Stable→Beta quand templatesList arrive (souvent après le GET cv).
+  useEffect(() => {
+    if (loading || profileLoadError || !cv) return;
+    if (!Array.isArray(templatesList) || templatesList.length === 0) return;
+    if (designBridgeSeededRef.current) return;
+    const tid = String(
+      profileTemplateIdRef.current || cv.template_id || templateId || '',
+    ).trim();
+    const offer = buildStableToBetaOffer(layoutRef.current, tid, templatesList);
+    designBridgeSeededRef.current = true;
+    setDesignBridgeOffer(offer);
+  }, [loading, profileLoadError, cv, templatesList, templateId]);
 
   const handleCvChange = useCallback((nextCv) => {
     if (profileLoadError || !nextCv) return;
@@ -576,22 +591,34 @@ function CvEditorBeta({
   ]);
 
   const handleApplyStableDesignBridge = useCallback((offer) => {
-    const tid = offer?.templateId || templateId;
+    const tid = offer?.templateId
+      || profileTemplateIdRef.current
+      || templateId;
     const template = resolveTemplateFromList(templatesList || [], tid);
     if (!template || !cv) {
-      setDesignBridgeOffer(null);
+      setDesignBridgeError(
+        !cv
+          ? 'Profil non chargé — réessaie dans un instant.'
+          : 'Ce template Stable n’a pas de projection canvas. Choisis un autre modèle.',
+      );
       return;
     }
     setDesignBridgeConfirming(true);
+    setDesignBridgeError('');
     try {
       const applied = applyStableDesignToCanvas(cv, template, { templatesList });
       if (!applied.ok || !applied.layout) {
-        setDesignBridgeOffer(null);
+        setDesignBridgeError(
+          applied.reason === 'no_canvas_spec'
+            ? 'Ce template Stable n’a pas de projection canvas utilisable.'
+            : 'Impossible d’appliquer le design Stable sur le canvas.',
+        );
         return;
       }
       if (onTemplateIdChange) onTemplateIdChange(template.id);
       openCanvasContext(templateCanvasContextKey(template.id), applied.layout);
       setDesignBridgeOffer(null);
+      setDesignBridgeError('');
       setStartupPromptOpen(false);
     } finally {
       setDesignBridgeConfirming(false);
@@ -600,16 +627,25 @@ function CvEditorBeta({
 
   const handleDismissDesignBridge = useCallback(() => {
     setDesignBridgeOffer(null);
+    setDesignBridgeError('');
   }, []);
 
   const handleApplyStableFromStartup = useCallback(() => {
-    const template = resolveTemplateFromList(templatesList || [], templateId);
-    if (!template) {
+    const tid = String(
+      profileTemplateIdRef.current || templateId || '',
+    ).trim();
+    const offer = buildStableToBetaOffer(layoutRef.current, tid, templatesList || [], {
+      force: true,
+    });
+    if (!offer) {
       handleChooseAtsSafeTemplate();
       return;
     }
-    handleApplyStableDesignBridge({ templateId: template.id, templateLabel: template.name || template.id });
-  }, [templatesList, templateId, handleApplyStableDesignBridge, handleChooseAtsSafeTemplate]);
+    // Opt-in via modal (warnings + Garder tel quel) — pas d’apply direct.
+    setStartupPromptOpen(false);
+    setDesignBridgeError('');
+    setDesignBridgeOffer(offer);
+  }, [templatesList, templateId, handleChooseAtsSafeTemplate]);
 
   const applyImportedCvToCanvas = useCallback(async (nextCv, {
     layoutHints = {},
@@ -2171,7 +2207,12 @@ function CvEditorBeta({
                     >
                       Importer mon CV
                     </button>
-                    {canBuildCanvasForTemplate(resolveTemplateFromList(templatesList || [], templateId)) && (
+                    {canBuildCanvasForTemplate(
+                      resolveTemplateFromList(
+                        templatesList || [],
+                        String(cv?.template_id || profileTemplateIdRef.current || templateId || '').trim(),
+                      ),
+                    ) && (
                       <button
                         type="button"
                         className="cv-editor-beta-start-panel__secondary"
@@ -2214,6 +2255,7 @@ function CvEditorBeta({
               <DesignModeBridgeModal
                 offer={designBridgeOffer}
                 confirming={designBridgeConfirming}
+                error={designBridgeError}
                 onConfirm={handleApplyStableDesignBridge}
                 onDismiss={handleDismissDesignBridge}
               />

--- a/frontend/src/components/editor/DesignModeBridgeModal.jsx
+++ b/frontend/src/components/editor/DesignModeBridgeModal.jsx
@@ -1,0 +1,76 @@
+import {
+  dismissDesignBridge,
+} from '../../lib/designModeBridge.js';
+import '../../styles/DesignModeBridgeModal.css';
+
+/**
+ * Modal opt-in pour appliquer un design Stable ↔ Beta (AXE-335).
+ * Aucune application automatique — l’utilisateur confirme.
+ */
+export default function DesignModeBridgeModal({
+  offer = null,
+  confirming = false,
+  variant = 'editor',
+  onConfirm,
+  onDismiss,
+}) {
+  if (!offer) return null;
+
+  const handleDismiss = (remember) => {
+    if (remember) {
+      dismissDesignBridge(offer.direction, offer.templateId);
+    }
+    onDismiss?.({ rememberChoice: Boolean(remember) });
+  };
+
+  return (
+    <div
+      className={`design-mode-bridge-modal${variant === 'profile' ? ' design-mode-bridge-modal--profile' : ''}`}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="design-mode-bridge-title"
+    >
+      <div className="design-mode-bridge-modal__card">
+        <header className="design-mode-bridge-modal__head">
+          <div>
+            <span className="design-mode-bridge-modal__eyebrow">Design Stable ↔ Beta</span>
+            <h3 id="design-mode-bridge-title">{offer.title}</h3>
+          </div>
+          <button
+            type="button"
+            className="design-mode-bridge-modal__close"
+            onClick={() => handleDismiss(false)}
+            aria-label="Fermer"
+          >
+            ×
+          </button>
+        </header>
+        <p className="design-mode-bridge-modal__copy">{offer.copy}</p>
+        {Array.isArray(offer.warnings) && offer.warnings.length > 0 && (
+          <ul className="design-mode-bridge-modal__warnings">
+            {offer.warnings.map((warning) => (
+              <li key={warning}>{warning}</li>
+            ))}
+          </ul>
+        )}
+        <footer className="design-mode-bridge-modal__actions">
+          <button type="button" onClick={() => handleDismiss(true)} disabled={confirming}>
+            Garder tel quel
+          </button>
+          <button
+            type="button"
+            className="design-mode-bridge-modal__primary"
+            onClick={() => onConfirm?.(offer)}
+            disabled={confirming}
+          >
+            {confirming
+              ? 'Application…'
+              : offer.direction === 'stable_to_beta'
+                ? `Appliquer « ${offer.templateLabel} »`
+                : `Utiliser « ${offer.templateLabel} »`}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/editor/DesignModeBridgeModal.jsx
+++ b/frontend/src/components/editor/DesignModeBridgeModal.jsx
@@ -10,6 +10,7 @@ import '../../styles/DesignModeBridgeModal.css';
 export default function DesignModeBridgeModal({
   offer = null,
   confirming = false,
+  error = '',
   variant = 'editor',
   onConfirm,
   onDismiss,
@@ -53,6 +54,9 @@ export default function DesignModeBridgeModal({
             ))}
           </ul>
         )}
+        {error ? (
+          <p className="design-mode-bridge-modal__error" role="alert">{error}</p>
+        ) : null}
         <footer className="design-mode-bridge-modal__actions">
           <button type="button" onClick={() => handleDismiss(true)} disabled={confirming}>
             Garder tel quel

--- a/frontend/src/lib/designModeBridge.js
+++ b/frontend/src/lib/designModeBridge.js
@@ -164,13 +164,15 @@ export function dismissDesignBridge(direction, templateId, storage) {
  * @param {object|null|undefined} layout
  * @param {string} templateId
  * @param {unknown[]} templatesList
- * @param {{ storage?: Storage|null }} [options]
+ * @param {{ storage?: Storage|null, force?: boolean }} [options]
  */
 export function buildStableToBetaOffer(layout, templateId, templatesList, options = {}) {
   const template = resolveTemplateFromList(templatesList, templateId);
   if (!template || !canBuildCanvasForTemplate(template)) return null;
   if (!isEmptyLayoutV3(layout)) return null;
-  if (isDesignBridgeDismissed('stable_to_beta', template.id, options.storage)) return null;
+  if (!options.force && isDesignBridgeDismissed('stable_to_beta', template.id, options.storage)) {
+    return null;
+  }
   return {
     direction: 'stable_to_beta',
     templateId: template.id,

--- a/frontend/src/lib/designModeBridge.js
+++ b/frontend/src/lib/designModeBridge.js
@@ -1,0 +1,217 @@
+/**
+ * Pont design Stable ↔ Beta (AXE-335).
+ *
+ * Contenu sémantique (`cv`) est déjà partagé. Ce module ne force aucune
+ * migration au toggle : il construit des **offres opt-in** pour appliquer
+ * un design d’un mode vers l’autre, avec un diff explicite si besoin.
+ */
+
+import { buildAdaptedCanvasLayoutForCv } from './canvasCvImportAdapter.js';
+import { buildTemplateBlocks } from './canvasTemplateSpecs.js';
+import { detectTransferCandidates } from './canvasLayoutTransfer.js';
+import { createCanvasLayoutForTemplate } from './layoutTemplatePresets.js';
+import { isEmptyLayoutV3, listAllBlocks } from './cvLayoutModelV3.js';
+
+export const DESIGN_BRIDGE_DISMISS_KEY = 'cv_bot_design_bridge_dismiss_v1';
+
+/**
+ * @param {unknown} templatesList
+ * @param {string|null|undefined} templateId
+ */
+export function resolveTemplateFromList(templatesList, templateId) {
+  const id = String(templateId || '').trim();
+  if (!id || !Array.isArray(templatesList)) return null;
+  return templatesList.find((t) => t && t.id === id) || null;
+}
+
+/**
+ * Un template HTML a-t-il une projection canvas utilisable ?
+ * @param {object|null|undefined} template
+ */
+export function canBuildCanvasForTemplate(template) {
+  if (!template?.id) return false;
+  try {
+    return buildTemplateBlocks(template).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Applique le design Stable (template HTML) sur un canvas Beta adapté au `cv`.
+ * @param {object|null|undefined} cv
+ * @param {object} template
+ * @param {{ templatesList?: unknown[] }} [options]
+ */
+export function applyStableDesignToCanvas(cv, template, options = {}) {
+  if (!template?.id) {
+    return { ok: false, reason: 'missing_template', layout: null };
+  }
+  if (!canBuildCanvasForTemplate(template)) {
+    return { ok: false, reason: 'no_canvas_spec', layout: null };
+  }
+  const result = buildAdaptedCanvasLayoutForCv(cv, template, {
+    templatesList: options.templatesList,
+    templateId: template.id,
+  });
+  return {
+    ok: true,
+    reason: null,
+    layout: result.layout,
+    templateId: template.id,
+  };
+}
+
+/**
+ * @param {object|null|undefined} layout
+ * @returns {string}
+ */
+export function suggestStableTemplateIdFromLayout(layout) {
+  const fromTheme = String(layout?.theme?.template_id || '').trim();
+  if (fromTheme) return fromTheme;
+  return '';
+}
+
+/**
+ * Diff honnête avant application cross-mode.
+ * @param {object|null|undefined} layout
+ * @param {string} [targetTemplateId]
+ */
+export function assessCrossModeDiff(layout, targetTemplateId = '') {
+  const warnings = [];
+  if (!layout || isEmptyLayoutV3(layout)) {
+    return { warnings, freeform: false, manualExtras: 0, blockMismatch: false };
+  }
+  const freeform = layout.freeform === true;
+  if (freeform) {
+    warnings.push(
+      'Ce canvas est en disposition libre (import fidèle). Stable utilisera le template HTML, pas le placement libre mm.',
+    );
+  }
+  const target = createCanvasLayoutForTemplate(
+    targetTemplateId ? { id: targetTemplateId } : { id: suggestStableTemplateIdFromLayout(layout) || 'minimal' },
+  );
+  const candidates = detectTransferCandidates(layout, target);
+  const manualExtras = candidates.length;
+  if (manualExtras > 0) {
+    warnings.push(
+      `${manualExtras} élément(s) personnalisé(s) du canvas ne seront pas repris dans l’aperçu Stable.`,
+    );
+  }
+  const suggested = suggestStableTemplateIdFromLayout(layout);
+  const targetId = String(targetTemplateId || '').trim();
+  const templateMismatch = Boolean(suggested && targetId && suggested !== targetId);
+  if (templateMismatch) {
+    warnings.push(
+      `Le canvas est lié au template « ${suggested} », différent de « ${targetId} » actuellement en Stable.`,
+    );
+  }
+  return { warnings, freeform, manualExtras, templateMismatch };
+}
+
+/**
+ * @param {Storage|null|undefined} storage
+ */
+function resolveStorage(storage) {
+  if (storage) return storage;
+  if (typeof globalThis !== 'undefined' && globalThis.localStorage) {
+    return globalThis.localStorage;
+  }
+  return null;
+}
+
+/**
+ * @param {'stable_to_beta'|'beta_to_stable'} direction
+ * @param {string} templateId
+ * @param {Storage|null} [storage]
+ */
+export function isDesignBridgeDismissed(direction, templateId, storage) {
+  const s = resolveStorage(storage);
+  if (!s) return false;
+  try {
+    const raw = s.getItem(DESIGN_BRIDGE_DISMISS_KEY);
+    if (!raw) return false;
+    const parsed = JSON.parse(raw);
+    const key = `${direction}:${String(templateId || '').trim()}`;
+    return Boolean(parsed && parsed[key]);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @param {'stable_to_beta'|'beta_to_stable'} direction
+ * @param {string} templateId
+ * @param {Storage|null} [storage]
+ */
+export function dismissDesignBridge(direction, templateId, storage) {
+  const s = resolveStorage(storage);
+  if (!s) return false;
+  try {
+    const raw = s.getItem(DESIGN_BRIDGE_DISMISS_KEY);
+    const parsed = raw ? JSON.parse(raw) : {};
+    const next = parsed && typeof parsed === 'object' ? { ...parsed } : {};
+    next[`${direction}:${String(templateId || '').trim()}`] = true;
+    s.setItem(DESIGN_BRIDGE_DISMISS_KEY, JSON.stringify(next));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Offre Stable → Beta : canvas vide + template Stable projetable.
+ * @param {object|null|undefined} layout
+ * @param {string} templateId
+ * @param {unknown[]} templatesList
+ * @param {{ storage?: Storage|null }} [options]
+ */
+export function buildStableToBetaOffer(layout, templateId, templatesList, options = {}) {
+  const template = resolveTemplateFromList(templatesList, templateId);
+  if (!template || !canBuildCanvasForTemplate(template)) return null;
+  if (!isEmptyLayoutV3(layout)) return null;
+  if (isDesignBridgeDismissed('stable_to_beta', template.id, options.storage)) return null;
+  return {
+    direction: 'stable_to_beta',
+    templateId: template.id,
+    templateLabel: template.name || template.label || template.id,
+    title: 'Appliquer le design Stable ?',
+    copy:
+      'Ton contenu est déjà partagé. Tu peux reconstruire le canvas Beta à partir du template Stable — sans forcer une migration.',
+    warnings: [
+      'Le rendu Beta est une projection canvas du template (pas un clone pixel-perfect du HTML Stable).',
+    ],
+  };
+}
+
+/**
+ * Offre Beta → Stable : layout présent avec template_id différent ou libre.
+ * @param {object|null|undefined} layout
+ * @param {string} currentTemplateId
+ * @param {{ storage?: Storage|null }} [options]
+ */
+export function buildBetaToStableOffer(layout, currentTemplateId, options = {}) {
+  if (!layout || isEmptyLayoutV3(layout)) return null;
+  const suggested = suggestStableTemplateIdFromLayout(layout);
+  if (!suggested) return null;
+  const current = String(currentTemplateId || '').trim();
+  const diff = assessCrossModeDiff(layout, current);
+  const shouldOffer =
+    suggested !== current
+    || diff.freeform
+    || diff.manualExtras > 0;
+  if (!shouldOffer) return null;
+  if (isDesignBridgeDismissed('beta_to_stable', suggested, options.storage)) return null;
+  const blocks = listAllBlocks(layout).length;
+  return {
+    direction: 'beta_to_stable',
+    templateId: suggested,
+    templateLabel: suggested,
+    title: 'Utiliser ce template en Stable ?',
+    copy:
+      blocks > 0
+        ? `Le canvas Beta référence « ${suggested} ». Stable affichera le template HTML correspondant (contenu inchangé).`
+        : `Appliquer « ${suggested} » comme template Stable.`,
+    warnings: diff.warnings,
+  };
+}

--- a/frontend/src/styles/DesignModeBridgeModal.css
+++ b/frontend/src/styles/DesignModeBridgeModal.css
@@ -1,0 +1,118 @@
+.design-mode-bridge-modal {
+  position: absolute;
+  inset: 0;
+  z-index: 42;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 72px 24px 24px;
+  background: rgba(7, 24, 41, 0.2);
+}
+
+.design-mode-bridge-modal--profile {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  padding-top: 96px;
+}
+
+.design-mode-bridge-modal__card {
+  width: min(440px, 100%);
+  max-height: min(620px, calc(100vh - 120px));
+  overflow-y: auto;
+  padding: 16px;
+  background: var(--color-canvas, #ffffff);
+  border: 1px solid var(--color-hairline, #d9d9dd);
+  border-radius: 16px;
+}
+
+.design-mode-bridge-modal__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.design-mode-bridge-modal__eyebrow {
+  display: block;
+  margin-bottom: 4px;
+  font-family: CohereMono, Arial, ui-sans-serif, system-ui, sans-serif;
+  font-size: 12px;
+  font-weight: 400;
+  letter-spacing: 0.28px;
+  text-transform: uppercase;
+  color: var(--color-muted, #93939f);
+}
+
+.design-mode-bridge-modal__head h3 {
+  margin: 0;
+  font-family: Unica77, Inter, ui-sans-serif, system-ui, sans-serif;
+  font-size: 24px;
+  font-weight: 400;
+  line-height: 1.3;
+  color: var(--color-ink, #212121);
+}
+
+.design-mode-bridge-modal__close {
+  border: 0;
+  background: transparent;
+  color: var(--color-slate, #75758a);
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+}
+
+.design-mode-bridge-modal__copy {
+  margin: 12px 0 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: var(--color-body-muted, #616161);
+}
+
+.design-mode-bridge-modal__warnings {
+  margin: 12px 0 0;
+  padding: 12px 12px 12px 28px;
+  border-radius: 8px;
+  background: var(--color-soft-stone, #eeece7);
+  border: 1px solid var(--color-card-border, #f2f2f2);
+  color: var(--color-ink, #212121);
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.design-mode-bridge-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.design-mode-bridge-modal__actions button {
+  border: 1px solid var(--color-primary, #17171c);
+  background: transparent;
+  color: var(--color-primary, #17171c);
+  border-radius: 32px;
+  padding: 8px 16px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.design-mode-bridge-modal__actions button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.design-mode-bridge-modal__primary {
+  background: var(--color-primary, #17171c) !important;
+  color: var(--color-on-dark, #ffffff) !important;
+  border-color: var(--color-primary, #17171c) !important;
+}
+
+.design-mode-bridge-modal__primary:focus-visible,
+.design-mode-bridge-modal__actions button:focus-visible,
+.design-mode-bridge-modal__close:focus-visible {
+  outline: 2px solid var(--color-focus-blue, #4c6ee6);
+  outline-offset: 2px;
+}

--- a/frontend/src/styles/DesignModeBridgeModal.css
+++ b/frontend/src/styles/DesignModeBridgeModal.css
@@ -81,6 +81,17 @@
   line-height: 1.4;
 }
 
+.design-mode-bridge-modal__error {
+  margin: 12px 0 0;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--color-coral-soft, #ffad9b);
+  background: #fff7f5;
+  color: var(--color-error, #b30000);
+  font-size: 14px;
+  line-height: 1.4;
+}
+
 .design-mode-bridge-modal__actions {
   display: flex;
   justify-content: flex-end;

--- a/frontend/tests/unit/designModeBridge.test.js
+++ b/frontend/tests/unit/designModeBridge.test.js
@@ -107,3 +107,13 @@ test('dismissDesignBridge suppresses future offers', () => {
   assert.equal(isDesignBridgeDismissed('stable_to_beta', 'minimal', storage), true);
   assert.equal(buildStableToBetaOffer(blank, 'minimal', templates, { storage }), null);
 });
+
+test('buildStableToBetaOffer force bypasses dismiss for explicit CTA', () => {
+  const storage = makeStorage();
+  const blank = createBlankLayoutV3();
+  dismissDesignBridge('stable_to_beta', 'minimal', storage);
+  assert.equal(buildStableToBetaOffer(blank, 'minimal', templates, { storage }), null);
+  const forced = buildStableToBetaOffer(blank, 'minimal', templates, { storage, force: true });
+  assert.ok(forced);
+  assert.equal(forced.templateId, 'minimal');
+});

--- a/frontend/tests/unit/designModeBridge.test.js
+++ b/frontend/tests/unit/designModeBridge.test.js
@@ -1,0 +1,109 @@
+/**
+ * Tests unitaires pont design Stable ↔ Beta (AXE-335).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createBlankLayoutV3 } from '../../src/lib/cvLayoutModelV3.js';
+import {
+  applyStableDesignToCanvas,
+  assessCrossModeDiff,
+  buildBetaToStableOffer,
+  buildStableToBetaOffer,
+  canBuildCanvasForTemplate,
+  dismissDesignBridge,
+  isDesignBridgeDismissed,
+  resolveTemplateFromList,
+  suggestStableTemplateIdFromLayout,
+} from '../../src/lib/designModeBridge.js';
+
+function makeStorage() {
+  const store = new Map();
+  return {
+    getItem: (key) => (store.has(key) ? store.get(key) : null),
+    setItem: (key, value) => { store.set(key, String(value)); },
+    removeItem: (key) => { store.delete(key); },
+  };
+}
+
+const templates = [
+  { id: 'minimal', name: 'Minimal' },
+  { id: 'modern', name: 'Modern' },
+  { id: 'custom_unknown', name: 'Perso' },
+];
+
+test('resolveTemplateFromList finds by id', () => {
+  assert.equal(resolveTemplateFromList(templates, 'modern')?.id, 'modern');
+  assert.equal(resolveTemplateFromList(templates, 'nope'), null);
+});
+
+test('canBuildCanvasForTemplate accepts known HTML twins', () => {
+  assert.equal(canBuildCanvasForTemplate({ id: 'minimal' }), true);
+  assert.equal(canBuildCanvasForTemplate({ id: 'custom_unknown' }), false);
+});
+
+test('applyStableDesignToCanvas builds non-empty layout from Stable template', () => {
+  const cv = {
+    prenom: 'Ada',
+    nom: 'Lovelace',
+    email: 'ada@example.com',
+    experiences: [{ poste: 'Engineer', entreprise: 'Analytical' }],
+  };
+  const result = applyStableDesignToCanvas(cv, { id: 'minimal' }, { templatesList: templates });
+  assert.equal(result.ok, true);
+  assert.ok(result.layout?.pages?.[0]?.blocks?.length > 0);
+  assert.equal(result.templateId, 'minimal');
+});
+
+test('buildStableToBetaOffer only when canvas empty + projectable template', () => {
+  const blank = createBlankLayoutV3();
+  const offer = buildStableToBetaOffer(blank, 'minimal', templates, { storage: makeStorage() });
+  assert.ok(offer);
+  assert.equal(offer.direction, 'stable_to_beta');
+  assert.equal(offer.templateId, 'minimal');
+
+  const filled = {
+    ...blank,
+    pages: [{ ...blank.pages[0], blocks: [{ id: 'b1', type: 'text', x: 10, y: 10, w: 40, h: 10, z: 1 }] }],
+  };
+  assert.equal(buildStableToBetaOffer(filled, 'minimal', templates, { storage: makeStorage() }), null);
+});
+
+test('buildBetaToStableOffer when theme template differs', () => {
+  const layout = {
+    version: 3,
+    theme: { template_id: 'modern' },
+    pages: [{ blocks: [{ id: 'b1', type: 'identity', x: 10, y: 10, w: 40, h: 20, z: 1 }] }],
+  };
+  const offer = buildBetaToStableOffer(layout, 'minimal', { storage: makeStorage() });
+  assert.ok(offer);
+  assert.equal(offer.direction, 'beta_to_stable');
+  assert.equal(offer.templateId, 'modern');
+});
+
+test('suggestStableTemplateIdFromLayout reads theme', () => {
+  assert.equal(suggestStableTemplateIdFromLayout({ theme: { template_id: 'elegant' } }), 'elegant');
+  assert.equal(suggestStableTemplateIdFromLayout({}), '');
+});
+
+test('assessCrossModeDiff warns on freeform', () => {
+  const layout = {
+    version: 3,
+    freeform: true,
+    theme: { template_id: 'modern' },
+    pages: [{ blocks: [{ id: 't1', type: 'text', content: 'Note', x: 10, y: 10, w: 40, h: 10, z: 1 }] }],
+  };
+  const diff = assessCrossModeDiff(layout, 'minimal');
+  assert.equal(diff.freeform, true);
+  assert.ok(diff.warnings.some((w) => /libre/i.test(w)));
+});
+
+test('dismissDesignBridge suppresses future offers', () => {
+  const storage = makeStorage();
+  const blank = createBlankLayoutV3();
+  assert.ok(buildStableToBetaOffer(blank, 'minimal', templates, { storage }));
+  dismissDesignBridge('stable_to_beta', 'minimal', storage);
+  assert.equal(isDesignBridgeDismissed('stable_to_beta', 'minimal', storage), true);
+  assert.equal(buildStableToBetaOffer(blank, 'minimal', templates, { storage }), null);
+});


### PR DESCRIPTION
## Summary
- Pont **opt-in** Stable ↔ Beta : le toggle ne migre plus rien en silence ; l’utilisateur choisit d’appliquer un design.
- **Stable → Beta** : sur canvas vide, modal + CTA démarrage « Appliquer mon design Stable » (`buildAdaptedCanvasLayoutForCv`).
- **Beta → Stable** : si le layout référence un autre `template_id` (ou freeform/extras), modal pour synchroniser le template HTML Stable, avec warnings explicites.
- Dismiss mémorisé par direction + template ; tests unitaires `designModeBridge.test.js`.

## Linear
Fixes AXE-335

## GitHub issue
Closes #109

## Test plan
- [ ] Stable → Beta avec canvas vide + template connu : offre / CTA « Appliquer mon design Stable »
- [ ] Appliquer → canvas rempli, `template_id` aligné ; « Garder tel quel » ne force rien
- [ ] Beta → Stable avec `layout.theme.template_id` ≠ template courant : modal + apply met à jour l’aperçu
- [ ] Layout `freeform` : warning visible dans la modal
- [ ] Toggle Beta ne réécrit pas le layout sans confirmation
- [ ] `node --test tests/unit/designModeBridge.test.js`
- [ ] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks` OK


Made with [Cursor](https://cursor.com)