### PR TITLE
feat(AXE-330): export multi-format depuis Télécharger (PDF, HTML, TXT)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -366,6 +366,12 @@ class PdfBody(BaseModel):
     layout: dict | None = None
 
 
+class CvExportBody(PdfBody):
+    """Export multi-format (AXE-330) — mêmes champs que PdfBody + format."""
+
+    format: str = "pdf"
+
+
 class ExportDossierBody(BaseModel):
     cv: dict
     titre: str = ""
@@ -3726,6 +3732,113 @@ def api_pdf(request: Request, body: PdfBody):
             "X-CV-PDF-Engine": cv_pdf_engine(),
         },
     )
+
+
+def _cv_export_basename(cv: dict, offre: dict) -> str:
+    from backend.services.generator import _nom_fichier_pdf
+
+    pdf_name = _nom_fichier_pdf(cv or {}, offre or {})
+    return pdf_name[:-4] if pdf_name.lower().endswith(".pdf") else (pdf_name or "CV")
+
+
+@app.post("/api/cv-export")
+def api_cv_export(request: Request, body: CvExportBody):
+    """
+    Export CV multi-format (AXE-330) : pdf | html | txt.
+    PDF réutilise le même rendu que POST /api/pdf.
+    """
+    user_id = _get_user_id(request)
+    fmt = (body.format or "pdf").strip().lower()
+    if fmt not in ("pdf", "html", "txt"):
+        raise HTTPException(
+            status_code=400,
+            detail="Format non supporté. Formats disponibles : pdf, html, txt.",
+        )
+    check_rate_limit(user_id, 10, scope="cv_export")
+    if fmt in ("pdf", "html"):
+        _check_premium_template(user_id, body.template_id)
+        _check_custom_template_access(user_id, body.template_id)
+
+    cv = body.cv or {}
+    offre = {"titre": body.titre, "entreprise": body.entreprise}
+    basename = _cv_export_basename(cv, offre)
+
+    try:
+        if fmt == "pdf":
+            pdf_bytes, filename = _cv_pdf_bytes_same_as_download(request, body)
+            PDF_COUNT.inc()
+            _track_analytics(
+                request,
+                event_log.EVENT_PDF_GENERATED,
+                user_id,
+                {
+                    "titre": body.titre or "",
+                    "entreprise": body.entreprise or "",
+                    "template_id": body.template_id or DEFAULT_TEMPLATE_ID,
+                    "export_format": "pdf",
+                },
+            )
+            from backend.cv_pdf_dispatch import cv_pdf_engine
+
+            return Response(
+                content=pdf_bytes,
+                media_type="application/pdf",
+                headers={
+                    "Content-Disposition": f'attachment; filename="{filename}"',
+                    "X-CV-PDF-Engine": cv_pdf_engine(),
+                },
+            )
+
+        if fmt == "html":
+            # Aligné sur le HTML du PDF (layout free-canvas ou template).
+            if USE_SUPABASE and user_id:
+                cv = _apply_user_photo_for_pdf(cv, user_id)
+            if isinstance(body.layout, dict) and body.layout:
+                from backend.services.layout_renderer import render_html as render_layout_html
+
+                html = render_layout_html(cv, body.layout, for_preview=False)
+            else:
+                html = _render_cv_html(
+                    cv,
+                    for_preview=False,
+                    for_pdf=False,
+                    template_id=body.template_id,
+                    template_options=body.template_options,
+                    selection_a4=body.selection_a4,
+                )
+            filename = f"{basename}.html"
+            return Response(
+                content=html.encode("utf-8"),
+                media_type="text/html; charset=utf-8",
+                headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+            )
+
+        # txt
+        from backend.services.cv_text_export import cv_to_plain_text
+
+        text = cv_to_plain_text(cv)
+        if not text.strip():
+            raise HTTPException(
+                status_code=400,
+                detail="Rien à exporter en texte : le CV sémantique est vide.",
+            )
+        filename = f"{basename}.txt"
+        return Response(
+            content=text.encode("utf-8"),
+            media_type="text/plain; charset=utf-8",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(e)
+        if IS_PRODUCTION:
+            raise HTTPException(
+                status_code=500,
+                detail="Erreur lors de l’export. Réessaie ou contacte le support.",
+            )
+        err_msg = str(e).strip() or repr(e)
+        raise HTTPException(status_code=500, detail=f"Erreur export ({fmt}): {err_msg}")
 
 
 @app.get("/api/export-default-dir")

--- a/backend/main.py
+++ b/backend/main.py
@@ -3817,7 +3817,8 @@ def api_cv_export(request: Request, body: CvExportBody):
             from backend.services.cv_docx_export import cv_to_docx_bytes
 
             try:
-                docx_bytes = cv_to_docx_bytes(cv)
+                layout = body.layout if isinstance(body.layout, dict) else None
+                docx_bytes = cv_to_docx_bytes(cv, layout)
             except ValueError:
                 raise HTTPException(
                     status_code=400,

--- a/backend/main.py
+++ b/backend/main.py
@@ -3744,15 +3744,15 @@ def _cv_export_basename(cv: dict, offre: dict) -> str:
 @app.post("/api/cv-export")
 def api_cv_export(request: Request, body: CvExportBody):
     """
-    Export CV multi-format (AXE-330) : pdf | html | txt.
-    PDF réutilise le même rendu que POST /api/pdf.
+    Export CV multi-format (AXE-330) : pdf | html | txt | docx.
+    PDF/HTML réutilisent le rendu layout ; TXT/DOCX = contenu sémantique (ATS).
     """
     user_id = _get_user_id(request)
     fmt = (body.format or "pdf").strip().lower()
-    if fmt not in ("pdf", "html", "txt"):
+    if fmt not in ("pdf", "html", "txt", "docx"):
         raise HTTPException(
             status_code=400,
-            detail="Format non supporté. Formats disponibles : pdf, html, txt.",
+            detail="Format non supporté. Formats disponibles : pdf, html, txt, docx.",
         )
     check_rate_limit(user_id, 10, scope="cv_export")
     if fmt in ("pdf", "html"):
@@ -3810,6 +3810,25 @@ def api_cv_export(request: Request, body: CvExportBody):
             return Response(
                 content=html.encode("utf-8"),
                 media_type="text/html; charset=utf-8",
+                headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+            )
+
+        if fmt == "docx":
+            from backend.services.cv_docx_export import cv_to_docx_bytes
+
+            try:
+                docx_bytes = cv_to_docx_bytes(cv)
+            except ValueError:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Rien à exporter en Word : le CV sémantique est vide.",
+                )
+            filename = f"{basename}.docx"
+            return Response(
+                content=docx_bytes,
+                media_type=(
+                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                ),
                 headers={"Content-Disposition": f'attachment; filename="{filename}"'},
             )
 

--- a/backend/services/cv_docx_export.py
+++ b/backend/services/cv_docx_export.py
@@ -1,6 +1,8 @@
-"""Export Word (.docx) d'un CV sémantique (AXE-330).
+"""Export Word (.docx) d'un CV (AXE-330).
 
-Document simple mono-colonne pour ATS / édition — ne reproduit pas le layout canvas.
+- Sans layout : document sémantique mono-colonne (ATS).
+- Avec layout free-canvas : flux design-aware (ordre de lecture, 1–2 colonnes,
+  typo / accents du thème). Word ne peut pas reproduire le placement absolu mm.
 """
 
 from __future__ import annotations
@@ -8,10 +10,31 @@ from __future__ import annotations
 from io import BytesIO
 from typing import Any
 
+from backend.services import layout_bindings as bind
 from backend.services.cv_text_export import (
     _as_str,
     _join_nonempty,
     _list_skills,
+)
+from backend.services.layout_renderer import SECTION_LABELS
+
+PAGE_WIDTH_MM = 210.0
+COLUMN_GAP_MM = 30.0
+FULL_WIDTH_MIN_MM = 140.0
+CONTENT_TYPES = frozenset(
+    {
+        "identity",
+        "contact",
+        "resume",
+        "experiences",
+        "formations",
+        "certifications",
+        "projets",
+        "skills",
+        "languages",
+        "text",
+        "title",
+    }
 )
 
 
@@ -32,103 +55,627 @@ def _has_content(cv: dict) -> bool:
     return False
 
 
-def _add_heading(doc: Any, text: str, level: int = 2) -> None:
-    doc.add_heading(text, level=level)
+def _num(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
 
 
-def _add_para(doc: Any, text: str, *, bold: bool = False) -> None:
-    p = doc.add_paragraph()
+def _reading_key(block: dict[str, Any]) -> tuple[float, float]:
+    return (_num(block.get("y")), _num(block.get("x")))
+
+
+def _theme(layout: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(layout, dict):
+        return {}
+    theme = layout.get("theme")
+    return theme if isinstance(theme, dict) else {}
+
+
+def _layout_has_pages(layout: dict | None) -> bool:
+    if not isinstance(layout, dict):
+        return False
+    pages = layout.get("pages")
+    return isinstance(pages, list) and any(
+        isinstance(p, dict) and isinstance(p.get("blocks"), list) and p.get("blocks") for p in pages
+    )
+
+
+def _iter_page_blocks(layout: dict[str, Any]) -> list[dict[str, Any]]:
+    """Blocs de contenu de la première page (export Word = page 1)."""
+    pages = layout.get("pages")
+    if not isinstance(pages, list) or not pages:
+        return []
+    page = pages[0] if isinstance(pages[0], dict) else {}
+    blocks = page.get("blocks")
+    if not isinstance(blocks, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        if str(block.get("type") or "") in CONTENT_TYPES:
+            out.append(block)
+    return out
+
+
+def _cluster_column_xs(blocks: list[dict[str, Any]]) -> list[float]:
+    xs = sorted({round(_num(b.get("x")), 1) for b in blocks})
+    if not xs:
+        return [0.0]
+    clusters = [xs[0]]
+    for x in xs[1:]:
+        if x - clusters[-1] >= COLUMN_GAP_MM:
+            clusters.append(x)
+    return clusters[:2]
+
+
+def _split_header_and_columns(
+    blocks: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Sépare bandeau pleine largeur vs colonnes gauche/droite."""
+    clusters = _cluster_column_xs(blocks)
+    if len(clusters) < 2:
+        return ([], sorted(blocks, key=_reading_key), [])
+
+    split_x = (clusters[0] + clusters[1]) / 2.0
+    header: list[dict[str, Any]] = []
+    left: list[dict[str, Any]] = []
+    right: list[dict[str, Any]] = []
+    for block in blocks:
+        x = _num(block.get("x"))
+        w = _num(block.get("w"), 20)
+        # Bandeau pleine largeur uniquement (pas les blocs sidebar qui dépassent un peu).
+        if w >= FULL_WIDTH_MIN_MM:
+            header.append(block)
+        elif x < split_x:
+            left.append(block)
+        else:
+            right.append(block)
+    header.sort(key=_reading_key)
+    left.sort(key=_reading_key)
+    right.sort(key=_reading_key)
+    return (header, left, right)
+
+
+def _sidebar_fill_hex(layout: dict[str, Any]) -> str | None:
+    theme = _theme(layout)
+    sidebar = theme.get("color_sidebar")
+    if isinstance(sidebar, str) and sidebar.strip().startswith("#"):
+        return sidebar.strip()
+    pages = layout.get("pages")
+    if not isinstance(pages, list) or not pages:
+        return None
+    page = pages[0] if isinstance(pages[0], dict) else {}
+    for block in page.get("blocks") or []:
+        if not isinstance(block, dict):
+            continue
+        if str(block.get("type") or "") != "shape":
+            continue
+        style = block.get("style") if isinstance(block.get("style"), dict) else {}
+        fill = style.get("bg") or style.get("color") or style.get("fill")
+        if not (isinstance(fill, str) and fill.strip().startswith("#")):
+            continue
+        # Bandeau gauche haut → teinte sidebar.
+        if _num(block.get("x")) < 40 and _num(block.get("h")) > 80:
+            return fill.strip()
+    return None
+
+
+def _parse_hex_color(raw: Any):
+    from docx.shared import RGBColor
+
+    if not isinstance(raw, str):
+        return None
+    s = raw.strip().lstrip("#")
+    if len(s) == 3:
+        s = "".join(ch * 2 for ch in s)
+    if len(s) != 6:
+        return None
+    try:
+        return RGBColor(int(s[0:2], 16), int(s[2:4], 16), int(s[4:6], 16))
+    except ValueError:
+        return None
+
+
+def _set_run_font(
+    run: Any,
+    *,
+    size_pt: float | None = None,
+    bold: bool | None = None,
+    italic: bool | None = None,
+    color_hex: str | None = None,
+    font_name: str | None = None,
+) -> None:
+    from docx.shared import Pt
+
+    if font_name:
+        run.font.name = font_name
+    if size_pt is not None:
+        run.font.size = Pt(max(7.0, min(size_pt, 28.0)))
+    if bold is not None:
+        run.bold = bold
+    if italic is not None:
+        run.italic = italic
+    rgb = _parse_hex_color(color_hex)
+    if rgb is not None:
+        run.font.color.rgb = rgb
+
+
+def _add_para(
+    container: Any,
+    text: str,
+    *,
+    bold: bool = False,
+    italic: bool = False,
+    size_pt: float | None = None,
+    color_hex: str | None = None,
+    font_name: str | None = None,
+    space_after_pt: float = 4,
+) -> Any:
+    from docx.shared import Pt
+
+    p = container.add_paragraph()
+    p.paragraph_format.space_after = Pt(space_after_pt)
+    p.paragraph_format.space_before = Pt(0)
     run = p.add_run(text)
-    run.bold = bold
+    _set_run_font(
+        run,
+        size_pt=size_pt,
+        bold=bold,
+        italic=italic,
+        color_hex=color_hex,
+        font_name=font_name,
+    )
+    return p
 
 
-def cv_to_docx_bytes(cv: dict | None) -> bytes:
-    """
-    Sérialise le JSON sémantique `cv` en .docx utilisable (ATS / Word).
-    Lève ValueError si le CV est vide.
-    """
+def _section_title(block: dict[str, Any], key: str, *, default_title: bool) -> str:
+    style = block.get("style") if isinstance(block.get("style"), dict) else {}
+    custom = str(style.get("section_label") or "").strip()
+    if custom:
+        return custom
+    if default_title:
+        return SECTION_LABELS.get(key, key)
+    return ""
+
+
+def _emit_section_heading(
+    container: Any,
+    title: str,
+    theme: dict[str, Any],
+    style: dict[str, Any],
+) -> None:
+    if not title:
+        return
+    accent = str(style.get("color") or theme.get("color_accent") or "#1e293b").strip() or "#1e293b"
+    font = str(style.get("font_family") or theme.get("font_heading") or "").strip() or None
+    size = _num(style.get("font_size"), 11) if style.get("font_size") is not None else 11.0
+    p = _add_para(
+        container,
+        title.upper(),
+        bold=True,
+        size_pt=size,
+        color_hex=accent,
+        font_name=font,
+        space_after_pt=2,
+    )
+    # Soulignement discret via bordure bas (approx title_style underline).
+    title_style = str(style.get("title_style") or "")
+    if title_style in {"underline-accent", "underline", "sidebar-bar"} or not title_style:
+        from docx.oxml import OxmlElement
+        from docx.oxml.ns import qn
+
+        pPr = p._p.get_or_add_pPr()
+        pBdr = OxmlElement("w:pBdr")
+        bottom = OxmlElement("w:bottom")
+        bottom.set(qn("w:val"), "single")
+        bottom.set(qn("w:sz"), "12")
+        bottom.set(qn("w:space"), "4")
+        rgb = accent.lstrip("#")
+        if len(rgb) == 3:
+            rgb = "".join(ch * 2 for ch in rgb)
+        if len(rgb) == 6:
+            bottom.set(qn("w:color"), rgb.upper())
+        pBdr.append(bottom)
+        pPr.append(pBdr)
+
+
+def _body_font(theme: dict[str, Any], style: dict[str, Any]) -> str | None:
+    name = str(
+        style.get("font_family") or theme.get("font_body") or theme.get("font_heading") or ""
+    )
+    return name.strip() or None
+
+
+def _emit_block(container: Any, cv: dict, block: dict[str, Any], theme: dict[str, Any]) -> None:
+    btype = str(block.get("type") or "")
+    style = block.get("style") if isinstance(block.get("style"), dict) else {}
+    binding = block.get("bind")
+    limit = block.get("limit")
+    body_font = _body_font(theme, style)
+    body_size = _num(style.get("font_size"), 10) if style.get("font_size") is not None else 10.0
+    body_color = str(style.get("color_body") or style.get("color") or "#1e293b")
+
+    if btype == "identity":
+        name = bind.resolve_bound_text(cv, ["prenom", "nom"])
+        title = bind.resolve_bound_text(cv, "titre_professionnel")
+        heading_font = (
+            str(style.get("font_family") or theme.get("font_heading") or "").strip() or None
+        )
+        if name:
+            _add_para(
+                container,
+                name,
+                bold=True,
+                size_pt=(
+                    _num(style.get("font_size"), 18) if style.get("font_size") is not None else 18
+                ),
+                color_hex=str(style.get("color") or theme.get("color_accent") or "#0f172a"),
+                font_name=heading_font,
+                space_after_pt=2,
+            )
+        if title:
+            if style.get("header_layout") == "inline-title" and name:
+                # Already separate lines is clearer in Word.
+                pass
+            _add_para(
+                container,
+                title,
+                size_pt=11,
+                color_hex="#475569",
+                font_name=body_font,
+                space_after_pt=6,
+            )
+        return
+
+    if btype == "contact":
+        parts = [
+            bind.resolve_bound_text(cv, "email"),
+            bind.resolve_bound_text(cv, "telephone"),
+            bind.resolve_bound_text(cv, "linkedin"),
+            bind.resolve_bound_text(cv, "ville") or _as_str(cv.get("localisation")),
+        ]
+        line = _join_nonempty([p for p in parts if p])
+        if line:
+            _add_para(
+                container,
+                line,
+                size_pt=9,
+                color_hex="#334155",
+                font_name=body_font,
+                space_after_pt=8,
+            )
+        return
+
+    if btype in {"text", "title"}:
+        content = _as_str(block.get("content"))
+        if not content:
+            return
+        is_title = btype == "title"
+        _add_para(
+            container,
+            content,
+            bold=is_title or bool(style.get("bold")),
+            italic=bool(style.get("italic")),
+            size_pt=body_size if style.get("font_size") is not None else (12 if is_title else 10),
+            color_hex=str(
+                style.get("color") or (theme.get("color_accent") if is_title else body_color)
+            ),
+            font_name=body_font,
+        )
+        return
+
+    if btype == "resume":
+        text = bind.resolve_bound_text(cv, binding if binding else "resume")
+        title = _section_title(block, "resume", default_title=False)
+        if title:
+            _emit_section_heading(container, title, theme, style)
+        if text:
+            _add_para(container, text, size_pt=body_size, color_hex=body_color, font_name=body_font)
+        return
+
+    if btype == "experiences":
+        items = bind.resolve_experiences(cv, limit if isinstance(limit, int | float) else None)
+        title = _section_title(block, "experiences", default_title=True)
+        _emit_section_heading(container, title, theme, style)
+        for exp in items:
+            ent = _as_str(exp.get("entreprise"))
+            poste = _as_str(exp.get("poste"))
+            dates = _join_nonempty(
+                [_as_str(exp.get("date_debut")), _as_str(exp.get("date_fin"))],
+                sep=" – ",
+            )
+            lieu = _as_str(exp.get("lieu"))
+            head = ent or poste
+            if head:
+                meta = _join_nonempty([dates, lieu])
+                label = f"{head}  {meta}" if meta else head
+                _add_para(
+                    container,
+                    label,
+                    bold=True,
+                    size_pt=body_size,
+                    color_hex=body_color,
+                    font_name=body_font,
+                    space_after_pt=1,
+                )
+            if poste and ent:
+                _add_para(
+                    container,
+                    poste,
+                    italic=True,
+                    size_pt=max(8.0, body_size - 1),
+                    color_hex="#64748b",
+                    font_name=body_font,
+                    space_after_pt=1,
+                )
+            for bullet in exp.get("bullet_points") or []:
+                s = _as_str(bullet)
+                if s:
+                    _add_para(
+                        container,
+                        f"• {s}",
+                        size_pt=max(8.0, body_size - 1),
+                        color_hex=body_color,
+                        font_name=body_font,
+                        space_after_pt=1,
+                    )
+        return
+
+    if btype == "formations":
+        items = bind.resolve_formations(cv, limit if isinstance(limit, int | float) else None)
+        title = _section_title(block, "formations", default_title=True)
+        _emit_section_heading(container, title, theme, style)
+        for row in items:
+            dip = _as_str(row.get("diplome"))
+            etab = _as_str(row.get("etablissement"))
+            date = _as_str(row.get("date"))
+            head = _join_nonempty([dip, etab])
+            if head and date:
+                head = f"{head} ({date})"
+            elif date and not head:
+                head = date
+            if head:
+                _add_para(
+                    container,
+                    head,
+                    bold=True,
+                    size_pt=body_size,
+                    color_hex=body_color,
+                    font_name=body_font,
+                )
+        return
+
+    if btype == "certifications":
+        items = bind.resolve_certifications(cv, limit if isinstance(limit, int | float) else None)
+        title = _section_title(block, "certifications", default_title=True)
+        _emit_section_heading(container, title, theme, style)
+        for row in items:
+            line = _join_nonempty(
+                [_as_str(row.get("nom")), _as_str(row.get("organisme")), _as_str(row.get("date"))]
+            )
+            if line:
+                _add_para(
+                    container, line, size_pt=body_size, color_hex=body_color, font_name=body_font
+                )
+        return
+
+    if btype == "projets":
+        items = bind.resolve_projets(cv, limit if isinstance(limit, int | float) else None)
+        title = _section_title(block, "projets", default_title=True)
+        _emit_section_heading(container, title, theme, style)
+        for row in items:
+            nom = _as_str(row.get("nom"))
+            desc = _as_str(row.get("description"))
+            if nom:
+                _add_para(
+                    container,
+                    nom,
+                    bold=True,
+                    size_pt=body_size,
+                    color_hex=body_color,
+                    font_name=body_font,
+                    space_after_pt=1,
+                )
+            if desc:
+                _add_para(
+                    container, desc, size_pt=body_size, color_hex=body_color, font_name=body_font
+                )
+        return
+
+    if btype == "skills":
+        items = bind.resolve_bound_string_list(cv, binding if binding else "competences.techniques")
+        title = _section_title(block, "skills", default_title=False)
+        if title:
+            _emit_section_heading(container, title, theme, style)
+        if items:
+            _add_para(
+                container,
+                ", ".join(items),
+                size_pt=body_size,
+                color_hex=body_color,
+                font_name=body_font,
+            )
+        return
+
+    if btype == "languages":
+        items = bind.resolve_langues(cv)
+        title = _section_title(block, "languages", default_title=True)
+        _emit_section_heading(container, title, theme, style)
+        labels: list[str] = []
+        for row in items:
+            label = _as_str(row.get("langue"))
+            niveau = _as_str(row.get("niveau"))
+            if niveau:
+                label = f"{label} ({niveau})"
+            if label:
+                labels.append(label)
+        if labels:
+            _add_para(
+                container,
+                ", ".join(labels),
+                size_pt=body_size,
+                color_hex=body_color,
+                font_name=body_font,
+            )
+
+
+def _set_cell_shading(cell: Any, hex_color: str) -> None:
+    from docx.oxml import OxmlElement
+    from docx.oxml.ns import qn
+
+    rgb = hex_color.strip().lstrip("#")
+    if len(rgb) == 3:
+        rgb = "".join(ch * 2 for ch in rgb)
+    if len(rgb) != 6:
+        return
+    shading = OxmlElement("w:shd")
+    shading.set(qn("w:fill"), rgb.upper())
+    shading.set(qn("w:val"), "clear")
+    cell._tc.get_or_add_tcPr().append(shading)
+
+
+def _emit_blocks(
+    container: Any, cv: dict, blocks: list[dict[str, Any]], theme: dict[str, Any]
+) -> None:
+    for block in blocks:
+        _emit_block(container, cv, block, theme)
+
+
+def _build_layout_docx(cv: dict, layout: dict[str, Any]) -> bytes:
     from docx import Document
+    from docx.shared import Cm, Pt
 
-    data = cv if isinstance(cv, dict) else {}
-    if not _has_content(data):
-        raise ValueError("empty_cv")
+    doc = Document()
+    # Marges un peu plus serrées pour coller au canvas.
+    for section in doc.sections:
+        section.top_margin = Cm(1.2)
+        section.bottom_margin = Cm(1.2)
+        section.left_margin = Cm(1.2)
+        section.right_margin = Cm(1.2)
+
+    theme = _theme(layout)
+    blocks = _iter_page_blocks(layout)
+    if not blocks:
+        # Layout vide → fallback sémantique via même document path.
+        raise ValueError("empty_layout")
+
+    header, left, right = _split_header_and_columns(blocks)
+    _emit_blocks(doc, cv, header, theme)
+
+    if left and right:
+        table = doc.add_table(rows=1, cols=2)
+        table.autofit = True
+        left_cell, right_cell = table.rows[0].cells
+        # Largeur relative ~ sidebar 35% / main 65% selon positions.
+        try:
+            left_w = max((_num(b.get("w")) for b in left), default=60)
+            right_w = max((_num(b.get("w")) for b in right), default=120)
+            total = max(left_w + right_w, 1)
+            usable = Cm(17.5)
+            left_cell.width = int(usable * (left_w / total))
+            right_cell.width = int(usable * (right_w / total))
+        except Exception:
+            pass
+
+        sidebar_hex = _sidebar_fill_hex(layout)
+        # Si la colonne gauche a plus de blocs « sidebar » (skills/languages) et x bas,
+        # teinter la cellule gauche.
+        left_is_sidebar = sum(1 for b in left if _num(b.get("x")) < 80) >= len(left) / 2
+        if sidebar_hex and left_is_sidebar:
+            _set_cell_shading(left_cell, sidebar_hex)
+
+        left_cell.text = ""
+        right_cell.text = ""
+        _emit_blocks(left_cell, cv, left, theme)
+        _emit_blocks(right_cell, cv, right, theme)
+    else:
+        single = left or right
+        _emit_blocks(doc, cv, single, theme)
+
+    # Évite un paragraphe vide orphelin excessif.
+    style = doc.styles["Normal"]
+    style.font.size = Pt(10)
+    body_name = str(theme.get("font_body") or theme.get("font_heading") or "").strip()
+    if body_name:
+        style.font.name = body_name
+
+    buf = BytesIO()
+    doc.save(buf)
+    return buf.getvalue()
+
+
+def _build_semantic_docx(cv: dict) -> bytes:
+    from docx import Document
 
     doc = Document()
 
     identity = _join_nonempty(
-        [_as_str(data.get("prenom")), _as_str(data.get("nom"))],
+        [_as_str(cv.get("prenom")), _as_str(cv.get("nom"))],
         sep=" ",
     )
     if identity:
-        _add_heading(doc, identity, level=1)
-
-    titre = _as_str(data.get("titre_professionnel"))
+        _add_para(doc, identity, bold=True, size_pt=18, space_after_pt=2)
+    titre = _as_str(cv.get("titre_professionnel"))
     if titre:
-        _add_para(doc, titre, bold=True)
+        _add_para(doc, titre, bold=True, size_pt=11, color_hex="#475569", space_after_pt=4)
 
     contact = _join_nonempty(
         [
-            _as_str(data.get("email")),
-            _as_str(data.get("telephone")),
-            _as_str(data.get("linkedin")),
-            _as_str(data.get("ville") or data.get("localisation")),
+            _as_str(cv.get("email")),
+            _as_str(cv.get("telephone")),
+            _as_str(cv.get("linkedin")),
+            _as_str(cv.get("ville") or cv.get("localisation")),
         ]
     )
     if contact:
-        _add_para(doc, contact)
+        _add_para(doc, contact, size_pt=9, color_hex="#334155", space_after_pt=8)
 
-    resume = _as_str(data.get("resume"))
+    resume = _as_str(cv.get("resume"))
     if resume:
-        _add_heading(doc, "Profil")
-        _add_para(doc, resume)
+        _add_para(doc, "PROFIL", bold=True, size_pt=11, color_hex="#1e293b", space_after_pt=2)
+        _add_para(doc, resume, size_pt=10)
 
-    experiences = data.get("experiences") or []
-    exp_rows = [row for row in experiences if isinstance(row, dict)]
-    if exp_rows:
-        _add_heading(doc, "Expériences")
-        for row in exp_rows:
+    experiences = [r for r in (cv.get("experiences") or []) if isinstance(r, dict)]
+    if experiences:
+        _add_para(doc, "EXPÉRIENCES", bold=True, size_pt=11, color_hex="#1e293b", space_after_pt=2)
+        for row in experiences:
             head = _join_nonempty([_as_str(row.get("poste")), _as_str(row.get("entreprise"))])
             dates = _join_nonempty(
                 [_as_str(row.get("date_debut")), _as_str(row.get("date_fin"))],
                 sep=" – ",
             )
-            lieu = _as_str(row.get("lieu"))
-            desc = _as_str(row.get("description") or row.get("missions"))
             if head:
                 line = head if not dates else f"{head} ({dates})"
-                _add_para(doc, line, bold=True)
-            elif dates:
-                _add_para(doc, dates, bold=True)
-            if lieu:
-                _add_para(doc, lieu)
+                _add_para(doc, line, bold=True, size_pt=10, space_after_pt=1)
+            desc = _as_str(row.get("description") or row.get("missions"))
             if desc:
-                _add_para(doc, desc)
+                _add_para(doc, desc, size_pt=9)
 
-    formations = data.get("formations") or []
-    form_rows = [row for row in formations if isinstance(row, dict)]
-    if form_rows:
-        _add_heading(doc, "Formations")
-        for row in form_rows:
+    formations = [r for r in (cv.get("formations") or []) if isinstance(r, dict)]
+    if formations:
+        _add_para(doc, "FORMATIONS", bold=True, size_pt=11, color_hex="#1e293b", space_after_pt=2)
+        for row in formations:
             head = _join_nonempty([_as_str(row.get("diplome")), _as_str(row.get("etablissement"))])
             date = _as_str(row.get("date"))
             if head:
                 line = head if not date else f"{head} ({date})"
-                _add_para(doc, line, bold=True)
-            elif date:
-                _add_para(doc, date)
+                _add_para(doc, line, bold=True, size_pt=10)
 
-    competences = data.get("competences") if isinstance(data.get("competences"), dict) else {}
+    competences = cv.get("competences") if isinstance(cv.get("competences"), dict) else {}
     tech = _list_skills(competences.get("techniques"))
     soft = _list_skills(competences.get("logiciels") or competences.get("outils"))
     autres = _list_skills(competences.get("autres"))
     if tech or soft or autres:
-        _add_heading(doc, "Compétences")
+        _add_para(doc, "COMPÉTENCES", bold=True, size_pt=11, color_hex="#1e293b", space_after_pt=2)
         if tech:
-            _add_para(doc, "Techniques : " + ", ".join(tech))
+            _add_para(doc, "Techniques : " + ", ".join(tech), size_pt=10)
         if soft:
-            _add_para(doc, "Outils : " + ", ".join(soft))
+            _add_para(doc, "Outils : " + ", ".join(soft), size_pt=10)
         if autres:
-            _add_para(doc, "Autres : " + ", ".join(autres))
+            _add_para(doc, "Autres : " + ", ".join(autres), size_pt=10)
 
     lang_lines: list[str] = []
     for row in competences.get("langues") or []:
@@ -142,40 +689,57 @@ def cv_to_docx_bytes(cv: dict | None) -> bytes:
             if s:
                 lang_lines.append(s)
     if lang_lines:
-        _add_heading(doc, "Langues")
+        _add_para(doc, "LANGUES", bold=True, size_pt=11, color_hex="#1e293b", space_after_pt=2)
         for line in lang_lines:
-            _add_para(doc, line)
+            _add_para(doc, line, size_pt=10)
 
     cert_lines: list[str] = []
-    for row in data.get("certifications") or []:
+    for row in cv.get("certifications") or []:
         if not isinstance(row, dict):
             continue
         s = _join_nonempty(
-            [
-                _as_str(row.get("nom")),
-                _as_str(row.get("organisme")),
-                _as_str(row.get("date")),
-            ]
+            [_as_str(row.get("nom")), _as_str(row.get("organisme")), _as_str(row.get("date"))]
         )
         if s:
             cert_lines.append(s)
     if cert_lines:
-        _add_heading(doc, "Certifications")
+        _add_para(
+            doc, "CERTIFICATIONS", bold=True, size_pt=11, color_hex="#1e293b", space_after_pt=2
+        )
         for line in cert_lines:
-            _add_para(doc, line)
+            _add_para(doc, line, size_pt=10)
 
-    projets = data.get("projets") or []
-    projet_rows = [row for row in projets if isinstance(row, dict)]
-    if projet_rows:
-        _add_heading(doc, "Projets")
-        for row in projet_rows:
+    projets = [r for r in (cv.get("projets") or []) if isinstance(r, dict)]
+    if projets:
+        _add_para(doc, "PROJETS", bold=True, size_pt=11, color_hex="#1e293b", space_after_pt=2)
+        for row in projets:
             head = _as_str(row.get("nom"))
             desc = _as_str(row.get("description"))
             if head:
-                _add_para(doc, head, bold=True)
+                _add_para(doc, head, bold=True, size_pt=10, space_after_pt=1)
             if desc:
-                _add_para(doc, desc)
+                _add_para(doc, desc, size_pt=9)
 
     buf = BytesIO()
     doc.save(buf)
     return buf.getvalue()
+
+
+def cv_to_docx_bytes(cv: dict | None, layout: dict | None = None) -> bytes:
+    """
+    Sérialise le CV en .docx.
+
+    Si ``layout`` free-canvas est fourni, produit un document design-aware
+    (ordre spatial, 2 colonnes, thème). Sinon, export sémantique simple.
+    Lève ValueError si le CV (et le layout) ne permettent aucun contenu.
+    """
+    data = cv if isinstance(cv, dict) else {}
+    if _layout_has_pages(layout):
+        assert isinstance(layout, dict)
+        try:
+            return _build_layout_docx(data, layout)
+        except ValueError:
+            pass
+    if not _has_content(data):
+        raise ValueError("empty_cv")
+    return _build_semantic_docx(data)

--- a/backend/services/cv_docx_export.py
+++ b/backend/services/cv_docx_export.py
@@ -1,0 +1,181 @@
+"""Export Word (.docx) d'un CV sémantique (AXE-330).
+
+Document simple mono-colonne pour ATS / édition — ne reproduit pas le layout canvas.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+from typing import Any
+
+from backend.services.cv_text_export import (
+    _as_str,
+    _join_nonempty,
+    _list_skills,
+)
+
+
+def _has_content(cv: dict) -> bool:
+    if _as_str(cv.get("prenom")) or _as_str(cv.get("nom")):
+        return True
+    if _as_str(cv.get("titre_professionnel")) or _as_str(cv.get("resume")):
+        return True
+    if _as_str(cv.get("email")) or _as_str(cv.get("telephone")):
+        return True
+    for key in ("experiences", "formations", "certifications", "projets"):
+        rows = cv.get(key)
+        if isinstance(rows, list) and any(isinstance(r, dict) and r for r in rows):
+            return True
+    competences = cv.get("competences")
+    if isinstance(competences, dict) and competences:
+        return True
+    return False
+
+
+def _add_heading(doc: Any, text: str, level: int = 2) -> None:
+    doc.add_heading(text, level=level)
+
+
+def _add_para(doc: Any, text: str, *, bold: bool = False) -> None:
+    p = doc.add_paragraph()
+    run = p.add_run(text)
+    run.bold = bold
+
+
+def cv_to_docx_bytes(cv: dict | None) -> bytes:
+    """
+    Sérialise le JSON sémantique `cv` en .docx utilisable (ATS / Word).
+    Lève ValueError si le CV est vide.
+    """
+    from docx import Document
+
+    data = cv if isinstance(cv, dict) else {}
+    if not _has_content(data):
+        raise ValueError("empty_cv")
+
+    doc = Document()
+
+    identity = _join_nonempty(
+        [_as_str(data.get("prenom")), _as_str(data.get("nom"))],
+        sep=" ",
+    )
+    if identity:
+        _add_heading(doc, identity, level=1)
+
+    titre = _as_str(data.get("titre_professionnel"))
+    if titre:
+        _add_para(doc, titre, bold=True)
+
+    contact = _join_nonempty(
+        [
+            _as_str(data.get("email")),
+            _as_str(data.get("telephone")),
+            _as_str(data.get("linkedin")),
+            _as_str(data.get("ville") or data.get("localisation")),
+        ]
+    )
+    if contact:
+        _add_para(doc, contact)
+
+    resume = _as_str(data.get("resume"))
+    if resume:
+        _add_heading(doc, "Profil")
+        _add_para(doc, resume)
+
+    experiences = data.get("experiences") or []
+    exp_rows = [row for row in experiences if isinstance(row, dict)]
+    if exp_rows:
+        _add_heading(doc, "Expériences")
+        for row in exp_rows:
+            head = _join_nonempty([_as_str(row.get("poste")), _as_str(row.get("entreprise"))])
+            dates = _join_nonempty(
+                [_as_str(row.get("date_debut")), _as_str(row.get("date_fin"))],
+                sep=" – ",
+            )
+            lieu = _as_str(row.get("lieu"))
+            desc = _as_str(row.get("description") or row.get("missions"))
+            if head:
+                line = head if not dates else f"{head} ({dates})"
+                _add_para(doc, line, bold=True)
+            elif dates:
+                _add_para(doc, dates, bold=True)
+            if lieu:
+                _add_para(doc, lieu)
+            if desc:
+                _add_para(doc, desc)
+
+    formations = data.get("formations") or []
+    form_rows = [row for row in formations if isinstance(row, dict)]
+    if form_rows:
+        _add_heading(doc, "Formations")
+        for row in form_rows:
+            head = _join_nonempty([_as_str(row.get("diplome")), _as_str(row.get("etablissement"))])
+            date = _as_str(row.get("date"))
+            if head:
+                line = head if not date else f"{head} ({date})"
+                _add_para(doc, line, bold=True)
+            elif date:
+                _add_para(doc, date)
+
+    competences = data.get("competences") if isinstance(data.get("competences"), dict) else {}
+    tech = _list_skills(competences.get("techniques"))
+    soft = _list_skills(competences.get("logiciels") or competences.get("outils"))
+    autres = _list_skills(competences.get("autres"))
+    if tech or soft or autres:
+        _add_heading(doc, "Compétences")
+        if tech:
+            _add_para(doc, "Techniques : " + ", ".join(tech))
+        if soft:
+            _add_para(doc, "Outils : " + ", ".join(soft))
+        if autres:
+            _add_para(doc, "Autres : " + ", ".join(autres))
+
+    lang_lines: list[str] = []
+    for row in competences.get("langues") or []:
+        if isinstance(row, str):
+            s = row.strip()
+            if s:
+                lang_lines.append(s)
+            continue
+        if isinstance(row, dict):
+            s = _join_nonempty([_as_str(row.get("langue")), _as_str(row.get("niveau"))])
+            if s:
+                lang_lines.append(s)
+    if lang_lines:
+        _add_heading(doc, "Langues")
+        for line in lang_lines:
+            _add_para(doc, line)
+
+    cert_lines: list[str] = []
+    for row in data.get("certifications") or []:
+        if not isinstance(row, dict):
+            continue
+        s = _join_nonempty(
+            [
+                _as_str(row.get("nom")),
+                _as_str(row.get("organisme")),
+                _as_str(row.get("date")),
+            ]
+        )
+        if s:
+            cert_lines.append(s)
+    if cert_lines:
+        _add_heading(doc, "Certifications")
+        for line in cert_lines:
+            _add_para(doc, line)
+
+    projets = data.get("projets") or []
+    projet_rows = [row for row in projets if isinstance(row, dict)]
+    if projet_rows:
+        _add_heading(doc, "Projets")
+        for row in projet_rows:
+            head = _as_str(row.get("nom"))
+            desc = _as_str(row.get("description"))
+            if head:
+                _add_para(doc, head, bold=True)
+            if desc:
+                _add_para(doc, desc)
+
+    buf = BytesIO()
+    doc.save(buf)
+    return buf.getvalue()

--- a/backend/services/cv_text_export.py
+++ b/backend/services/cv_text_export.py
@@ -27,10 +27,7 @@ def _list_skills(value: Any) -> list[str]:
             continue
         if isinstance(item, dict):
             s = _as_str(
-                item.get("name")
-                or item.get("label")
-                or item.get("value")
-                or item.get("text")
+                item.get("name") or item.get("label") or item.get("value") or item.get("text")
             )
             if s:
                 out.append(s)
@@ -107,9 +104,7 @@ def cv_to_plain_text(cv: dict | None) -> str:
     for row in data.get("formations") or []:
         if not isinstance(row, dict):
             continue
-        head = _join_nonempty(
-            [_as_str(row.get("diplome")), _as_str(row.get("etablissement"))]
-        )
+        head = _join_nonempty([_as_str(row.get("diplome")), _as_str(row.get("etablissement"))])
         date = _as_str(row.get("date"))
         block = [x for x in (head, date) if x]
         if block:

--- a/backend/services/cv_text_export.py
+++ b/backend/services/cv_text_export.py
@@ -1,0 +1,178 @@
+"""Export texte brut d'un CV sémantique (AXE-330)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _as_str(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _join_nonempty(parts: list[str], sep: str = " · ") -> str:
+    return sep.join(p for p in parts if p)
+
+
+def _list_skills(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for item in value:
+        if isinstance(item, str):
+            s = item.strip()
+            if s:
+                out.append(s)
+            continue
+        if isinstance(item, dict):
+            s = _as_str(
+                item.get("name")
+                or item.get("label")
+                or item.get("value")
+                or item.get("text")
+            )
+            if s:
+                out.append(s)
+    return out
+
+
+def _section(title: str, lines: list[str]) -> list[str]:
+    body = [line for line in lines if line]
+    if not body:
+        return []
+    return ["", title.upper(), "-" * len(title), *body]
+
+
+def cv_to_plain_text(cv: dict | None) -> str:
+    """
+    Sérialise le JSON sémantique `cv` en texte lisible (ATS / collage).
+    Ne tente pas de reproduire le layout canvas.
+    """
+    data = cv if isinstance(cv, dict) else {}
+    lines: list[str] = []
+
+    identity = _join_nonempty(
+        [
+            _as_str(data.get("prenom")),
+            _as_str(data.get("nom")),
+        ],
+        sep=" ",
+    )
+    if identity:
+        lines.append(identity)
+    titre = _as_str(data.get("titre_professionnel"))
+    if titre:
+        lines.append(titre)
+
+    contact = _join_nonempty(
+        [
+            _as_str(data.get("email")),
+            _as_str(data.get("telephone")),
+            _as_str(data.get("linkedin")),
+            _as_str(data.get("ville") or data.get("localisation")),
+        ]
+    )
+    if contact:
+        lines.append(contact)
+
+    resume = _as_str(data.get("resume"))
+    lines.extend(_section("Profil", [resume] if resume else []))
+
+    exp_lines: list[str] = []
+    for row in data.get("experiences") or []:
+        if not isinstance(row, dict):
+            continue
+        head = _join_nonempty(
+            [
+                _as_str(row.get("poste")),
+                _as_str(row.get("entreprise")),
+            ]
+        )
+        dates = _join_nonempty(
+            [_as_str(row.get("date_debut")), _as_str(row.get("date_fin"))],
+            sep=" – ",
+        )
+        lieu = _as_str(row.get("lieu"))
+        desc = _as_str(row.get("description") or row.get("missions"))
+        block = [x for x in (head, dates, lieu, desc) if x]
+        if block:
+            exp_lines.extend(block)
+            exp_lines.append("")
+    if exp_lines and not exp_lines[-1]:
+        exp_lines.pop()
+    lines.extend(_section("Expériences", exp_lines))
+
+    form_lines: list[str] = []
+    for row in data.get("formations") or []:
+        if not isinstance(row, dict):
+            continue
+        head = _join_nonempty(
+            [_as_str(row.get("diplome")), _as_str(row.get("etablissement"))]
+        )
+        date = _as_str(row.get("date"))
+        block = [x for x in (head, date) if x]
+        if block:
+            form_lines.extend(block)
+            form_lines.append("")
+    if form_lines and not form_lines[-1]:
+        form_lines.pop()
+    lines.extend(_section("Formations", form_lines))
+
+    competences = data.get("competences") if isinstance(data.get("competences"), dict) else {}
+    tech = _list_skills(competences.get("techniques"))
+    soft = _list_skills(competences.get("logiciels") or competences.get("outils"))
+    autres = _list_skills(competences.get("autres"))
+    skill_lines: list[str] = []
+    if tech:
+        skill_lines.append("Techniques : " + ", ".join(tech))
+    if soft:
+        skill_lines.append("Outils : " + ", ".join(soft))
+    if autres:
+        skill_lines.append("Autres : " + ", ".join(autres))
+    lines.extend(_section("Compétences", skill_lines))
+
+    lang_lines: list[str] = []
+    for row in competences.get("langues") or []:
+        if isinstance(row, str):
+            s = row.strip()
+            if s:
+                lang_lines.append(s)
+            continue
+        if isinstance(row, dict):
+            s = _join_nonempty([_as_str(row.get("langue")), _as_str(row.get("niveau"))])
+            if s:
+                lang_lines.append(s)
+    lines.extend(_section("Langues", lang_lines))
+
+    cert_lines: list[str] = []
+    for row in data.get("certifications") or []:
+        if not isinstance(row, dict):
+            continue
+        s = _join_nonempty(
+            [
+                _as_str(row.get("nom")),
+                _as_str(row.get("organisme")),
+                _as_str(row.get("date")),
+            ]
+        )
+        if s:
+            cert_lines.append(s)
+    lines.extend(_section("Certifications", cert_lines))
+
+    projet_lines: list[str] = []
+    for row in data.get("projets") or []:
+        if not isinstance(row, dict):
+            continue
+        head = _as_str(row.get("nom"))
+        desc = _as_str(row.get("description"))
+        block = [x for x in (head, desc) if x]
+        if block:
+            projet_lines.extend(block)
+            projet_lines.append("")
+    if projet_lines and not projet_lines[-1]:
+        projet_lines.pop()
+    lines.extend(_section("Projets", projet_lines))
+
+    text = "\n".join(lines).strip()
+    return text + ("\n" if text else "")

--- a/backend/services/cv_text_export.py
+++ b/backend/services/cv_text_export.py
@@ -92,7 +92,13 @@ def cv_to_plain_text(cv: dict | None) -> str:
         )
         lieu = _as_str(row.get("lieu"))
         desc = _as_str(row.get("description") or row.get("missions"))
-        block = [x for x in (head, dates, lieu, desc) if x]
+        raw_bullets = row.get("bullet_points")
+        bullets = (
+            [f"- {item.strip()}" for item in raw_bullets if isinstance(item, str) and item.strip()]
+            if isinstance(raw_bullets, list)
+            else []
+        )
+        block = [x for x in (head, dates, lieu, desc, *bullets) if x]
         if block:
             exp_lines.extend(block)
             exp_lines.append("")

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -142,8 +142,6 @@ import {
 import '../../styles/HeaderComposerModal.css';
 
 import {
-  buildCanvasPdfFilename,
-  formatPdfExportError,
   sameLayout,
   blockSupportsEditHint,
   dismissCanvasEditHint,
@@ -152,6 +150,11 @@ import {
   isCanvasEditHintDismissed,
   isSemanticEditNoteDismissed,
 } from '../../lib/canvasEditorUtils.js';
+import {
+  CANVAS_EXPORT_FORMATS,
+  buildCanvasExportFilename,
+  formatCanvasExportError,
+} from '../../lib/canvasExportFormats.js';
 import {
   dismissEditorOnboarding,
   isEditorOnboardingDismissed,
@@ -209,6 +212,8 @@ function CvEditorBeta({
   const [startupPromptOpen, setStartupPromptOpen] = useState(false);
   const [onboardingDismissed, setOnboardingDismissed] = useState(() => isEditorOnboardingDismissed());
   const [pdfExportError, setPdfExportError] = useState('');
+  const [exportMenuOpen, setExportMenuOpen] = useState(false);
+  const exportMenuRef = useRef(null);
   const [atsOptimizeMessage, setAtsOptimizeMessage] = useState('');
   const [atsOptimizePreview, setAtsOptimizePreview] = useState(null);
   const [atsOptimizePreviewLoading, setAtsOptimizePreviewLoading] = useState(false);
@@ -1596,30 +1601,49 @@ function CvEditorBeta({
     }
   }, [layout, atsOptimizeUndoAfter]);
 
-  const handleExportLayoutPdf = useCallback(async () => {
+  const handleExportFormat = useCallback(async (format) => {
     if (!cv || !layout || pdfExporting) return;
+    setExportMenuOpen(false);
     setPdfExporting(true);
     setPdfExportError('');
     const preopenedWindow = prepareAppleDownloadWindow();
     try {
-      const { blob, filename } = await apiPostBlob('/api/pdf', {
+      const { blob, filename } = await apiPostBlob('/api/cv-export', {
         cv,
         template_id: templateId,
         layout,
+        format,
       });
       await saveBlobWithPreferredMethod(
         blob,
-        filename || buildCanvasPdfFilename(cv),
+        filename || buildCanvasExportFilename(cv, format),
         { preopenedWindow },
       );
     } catch (err) {
       if (preopenedWindow && !preopenedWindow.closed) preopenedWindow.close();
-      console.error('[cv-editor-beta] export PDF layout', err);
-      setPdfExportError(formatPdfExportError(err, getDownloadPermissionHint()));
+      console.error(`[cv-editor-beta] export ${format}`, err);
+      setPdfExportError(formatCanvasExportError(err, getDownloadPermissionHint(), format));
     } finally {
       setPdfExporting(false);
     }
   }, [cv, layout, templateId, pdfExporting]);
+
+  useEffect(() => {
+    if (!exportMenuOpen) return undefined;
+    const onPointerDown = (event) => {
+      const root = exportMenuRef.current;
+      if (root && !root.contains(event.target)) setExportMenuOpen(false);
+    };
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') setExportMenuOpen(false);
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [exportMenuOpen]);
 
   const handleSaveLayoutProposal = useCallback((name) => {
     if (!layout) return;
@@ -1887,15 +1911,36 @@ function CvEditorBeta({
               {atsOptimizePreviewLoading ? 'Analyse ATS…' : 'Optimiser ATS'}
             </button>
           </div>
-          <button
-            type="button"
-            className="cv-editor-beta-history-btn"
-            onClick={handleExportLayoutPdf}
-            disabled={loading || !layout || pdfExporting}
-            title="Télécharger le CV Canva en PDF"
-          >
-            {pdfExporting ? 'Téléchargement…' : 'Télécharger'}
-          </button>
+          <div className="cv-editor-beta-export-wrap" ref={exportMenuRef}>
+            <button
+              type="button"
+              className="cv-editor-beta-history-btn"
+              onClick={() => setExportMenuOpen((open) => !open)}
+              disabled={loading || !layout || pdfExporting}
+              aria-expanded={exportMenuOpen}
+              aria-haspopup="menu"
+              title="Télécharger le CV (PDF, HTML ou TXT)"
+            >
+              {pdfExporting ? 'Téléchargement…' : 'Télécharger'}
+            </button>
+            {exportMenuOpen && (
+              <div className="cv-editor-beta-export-menu" role="menu" aria-label="Formats d’export">
+                {CANVAS_EXPORT_FORMATS.map((item) => (
+                  <button
+                    key={item.id}
+                    type="button"
+                    role="menuitem"
+                    className="cv-editor-beta-export-menu__item"
+                    disabled={pdfExporting}
+                    onClick={() => handleExportFormat(item.id)}
+                  >
+                    <span className="cv-editor-beta-export-menu__label">{item.label}</span>
+                    <span className="cv-editor-beta-export-menu__hint">{item.hint}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       </header>
 

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -121,6 +121,7 @@ import EditorFloatingTextToolbar from './EditorFloatingTextToolbar.jsx';
 import EditorImageEditPopover from './EditorImageEditPopover.jsx';
 import EditorCanvaTransferModal from './EditorCanvaTransferModal.jsx';
 import DesignModeBridgeModal from './DesignModeBridgeModal.jsx';
+import DocxExportNoticeModal from './DocxExportNoticeModal.jsx';
 import EditorCvImportModal from './EditorCvImportModal.jsx';
 import EditorOnboardingTour from './EditorOnboardingTour.jsx';
 import HeaderComposerModal from './HeaderComposerModal.jsx';
@@ -153,7 +154,9 @@ import {
 import {
   CANVAS_EXPORT_FORMATS,
   buildCanvasExportFilename,
+  dismissDocxFidelityNotice,
   formatCanvasExportError,
+  isDocxFidelityNoticeDismissed,
 } from '../../lib/canvasExportFormats.js';
 import {
   dismissEditorOnboarding,
@@ -213,6 +216,7 @@ function CvEditorBeta({
   const [onboardingDismissed, setOnboardingDismissed] = useState(() => isEditorOnboardingDismissed());
   const [pdfExportError, setPdfExportError] = useState('');
   const [exportMenuOpen, setExportMenuOpen] = useState(false);
+  const [docxNoticeOpen, setDocxNoticeOpen] = useState(false);
   const exportMenuRef = useRef(null);
   const [atsOptimizeMessage, setAtsOptimizeMessage] = useState('');
   const [atsOptimizePreview, setAtsOptimizePreview] = useState(null);
@@ -1604,6 +1608,7 @@ function CvEditorBeta({
   const handleExportFormat = useCallback(async (format) => {
     if (!cv || !layout || pdfExporting) return;
     setExportMenuOpen(false);
+    setDocxNoticeOpen(false);
     setPdfExporting(true);
     setPdfExportError('');
     const preopenedWindow = prepareAppleDownloadWindow();
@@ -1627,6 +1632,26 @@ function CvEditorBeta({
       setPdfExporting(false);
     }
   }, [cv, layout, templateId, pdfExporting]);
+
+  const requestExportFormat = useCallback((format) => {
+    if (!cv || !layout || pdfExporting) return;
+    setExportMenuOpen(false);
+    if (format === 'docx' && !isDocxFidelityNoticeDismissed()) {
+      setDocxNoticeOpen(true);
+      return;
+    }
+    void handleExportFormat(format);
+  }, [cv, layout, pdfExporting, handleExportFormat]);
+
+  const handleConfirmDocxNotice = useCallback(({ dontShowAgain = false } = {}) => {
+    if (dontShowAgain) dismissDocxFidelityNotice();
+    setDocxNoticeOpen(false);
+    void handleExportFormat('docx');
+  }, [handleExportFormat]);
+
+  const handleCancelDocxNotice = useCallback(() => {
+    setDocxNoticeOpen(false);
+  }, []);
 
   useEffect(() => {
     if (!exportMenuOpen) return undefined;
@@ -1936,7 +1961,7 @@ function CvEditorBeta({
                     role="menuitem"
                     className="cv-editor-beta-export-menu__item"
                     disabled={pdfExporting}
-                    onClick={() => handleExportFormat(item.id)}
+                    onClick={() => requestExportFormat(item.id)}
                   >
                     <span className="cv-editor-beta-export-menu__label">{item.label}</span>
                     <span className="cv-editor-beta-export-menu__hint">{item.hint}</span>
@@ -2318,6 +2343,11 @@ function CvEditorBeta({
                 onDismiss={handleDismissDesignBridge}
               />
             )}
+            <DocxExportNoticeModal
+              open={docxNoticeOpen}
+              onConfirm={handleConfirmDocxNotice}
+              onCancel={handleCancelDocxNotice}
+            />
             {transferRequest && (
               <EditorCanvaTransferModal
                 request={transferRequest}

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -1919,7 +1919,7 @@ function CvEditorBeta({
               disabled={loading || !layout || pdfExporting}
               aria-expanded={exportMenuOpen}
               aria-haspopup="menu"
-              title="Télécharger le CV (PDF, HTML ou TXT)"
+              title="Télécharger le CV (PDF, Word, HTML ou TXT)"
             >
               {pdfExporting ? 'Téléchargement…' : 'Télécharger'}
             </button>

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -1635,13 +1635,17 @@ function CvEditorBeta({
       if (root && !root.contains(event.target)) setExportMenuOpen(false);
     };
     const onKeyDown = (event) => {
-      if (event.key === 'Escape') setExportMenuOpen(false);
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      // Empêche le handler canvas (window) de vider la sélection en même temps.
+      event.stopPropagation();
+      setExportMenuOpen(false);
     };
     document.addEventListener('pointerdown', onPointerDown);
-    document.addEventListener('keydown', onKeyDown);
+    document.addEventListener('keydown', onKeyDown, true);
     return () => {
       document.removeEventListener('pointerdown', onPointerDown);
-      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('keydown', onKeyDown, true);
     };
   }, [exportMenuOpen]);
 

--- a/frontend/src/components/editor/DocxExportNoticeModal.jsx
+++ b/frontend/src/components/editor/DocxExportNoticeModal.jsx
@@ -1,0 +1,89 @@
+import { useEffect, useId, useRef, useState } from 'react';
+
+import '../../styles/DocxExportNoticeModal.css';
+
+/**
+ * Mini pop-up avant export Word : la mise en page n’est pas identique au canvas.
+ */
+export default function DocxExportNoticeModal({
+  open = false,
+  onConfirm,
+  onCancel,
+}) {
+  const titleId = useId();
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+  const checkboxId = useId();
+  const primaryRef = useRef(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    setDontShowAgain(false);
+    const t = window.setTimeout(() => primaryRef.current?.focus?.(), 0);
+    const onKeyDown = (event) => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      event.stopPropagation();
+      onCancel?.();
+    };
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => {
+      window.clearTimeout(t);
+      document.removeEventListener('keydown', onKeyDown, true);
+    };
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="docx-export-notice-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+    >
+      <div className="docx-export-notice-modal__card">
+        <header className="docx-export-notice-modal__head">
+          <div>
+            <span className="docx-export-notice-modal__eyebrow">Export Word</span>
+            <h3 id={titleId}>Ce n’est pas une copie exacte du canvas</h3>
+          </div>
+          <button
+            type="button"
+            className="docx-export-notice-modal__close"
+            onClick={() => onCancel?.()}
+            aria-label="Fermer"
+          >
+            ×
+          </button>
+        </header>
+        <p className="docx-export-notice-modal__copy">
+          Word reprend le contenu, l’ordre des sections et une mise en page
+          approximative (colonnes, titres, couleurs du thème). Le PDF reste la
+          référence visuelle fidèle.
+        </p>
+        <label className="docx-export-notice-modal__check" htmlFor={checkboxId}>
+          <input
+            id={checkboxId}
+            type="checkbox"
+            checked={dontShowAgain}
+            onChange={(event) => setDontShowAgain(event.target.checked)}
+          />
+          Ne plus afficher ce message
+        </label>
+        <footer className="docx-export-notice-modal__actions">
+          <button type="button" onClick={() => onCancel?.()}>
+            Annuler
+          </button>
+          <button
+            ref={primaryRef}
+            type="button"
+            className="docx-export-notice-modal__primary"
+            onClick={() => onConfirm?.({ dontShowAgain })}
+          >
+            Télécharger Word
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/canvasExportFormats.js
+++ b/frontend/src/lib/canvasExportFormats.js
@@ -4,6 +4,8 @@
 
 /** @typedef {'pdf'|'html'|'txt'|'docx'} CanvasExportFormat */
 
+export const DOCX_FIDELITY_NOTICE_DISMISSED_KEY = 'cv_beta_docx_fidelity_notice_dismissed';
+
 /** @type {ReadonlyArray<{ id: CanvasExportFormat, label: string, hint: string }>} */
 export const CANVAS_EXPORT_FORMATS = Object.freeze([
   {
@@ -34,6 +36,28 @@ export const CANVAS_EXPORT_FORMATS = Object.freeze([
  */
 export function isCanvasExportFormat(format) {
   return CANVAS_EXPORT_FORMATS.some((item) => item.id === format);
+}
+
+/**
+ * @returns {boolean}
+ */
+export function isDocxFidelityNoticeDismissed() {
+  try {
+    return localStorage.getItem(DOCX_FIDELITY_NOTICE_DISMISSED_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Mémorise le choix « ne plus afficher » pour l’avertissement Word.
+ */
+export function dismissDocxFidelityNotice() {
+  try {
+    localStorage.setItem(DOCX_FIDELITY_NOTICE_DISMISSED_KEY, '1');
+  } catch {
+    /* ignore quota / mode privé */
+  }
 }
 
 /**

--- a/frontend/src/lib/canvasExportFormats.js
+++ b/frontend/src/lib/canvasExportFormats.js
@@ -14,7 +14,7 @@ export const CANVAS_EXPORT_FORMATS = Object.freeze([
   {
     id: 'docx',
     label: 'Word',
-    hint: 'Contenu sémantique éditable (.docx) — idéal ATS',
+    hint: 'Mise en page approximative (colonnes + thème) — éditable / ATS',
   },
   {
     id: 'html',

--- a/frontend/src/lib/canvasExportFormats.js
+++ b/frontend/src/lib/canvasExportFormats.js
@@ -2,7 +2,7 @@
  * Formats d’export éditeur Beta (AXE-330).
  */
 
-/** @typedef {'pdf'|'html'|'txt'} CanvasExportFormat */
+/** @typedef {'pdf'|'html'|'txt'|'docx'} CanvasExportFormat */
 
 /** @type {ReadonlyArray<{ id: CanvasExportFormat, label: string, hint: string }>} */
 export const CANVAS_EXPORT_FORMATS = Object.freeze([
@@ -10,6 +10,11 @@ export const CANVAS_EXPORT_FORMATS = Object.freeze([
     id: 'pdf',
     label: 'PDF',
     hint: 'Mise en page fidèle — format principal',
+  },
+  {
+    id: 'docx',
+    label: 'Word',
+    hint: 'Contenu sémantique éditable (.docx) — idéal ATS',
   },
   {
     id: 'html',
@@ -43,7 +48,13 @@ export function buildCanvasExportFilename(cv, format) {
   const title = String(cv?.titre_professionnel || '').trim();
   const parts = ['CV', identity, title].filter(Boolean);
   const base = parts.join(' - ') || 'CV';
-  const ext = format === 'html' ? 'html' : format === 'txt' ? 'txt' : 'pdf';
+  const extByFormat = {
+    html: 'html',
+    txt: 'txt',
+    docx: 'docx',
+    pdf: 'pdf',
+  };
+  const ext = extByFormat[format] || 'pdf';
   return `${base}.${ext}`;
 }
 

--- a/frontend/src/lib/canvasExportFormats.js
+++ b/frontend/src/lib/canvasExportFormats.js
@@ -1,0 +1,61 @@
+/**
+ * Formats d’export éditeur Beta (AXE-330).
+ */
+
+/** @typedef {'pdf'|'html'|'txt'} CanvasExportFormat */
+
+/** @type {ReadonlyArray<{ id: CanvasExportFormat, label: string, hint: string }>} */
+export const CANVAS_EXPORT_FORMATS = Object.freeze([
+  {
+    id: 'pdf',
+    label: 'PDF',
+    hint: 'Mise en page fidèle — format principal',
+  },
+  {
+    id: 'html',
+    label: 'HTML',
+    hint: 'Snapshot web du canvas (même rendu que le PDF)',
+  },
+  {
+    id: 'txt',
+    label: 'TXT',
+    hint: 'Contenu sémantique brut (ATS / collage) — pas le layout',
+  },
+]);
+
+/**
+ * @param {string} format
+ * @returns {format is CanvasExportFormat}
+ */
+export function isCanvasExportFormat(format) {
+  return CANVAS_EXPORT_FORMATS.some((item) => item.id === format);
+}
+
+/**
+ * @param {unknown} cv
+ * @param {CanvasExportFormat} format
+ */
+export function buildCanvasExportFilename(cv, format) {
+  const identity = [cv?.prenom, cv?.nom]
+    .map((part) => String(part || '').trim())
+    .filter(Boolean)
+    .join(' ');
+  const title = String(cv?.titre_professionnel || '').trim();
+  const parts = ['CV', identity, title].filter(Boolean);
+  const base = parts.join(' - ') || 'CV';
+  const ext = format === 'html' ? 'html' : format === 'txt' ? 'txt' : 'pdf';
+  return `${base}.${ext}`;
+}
+
+/**
+ * @param {unknown} err
+ * @param {string} [hint]
+ * @param {string} [format]
+ */
+export function formatCanvasExportError(err, hint = '', format = '') {
+  const base =
+    err && typeof err === 'object' && typeof err.message === 'string' && err.message
+      ? err.message
+      : `Impossible de télécharger${format ? ` le ${String(format).toUpperCase()}` : ''}.`;
+  return `${base}${hint || ''}`;
+}

--- a/frontend/src/lib/settingsLocalData.js
+++ b/frontend/src/lib/settingsLocalData.js
@@ -6,6 +6,7 @@ import {
   CANVAS_EDIT_HINT_DISMISSED_KEY,
   SEMANTIC_EDIT_NOTE_DISMISSED_KEY,
 } from './canvasEditorUtils.js';
+import { DOCX_FIDELITY_NOTICE_DISMISSED_KEY } from './canvasExportFormats.js';
 
 const DRAFTS_KEY = 'cv_canvas_layout_drafts_v1';
 const DRAFT_PREFS_KEY = 'cv_canvas_layout_draft_prefs_v1';
@@ -36,6 +37,7 @@ export function resetEditorHints() {
   try {
     localStorage.removeItem(CANVAS_EDIT_HINT_DISMISSED_KEY);
     localStorage.removeItem(SEMANTIC_EDIT_NOTE_DISMISSED_KEY);
+    localStorage.removeItem(DOCX_FIDELITY_NOTICE_DISMISSED_KEY);
     return true;
   } catch {
     return false;

--- a/frontend/src/styles/CvEditorBeta.css
+++ b/frontend/src/styles/CvEditorBeta.css
@@ -164,6 +164,65 @@
   cursor: not-allowed;
 }
 
+.cv-editor-beta-export-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.cv-editor-beta-export-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 30;
+  min-width: 240px;
+  padding: 6px;
+  background: var(--color-canvas);
+  border: 1px solid var(--color-hairline);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.cv-editor-beta-export-menu__item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  border-radius: 8px;
+  padding: 8px 10px;
+  text-align: left;
+  cursor: pointer;
+  font-family: var(--editor-font-family);
+  color: var(--color-ink);
+}
+
+.cv-editor-beta-export-menu__item:hover:not(:disabled),
+.cv-editor-beta-export-menu__item:focus-visible {
+  background: var(--color-soft-stone);
+  outline: none;
+}
+
+.cv-editor-beta-export-menu__item:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.cv-editor-beta-export-menu__label {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.cv-editor-beta-export-menu__hint {
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--color-body-muted);
+}
+
 .cv-editor-beta-delete-block-btn {
   border-color: #fecaca;
   color: var(--color-error);

--- a/frontend/src/styles/CvEditorBeta.css
+++ b/frontend/src/styles/CvEditorBeta.css
@@ -200,10 +200,14 @@
   color: var(--color-ink);
 }
 
-.cv-editor-beta-export-menu__item:hover:not(:disabled),
+.cv-editor-beta-export-menu__item:hover:not(:disabled) {
+  background: var(--color-soft-stone);
+}
+
 .cv-editor-beta-export-menu__item:focus-visible {
   background: var(--color-soft-stone);
-  outline: none;
+  outline: 2px solid var(--color-focus-blue);
+  outline-offset: 2px;
 }
 
 .cv-editor-beta-export-menu__item:disabled {

--- a/frontend/src/styles/DocxExportNoticeModal.css
+++ b/frontend/src/styles/DocxExportNoticeModal.css
@@ -1,0 +1,109 @@
+.docx-export-notice-modal {
+  position: absolute;
+  inset: 0;
+  z-index: 44;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 72px 24px 24px;
+  background: rgba(7, 24, 41, 0.2);
+}
+
+.docx-export-notice-modal__card {
+  width: min(400px, 100%);
+  padding: 16px;
+  background: var(--color-canvas, #ffffff);
+  border: 1px solid var(--color-hairline, #d9d9dd);
+  border-radius: 16px;
+}
+
+.docx-export-notice-modal__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.docx-export-notice-modal__eyebrow {
+  display: block;
+  margin-bottom: 4px;
+  font-family: CohereMono, Arial, ui-sans-serif, system-ui, sans-serif;
+  font-size: 12px;
+  font-weight: 400;
+  letter-spacing: 0.28px;
+  text-transform: uppercase;
+  color: var(--color-muted, #93939f);
+}
+
+.docx-export-notice-modal__head h3 {
+  margin: 0;
+  font-family: Unica77, Inter, ui-sans-serif, system-ui, sans-serif;
+  font-size: 24px;
+  font-weight: 400;
+  line-height: 1.3;
+  color: var(--color-ink, #212121);
+}
+
+.docx-export-notice-modal__close {
+  border: 0;
+  background: transparent;
+  color: var(--color-slate, #75758a);
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+}
+
+.docx-export-notice-modal__copy {
+  margin: 12px 0 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: var(--color-body-muted, #616161);
+}
+
+.docx-export-notice-modal__check {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-top: 14px;
+  font-size: 14px;
+  line-height: 1.4;
+  color: var(--color-ink, #212121);
+  cursor: pointer;
+}
+
+.docx-export-notice-modal__check input {
+  margin-top: 2px;
+  accent-color: var(--color-primary, #17171c);
+}
+
+.docx-export-notice-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.docx-export-notice-modal__actions button {
+  border: 1px solid var(--color-primary, #17171c);
+  background: transparent;
+  color: var(--color-primary, #17171c);
+  border-radius: 32px;
+  padding: 8px 16px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.docx-export-notice-modal__primary {
+  background: var(--color-primary, #17171c) !important;
+  color: var(--color-on-dark, #ffffff) !important;
+  border-color: var(--color-primary, #17171c) !important;
+}
+
+.docx-export-notice-modal__primary:focus-visible,
+.docx-export-notice-modal__actions button:focus-visible,
+.docx-export-notice-modal__close:focus-visible {
+  outline: 2px solid var(--color-focus-blue, #4c6ee6);
+  outline-offset: 2px;
+}

--- a/frontend/tests/unit/canvasExportFormats.test.js
+++ b/frontend/tests/unit/canvasExportFormats.test.js
@@ -2,15 +2,32 @@
  * Tests formats d’export canvas (AXE-330).
  */
 
-import { test } from 'node:test';
+import { test, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
   CANVAS_EXPORT_FORMATS,
+  DOCX_FIDELITY_NOTICE_DISMISSED_KEY,
   buildCanvasExportFilename,
+  dismissDocxFidelityNotice,
   formatCanvasExportError,
   isCanvasExportFormat,
+  isDocxFidelityNoticeDismissed,
 } from '../../src/lib/canvasExportFormats.js';
+
+function installLocalStorage() {
+  const store = new Map();
+  globalThis.localStorage = {
+    getItem: (key) => (store.has(key) ? store.get(key) : null),
+    setItem: (key, value) => store.set(key, String(value)),
+    removeItem: (key) => store.delete(key),
+    clear: () => store.clear(),
+  };
+}
+
+beforeEach(() => {
+  installLocalStorage();
+});
 
 test('exposes pdf docx html txt', () => {
   assert.deepEqual(
@@ -36,4 +53,11 @@ test('formatCanvasExportError keeps API message', () => {
     formatCanvasExportError({ message: 'Format non supporté' }, '', 'docx'),
     /Format non supporté/,
   );
+});
+
+test('docx fidelity notice dismiss persists in localStorage', () => {
+  assert.equal(isDocxFidelityNoticeDismissed(), false);
+  dismissDocxFidelityNotice();
+  assert.equal(isDocxFidelityNoticeDismissed(), true);
+  assert.equal(localStorage.getItem(DOCX_FIDELITY_NOTICE_DISMISSED_KEY), '1');
 });

--- a/frontend/tests/unit/canvasExportFormats.test.js
+++ b/frontend/tests/unit/canvasExportFormats.test.js
@@ -12,13 +12,14 @@ import {
   isCanvasExportFormat,
 } from '../../src/lib/canvasExportFormats.js';
 
-test('exposes pdf html txt', () => {
+test('exposes pdf docx html txt', () => {
   assert.deepEqual(
     CANVAS_EXPORT_FORMATS.map((f) => f.id),
-    ['pdf', 'html', 'txt'],
+    ['pdf', 'docx', 'html', 'txt'],
   );
   assert.equal(isCanvasExportFormat('pdf'), true);
-  assert.equal(isCanvasExportFormat('docx'), false);
+  assert.equal(isCanvasExportFormat('docx'), true);
+  assert.equal(isCanvasExportFormat('png'), false);
 });
 
 test('buildCanvasExportFilename switches extension', () => {
@@ -26,6 +27,7 @@ test('buildCanvasExportFilename switches extension', () => {
   assert.match(buildCanvasExportFilename(cv, 'pdf'), /\.pdf$/);
   assert.match(buildCanvasExportFilename(cv, 'html'), /\.html$/);
   assert.match(buildCanvasExportFilename(cv, 'txt'), /\.txt$/);
+  assert.match(buildCanvasExportFilename(cv, 'docx'), /\.docx$/);
   assert.ok(buildCanvasExportFilename(cv, 'pdf').includes('Ada'));
 });
 

--- a/frontend/tests/unit/canvasExportFormats.test.js
+++ b/frontend/tests/unit/canvasExportFormats.test.js
@@ -1,0 +1,37 @@
+/**
+ * Tests formats d’export canvas (AXE-330).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  CANVAS_EXPORT_FORMATS,
+  buildCanvasExportFilename,
+  formatCanvasExportError,
+  isCanvasExportFormat,
+} from '../../src/lib/canvasExportFormats.js';
+
+test('exposes pdf html txt', () => {
+  assert.deepEqual(
+    CANVAS_EXPORT_FORMATS.map((f) => f.id),
+    ['pdf', 'html', 'txt'],
+  );
+  assert.equal(isCanvasExportFormat('pdf'), true);
+  assert.equal(isCanvasExportFormat('docx'), false);
+});
+
+test('buildCanvasExportFilename switches extension', () => {
+  const cv = { prenom: 'Ada', nom: 'Lovelace', titre_professionnel: 'Analyste' };
+  assert.match(buildCanvasExportFilename(cv, 'pdf'), /\.pdf$/);
+  assert.match(buildCanvasExportFilename(cv, 'html'), /\.html$/);
+  assert.match(buildCanvasExportFilename(cv, 'txt'), /\.txt$/);
+  assert.ok(buildCanvasExportFilename(cv, 'pdf').includes('Ada'));
+});
+
+test('formatCanvasExportError keeps API message', () => {
+  assert.match(
+    formatCanvasExportError({ message: 'Format non supporté' }, '', 'docx'),
+    /Format non supporté/,
+  );
+});

--- a/tests/test_api_cv_export.py
+++ b/tests/test_api_cv_export.py
@@ -1,0 +1,158 @@
+"""Tests de contrat pour ``POST /api/cv-export`` (AXE-330).
+
+Appelle le handler FastAPI directement (même modèle que ``test_api_ats_route``).
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastapi import HTTPException
+from fastapi.responses import Response
+
+from backend import main
+
+
+class _FakeRequest:
+    def __init__(self) -> None:
+        self.headers = {}
+        self.state = SimpleNamespace()
+
+
+def _body(**kwargs):
+    base = {
+        "cv": {"prenom": "Ada", "nom": "Lovelace", "email": "ada@example.com"},
+        "format": "txt",
+    }
+    base.update(kwargs)
+    return main.CvExportBody(**base)
+
+
+class TestCvExportFormatValidation(unittest.TestCase):
+    def test_rejects_unsupported_format(self):
+        with (
+            patch.object(main, "_get_user_id", return_value="user_test"),
+            patch.object(main, "check_rate_limit"),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                main.api_cv_export(_FakeRequest(), _body(format="png"))
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("Format non supporté", str(ctx.exception.detail))
+
+
+class TestCvExportTxt(unittest.TestCase):
+    def test_txt_returns_plain_text_attachment(self):
+        with (
+            patch.object(main, "_get_user_id", return_value="user_test"),
+            patch.object(main, "check_rate_limit") as rl_mock,
+        ):
+            resp = main.api_cv_export(_FakeRequest(), _body(format="txt"))
+        self.assertIsInstance(resp, Response)
+        self.assertEqual(resp.media_type, "text/plain; charset=utf-8")
+        self.assertIn("Ada Lovelace", resp.body.decode("utf-8"))
+        self.assertIn('attachment; filename="', resp.headers.get("content-disposition", ""))
+        self.assertTrue(resp.headers.get("content-disposition", "").endswith('.txt"'))
+        rl_mock.assert_called_once_with("user_test", 10, scope="cv_export")
+
+    def test_txt_empty_cv_returns_400(self):
+        with (
+            patch.object(main, "_get_user_id", return_value="user_test"),
+            patch.object(main, "check_rate_limit"),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                main.api_cv_export(_FakeRequest(), _body(cv={}, format="txt"))
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("texte", str(ctx.exception.detail).lower())
+
+
+class TestCvExportDocx(unittest.TestCase):
+    def test_docx_returns_ooxml_attachment(self):
+        with (
+            patch.object(main, "_get_user_id", return_value="user_test"),
+            patch.object(main, "check_rate_limit"),
+        ):
+            resp = main.api_cv_export(_FakeRequest(), _body(format="docx"))
+        self.assertIsInstance(resp, Response)
+        self.assertIn("wordprocessingml", resp.media_type or "")
+        self.assertEqual(resp.body[:2], b"PK")
+        self.assertTrue(resp.headers.get("content-disposition", "").endswith('.docx"'))
+
+    def test_docx_empty_cv_returns_400(self):
+        with (
+            patch.object(main, "_get_user_id", return_value="user_test"),
+            patch.object(main, "check_rate_limit"),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                main.api_cv_export(_FakeRequest(), _body(cv={}, format="docx"))
+        self.assertEqual(ctx.exception.status_code, 400)
+
+
+class TestCvExportHtmlPdf(unittest.TestCase):
+    def test_html_returns_html_attachment(self):
+        with (
+            patch.object(main, "_get_user_id", return_value="user_test"),
+            patch.object(main, "check_rate_limit"),
+            patch.object(main, "_check_premium_template"),
+            patch.object(main, "_check_custom_template_access"),
+            patch.object(main, "_render_cv_html", return_value="<html>cv</html>"),
+            patch.object(main, "USE_SUPABASE", False),
+        ):
+            resp = main.api_cv_export(_FakeRequest(), _body(format="html", template_id="minimal"))
+        self.assertEqual(resp.media_type, "text/html; charset=utf-8")
+        self.assertIn(b"<html>cv</html>", resp.body)
+        self.assertTrue(resp.headers.get("content-disposition", "").endswith('.html"'))
+
+    def test_pdf_reuses_pdf_pipeline(self):
+        with (
+            patch.object(main, "_get_user_id", return_value="user_test"),
+            patch.object(main, "check_rate_limit"),
+            patch.object(main, "_check_premium_template"),
+            patch.object(main, "_check_custom_template_access"),
+            patch.object(
+                main,
+                "_cv_pdf_bytes_same_as_download",
+                return_value=(b"%PDF-1.4", "CV-Ada.pdf"),
+            ),
+            patch.object(main, "_track_analytics"),
+            patch.object(main, "PDF_COUNT") as pdf_count,
+            patch("backend.cv_pdf_dispatch.cv_pdf_engine", return_value="weasy"),
+        ):
+            resp = main.api_cv_export(_FakeRequest(), _body(format="pdf", template_id="minimal"))
+        self.assertEqual(resp.media_type, "application/pdf")
+        self.assertEqual(resp.body, b"%PDF-1.4")
+        self.assertIn("CV-Ada.pdf", resp.headers.get("content-disposition", ""))
+        pdf_count.inc.assert_called_once()
+
+    def test_html_runs_premium_and_custom_template_checks(self):
+        with (
+            patch.object(main, "_get_user_id", return_value="user_test"),
+            patch.object(main, "check_rate_limit"),
+            patch.object(
+                main,
+                "_check_premium_template",
+                side_effect=HTTPException(status_code=403, detail="premium"),
+            ) as premium,
+            patch.object(main, "_check_custom_template_access") as custom,
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                main.api_cv_export(_FakeRequest(), _body(format="html", template_id="pro_tpl"))
+        self.assertEqual(ctx.exception.status_code, 403)
+        premium.assert_called_once()
+        custom.assert_not_called()
+
+    def test_txt_skips_template_access_checks(self):
+        with (
+            patch.object(main, "_get_user_id", return_value="user_test"),
+            patch.object(main, "check_rate_limit"),
+            patch.object(main, "_check_premium_template") as premium,
+            patch.object(main, "_check_custom_template_access") as custom,
+        ):
+            main.api_cv_export(_FakeRequest(), _body(format="txt", template_id="pro_tpl"))
+        premium.assert_not_called()
+        custom.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cv_docx_export.py
+++ b/tests/test_cv_docx_export.py
@@ -1,0 +1,54 @@
+"""Tests export Word CV (AXE-330)."""
+
+from io import BytesIO
+
+import pytest
+
+from backend.services.cv_docx_export import cv_to_docx_bytes
+from backend.services.docx_text_extract import extract_text_from_docx_bytes
+
+
+def _sample_cv() -> dict:
+    return {
+        "prenom": "Ada",
+        "nom": "Lovelace",
+        "titre_professionnel": "Analyste",
+        "email": "ada@example.com",
+        "resume": "Pionnière du calcul.",
+        "experiences": [
+            {
+                "poste": "Analyste",
+                "entreprise": "Babbage",
+                "date_debut": "1840",
+                "date_fin": "1850",
+            }
+        ],
+        "competences": {"techniques": ["Maths", "Algo"]},
+    }
+
+
+def test_cv_to_docx_bytes_roundtrip_text():
+    raw = cv_to_docx_bytes(_sample_cv())
+    assert raw[:2] == b"PK"  # OOXML zip
+    text = extract_text_from_docx_bytes(raw)
+    assert "Ada Lovelace" in text
+    assert "Analyste" in text
+    assert "ada@example.com" in text
+    assert "Profil" in text
+    assert "Maths" in text
+
+
+def test_cv_to_docx_bytes_empty_raises():
+    with pytest.raises(ValueError, match="empty_cv"):
+        cv_to_docx_bytes({})
+    with pytest.raises(ValueError, match="empty_cv"):
+        cv_to_docx_bytes(None)
+
+
+def test_cv_to_docx_bytes_opens_with_python_docx():
+    from docx import Document
+
+    raw = cv_to_docx_bytes(_sample_cv())
+    doc = Document(BytesIO(raw))
+    headings = [p.text for p in doc.paragraphs if p.style and p.style.name.startswith("Heading")]
+    assert any("Ada Lovelace" in h for h in headings)

--- a/tests/test_cv_docx_export.py
+++ b/tests/test_cv_docx_export.py
@@ -1,8 +1,9 @@
-"""Tests export Word CV (AXE-330)."""
+"""Tests export Word CV (AXE-330) — sémantique + layout-aware."""
 
 from io import BytesIO
 
 import pytest
+from docx import Document
 
 from backend.services.cv_docx_export import cv_to_docx_bytes
 from backend.services.docx_text_extract import extract_text_from_docx_bytes
@@ -14,6 +15,7 @@ def _sample_cv() -> dict:
         "nom": "Lovelace",
         "titre_professionnel": "Analyste",
         "email": "ada@example.com",
+        "telephone": "+33 1 23 45 67 89",
         "resume": "Pionnière du calcul.",
         "experiences": [
             {
@@ -21,9 +23,77 @@ def _sample_cv() -> dict:
                 "entreprise": "Babbage",
                 "date_debut": "1840",
                 "date_fin": "1850",
+                "bullet_points": ["Machine analytique"],
             }
         ],
         "competences": {"techniques": ["Maths", "Algo"]},
+        "formations": [{"diplome": "Maths", "etablissement": "Londres", "date": "1835"}],
+    }
+
+
+def _two_column_layout() -> dict:
+    return {
+        "version": 3,
+        "format": "A4",
+        "grid": "free",
+        "unit": "mm",
+        "theme": {
+            "font_heading": "Calibri",
+            "font_body": "Calibri",
+            "color_accent": "#003c33",
+            "color_sidebar": "#edfce9",
+        },
+        "pages": [
+            {
+                "id": "p1",
+                "blocks": [
+                    {
+                        "id": "id1",
+                        "type": "identity",
+                        "x": 10,
+                        "y": 8,
+                        "w": 190,
+                        "h": 20,
+                        "style": {"font_size": 18},
+                    },
+                    {
+                        "id": "ct1",
+                        "type": "contact",
+                        "x": 10,
+                        "y": 28,
+                        "w": 190,
+                        "h": 10,
+                    },
+                    {
+                        "id": "sk1",
+                        "type": "skills",
+                        "x": 10,
+                        "y": 45,
+                        "w": 55,
+                        "h": 40,
+                        "bind": "competences.techniques",
+                        "style": {"section_label": "Skills"},
+                    },
+                    {
+                        "id": "ex1",
+                        "type": "experiences",
+                        "x": 75,
+                        "y": 45,
+                        "w": 125,
+                        "h": 80,
+                        "style": {"section_label": "Expérience", "title_style": "underline-accent"},
+                    },
+                    {
+                        "id": "fm1",
+                        "type": "formations",
+                        "x": 75,
+                        "y": 140,
+                        "w": 125,
+                        "h": 40,
+                    },
+                ],
+            }
+        ],
     }
 
 
@@ -34,7 +104,6 @@ def test_cv_to_docx_bytes_roundtrip_text():
     assert "Ada Lovelace" in text
     assert "Analyste" in text
     assert "ada@example.com" in text
-    assert "Profil" in text
     assert "Maths" in text
 
 
@@ -46,9 +115,27 @@ def test_cv_to_docx_bytes_empty_raises():
 
 
 def test_cv_to_docx_bytes_opens_with_python_docx():
-    from docx import Document
-
     raw = cv_to_docx_bytes(_sample_cv())
     doc = Document(BytesIO(raw))
-    headings = [p.text for p in doc.paragraphs if p.style and p.style.name.startswith("Heading")]
-    assert any("Ada Lovelace" in h for h in headings)
+    texts = [p.text for p in doc.paragraphs if p.text.strip()]
+    assert any("Ada Lovelace" in t for t in texts)
+
+
+def test_layout_aware_docx_uses_section_labels_and_order():
+    raw = cv_to_docx_bytes(_sample_cv(), _two_column_layout())
+    text = extract_text_from_docx_bytes(raw)
+    assert "Ada Lovelace" in text
+    assert "SKILLS" in text or "Skills" in text
+    assert "EXPÉRIENCE" in text or "Expérience" in text
+    assert "Machine analytique" in text
+    assert "Maths" in text
+    # Skills (sidebar label) should appear before experience content in reading flow /
+    # or both present; layout uses table so order in linear extract may vary — both required.
+    assert "Babbage" in text
+
+
+def test_layout_aware_docx_builds_two_column_table():
+    raw = cv_to_docx_bytes(_sample_cv(), _two_column_layout())
+    doc = Document(BytesIO(raw))
+    assert len(doc.tables) == 1
+    assert len(doc.tables[0].columns) == 2

--- a/tests/test_cv_text_export.py
+++ b/tests/test_cv_text_export.py
@@ -30,6 +30,24 @@ def test_cv_to_plain_text_includes_identity_and_sections():
     assert "Maths" in text
 
 
+def test_cv_to_plain_text_includes_experience_bullet_points():
+    text = cv_to_plain_text(
+        {
+            "prenom": "Ada",
+            "nom": "Lovelace",
+            "experiences": [
+                {
+                    "poste": "Analyste",
+                    "entreprise": "Babbage",
+                    "bullet_points": ["Machine analytique", "  ", "Notes de traduction"],
+                }
+            ],
+        }
+    )
+    assert "- Machine analytique" in text
+    assert "- Notes de traduction" in text
+
+
 def test_cv_to_plain_text_empty_cv():
     assert cv_to_plain_text({}) == ""
     assert cv_to_plain_text(None) == ""

--- a/tests/test_cv_text_export.py
+++ b/tests/test_cv_text_export.py
@@ -1,0 +1,35 @@
+"""Tests export texte CV (AXE-330)."""
+
+from backend.services.cv_text_export import cv_to_plain_text
+
+
+def test_cv_to_plain_text_includes_identity_and_sections():
+    text = cv_to_plain_text(
+        {
+            "prenom": "Ada",
+            "nom": "Lovelace",
+            "titre_professionnel": "Analyste",
+            "email": "ada@example.com",
+            "resume": "Pionnière du calcul.",
+            "experiences": [
+                {
+                    "poste": "Analyste",
+                    "entreprise": "Babbage",
+                    "date_debut": "1840",
+                    "date_fin": "1850",
+                }
+            ],
+            "competences": {"techniques": ["Maths", "Algo"]},
+        }
+    )
+    assert "Ada Lovelace" in text
+    assert "Analyste" in text
+    assert "ada@example.com" in text
+    assert "PROFIL" in text
+    assert "EXPÉRIENCES" in text or "EXPERIENCES" in text.upper()
+    assert "Maths" in text
+
+
+def test_cv_to_plain_text_empty_cv():
+    assert cv_to_plain_text({}) == ""
+    assert cv_to_plain_text(None) == ""


### PR DESCRIPTION
## Summary
- Remplace le clic PDF unique par un **menu Télécharger** (PDF / HTML / TXT) dans l’éditeur Beta.
- Nouveau endpoint `POST /api/cv-export` : PDF = même rendu que `/api/pdf`, HTML via `layout_renderer`, TXT depuis le JSON sémantique.
- Erreurs API remontées clairement (format invalide, CV vide en TXT).

## Linear
Fixes AXE-330

## GitHub issue
Closes #111

## Test plan
- [ ] Beta → Télécharger → menu PDF / HTML / TXT
- [ ] PDF inchangé vs ancien bouton
- [ ] HTML s’ouvre / télécharge avec contenu canvas
- [ ] TXT contient identité + sections ; message si CV vide
- [ ] Esc / clic extérieur ferme le menu
- [ ] `pytest tests/test_cv_text_export.py`
- [ ] `node --test tests/unit/canvasExportFormats.test.js`
- [ ] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks` OK


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - Exportez votre CV aux formats PDF, HTML ou texte brut.
  - Choisissez le format depuis un nouveau menu d’export.
  - Les fichiers téléchargés reçoivent automatiquement un nom adapté au CV.
  - Les modèles et mises en page personnalisés sont pris en charge pour les exports compatibles.

- **Améliorations**
  - Le menu se ferme par clic extérieur ou avec la touche Échap.
  - Les erreurs d’export affichent désormais des messages plus clairs.

- **Tests**
  - Ajout de vérifications pour les formats, noms de fichiers et exports de CV en texte brut.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->