### PR TITLE
fix(AXE-348): simplifier copy pop-ups Beta (zéro jargon)

### DIFF
--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -617,7 +617,7 @@ function CvEditorBeta({
       setDesignBridgeError(
         !cv
           ? 'Profil non chargé — réessaie dans un instant.'
-          : 'Ce template Stable n’a pas de projection canvas. Choisis un autre modèle.',
+          : 'Ce modèle ne peut pas être appliqué ici. Choisis-en un autre.',
       );
       return;
     }
@@ -628,8 +628,8 @@ function CvEditorBeta({
       if (!applied.ok || !applied.layout) {
         setDesignBridgeError(
           applied.reason === 'no_canvas_spec'
-            ? 'Ce template Stable n’a pas de projection canvas utilisable.'
-            : 'Impossible d’appliquer le design Stable sur le canvas.',
+            ? 'Ce modèle ne peut pas être appliqué ici.'
+            : 'Impossible d’appliquer ce design.',
         );
         return;
       }
@@ -2272,11 +2272,10 @@ function CvEditorBeta({
               <section className="cv-editor-beta-start-panel" role="dialog" aria-modal="true" aria-label="Démarrer le canvas">
                 <div className="cv-editor-beta-start-panel__backdrop" aria-hidden />
                 <div className="cv-editor-beta-start-panel__card">
-                  <span className="cv-editor-beta-start-panel__eyebrow">Démarrer en Beta</span>
+                  <span className="cv-editor-beta-start-panel__eyebrow">Démarrer</span>
                   <h2>Comment veux-tu commencer ?</h2>
                   <p>
-                    Ne reste pas sur une page vide : importe ton CV, pars d’un modèle,
-                    ou génère une mise en page depuis ton profil.
+                    Importe ton CV, pars d’un modèle, ou génère une mise en page depuis ton profil.
                   </p>
                   <div className="cv-editor-beta-start-panel__actions">
                     <button
@@ -2327,9 +2326,8 @@ function CvEditorBeta({
                     </button>
                   </div>
                   <p className="cv-editor-beta-start-panel__hint">
-                    Après démarrage, utilise « Composer l’en-tête » dans Sections pour
-                    poser identité + contact avec un design soigné. La page blanche
-                    est réservée aux utilisateurs avancés.
+                    Ensuite, « Composer l’en-tête » dans Sections pose identité et contact.
+                    La page blanche est pour les usages avancés.
                   </p>
                 </div>
               </section>

--- a/frontend/src/components/editor/DesignModeBridgeModal.jsx
+++ b/frontend/src/components/editor/DesignModeBridgeModal.jsx
@@ -34,7 +34,7 @@ export default function DesignModeBridgeModal({
       <div className="design-mode-bridge-modal__card">
         <header className="design-mode-bridge-modal__head">
           <div>
-            <span className="design-mode-bridge-modal__eyebrow">Design Stable ↔ Beta</span>
+            <span className="design-mode-bridge-modal__eyebrow">Design</span>
             <h3 id="design-mode-bridge-title">{offer.title}</h3>
           </div>
           <button
@@ -59,7 +59,7 @@ export default function DesignModeBridgeModal({
         ) : null}
         <footer className="design-mode-bridge-modal__actions">
           <button type="button" onClick={() => handleDismiss(true)} disabled={confirming}>
-            Garder tel quel
+            Plus tard
           </button>
           <button
             type="button"
@@ -69,9 +69,7 @@ export default function DesignModeBridgeModal({
           >
             {confirming
               ? 'Application…'
-              : offer.direction === 'stable_to_beta'
-                ? `Appliquer « ${offer.templateLabel} »`
-                : `Utiliser « ${offer.templateLabel} »`}
+              : 'Appliquer'}
           </button>
         </footer>
       </div>

--- a/frontend/src/components/editor/DocxExportNoticeModal.jsx
+++ b/frontend/src/components/editor/DocxExportNoticeModal.jsx
@@ -45,7 +45,7 @@ export default function DocxExportNoticeModal({
         <header className="docx-export-notice-modal__head">
           <div>
             <span className="docx-export-notice-modal__eyebrow">Export Word</span>
-            <h3 id={titleId}>Ce n’est pas une copie exacte du canvas</h3>
+            <h3 id={titleId}>Le Word n’est pas identique au PDF</h3>
           </div>
           <button
             type="button"
@@ -57,9 +57,8 @@ export default function DocxExportNoticeModal({
           </button>
         </header>
         <p className="docx-export-notice-modal__copy">
-          Word reprend le contenu, l’ordre des sections et une mise en page
-          approximative (colonnes, titres, couleurs du thème). Le PDF reste la
-          référence visuelle fidèle.
+          Word reprend ton contenu et une mise en page simple.
+          Pour un rendu fidèle, préfère le PDF.
         </p>
         <label className="docx-export-notice-modal__check" htmlFor={checkboxId}>
           <input

--- a/frontend/src/components/editor/EditorCanvaSidebar.jsx
+++ b/frontend/src/components/editor/EditorCanvaSidebar.jsx
@@ -61,7 +61,7 @@ const SECTIONS = [
   {
     id: 'import',
     label: 'Importer',
-    title: 'Importer — images décoratives uniquement (pas de PDF/Word ici)',
+    title: 'Importer — images uniquement (pas de fichier CV)',
     icon: HiArrowUpTray,
   },
   {

--- a/frontend/src/components/editor/EditorCvImportModal.jsx
+++ b/frontend/src/components/editor/EditorCvImportModal.jsx
@@ -24,13 +24,11 @@ export default function EditorCvImportModal({
       <div className="editor-cv-import-modal" onClick={(e) => e.stopPropagation()}>
         <header className="editor-cv-import-head">
           <div>
-            <span className="editor-cv-import-eyebrow">Import intelligent</span>
+            <span className="editor-cv-import-eyebrow">Import</span>
             <h2 id="editor-cv-import-title">Importer un CV</h2>
             <p>
-              PDF natif (texte sélectionnable) : mise en page recopiée en blocs éditables.
-              Word (.docx) : contenu extrait puis adapté. Les PDF scannés (image sans texte)
-              ne sont pas supportés — pas d&apos;OCR pour l&apos;instant ; exporte un PDF texte,
-              un .docx, ou colle le texte.
+              PDF ou Word : on reconstruit ton CV sur le canvas.
+              Les PDF photo (sans texte) ne marchent pas — utilise un PDF texte ou un fichier Word.
             </p>
           </div>
           <button type="button" className="editor-cv-import-close" onClick={onClose} aria-label="Fermer">×</button>
@@ -57,7 +55,7 @@ export default function EditorCvImportModal({
               <line x1="12" y1="3" x2="12" y2="15" />
             </svg>
             <strong>Choisir un fichier</strong>
-            <span>PDF texte ou DOCX — pas de PDF scanné (OCR hors MVP)</span>
+            <span>PDF texte ou Word — pas de PDF photo</span>
           </button>
         </div>
 

--- a/frontend/src/components/editor/EditorImportLayoutChooserModal.jsx
+++ b/frontend/src/components/editor/EditorImportLayoutChooserModal.jsx
@@ -59,12 +59,10 @@ export default function EditorImportLayoutChooserModal({
       >
         <header className="editor-import-chooser-head">
           <div>
-            <span className="editor-import-chooser-eyebrow">Choix de mise en page</span>
-            <h2 id="editor-import-chooser-title">Trois variantes après import</h2>
+            <span className="editor-import-chooser-eyebrow">Après import</span>
+            <h2 id="editor-import-chooser-title">Choisis une mise en page</h2>
             <p>
-              Ce n&apos;est pas une copie pixel-perfect : on reconstruit un canvas
-              éditable. Comparez le rendu approximatif et le score ATS, puis
-              continuez avec la variante qui vous convient.
+              Trois propositions éditables. Compare le rendu et le score, puis continue.
             </p>
             {policyNotice ? (
               <p className="editor-import-chooser-policy" role="note">{policyNotice}</p>

--- a/frontend/src/lib/designModeBridge.js
+++ b/frontend/src/lib/designModeBridge.js
@@ -10,7 +10,7 @@ import { buildAdaptedCanvasLayoutForCv } from './canvasCvImportAdapter.js';
 import { buildTemplateBlocks } from './canvasTemplateSpecs.js';
 import { detectTransferCandidates } from './canvasLayoutTransfer.js';
 import { createCanvasLayoutForTemplate } from './layoutTemplatePresets.js';
-import { isEmptyLayoutV3, listAllBlocks } from './cvLayoutModelV3.js';
+import { isEmptyLayoutV3 } from './cvLayoutModelV3.js';
 
 export const DESIGN_BRIDGE_DISMISS_KEY = 'cv_bot_design_bridge_dismiss_v1';
 
@@ -85,7 +85,7 @@ export function assessCrossModeDiff(layout, targetTemplateId = '') {
   const freeform = layout.freeform === true;
   if (freeform) {
     warnings.push(
-      'Ce canvas est en disposition libre (import fidèle). Stable utilisera le template HTML, pas le placement libre mm.',
+      'La disposition libre ne sera pas reprise à l’identique.',
     );
   }
   const target = createCanvasLayoutForTemplate(
@@ -95,7 +95,7 @@ export function assessCrossModeDiff(layout, targetTemplateId = '') {
   const manualExtras = candidates.length;
   if (manualExtras > 0) {
     warnings.push(
-      `${manualExtras} élément(s) personnalisé(s) du canvas ne seront pas repris dans l’aperçu Stable.`,
+      `${manualExtras} élément(s) ajouté(s) à la main ne seront pas repris.`,
     );
   }
   const suggested = suggestStableTemplateIdFromLayout(layout);
@@ -103,7 +103,7 @@ export function assessCrossModeDiff(layout, targetTemplateId = '') {
   const templateMismatch = Boolean(suggested && targetId && suggested !== targetId);
   if (templateMismatch) {
     warnings.push(
-      `Le canvas est lié au template « ${suggested} », différent de « ${targetId} » actuellement en Stable.`,
+      'Un autre modèle est déjà sélectionné.',
     );
   }
   return { warnings, freeform, manualExtras, templateMismatch };
@@ -177,12 +177,9 @@ export function buildStableToBetaOffer(layout, templateId, templatesList, option
     direction: 'stable_to_beta',
     templateId: template.id,
     templateLabel: template.name || template.label || template.id,
-    title: 'Appliquer le design Stable ?',
-    copy:
-      'Ton contenu est déjà partagé. Tu peux reconstruire le canvas Beta à partir du template Stable — sans forcer une migration.',
-    warnings: [
-      'Le rendu Beta est une projection canvas du template (pas un clone pixel-perfect du HTML Stable).',
-    ],
+    title: 'Appliquer ce design ?',
+    copy: 'On pose ton modèle sur le canvas. Ton contenu reste.',
+    warnings: [],
   };
 }
 
@@ -204,16 +201,12 @@ export function buildBetaToStableOffer(layout, currentTemplateId, options = {}) 
     || diff.manualExtras > 0;
   if (!shouldOffer) return null;
   if (isDesignBridgeDismissed('beta_to_stable', suggested, options.storage)) return null;
-  const blocks = listAllBlocks(layout).length;
   return {
     direction: 'beta_to_stable',
     templateId: suggested,
     templateLabel: suggested,
-    title: 'Utiliser ce template en Stable ?',
-    copy:
-      blocks > 0
-        ? `Le canvas Beta référence « ${suggested} ». Stable affichera le template HTML correspondant (contenu inchangé).`
-        : `Appliquer « ${suggested} » comme template Stable.`,
+    title: 'Utiliser ce design ?',
+    copy: 'On applique ce modèle. Ton contenu reste.',
     warnings: diff.warnings,
   };
 }

--- a/frontend/src/lib/editorOnboarding.js
+++ b/frontend/src/lib/editorOnboarding.js
@@ -22,7 +22,7 @@ export const EDITOR_ONBOARDING_STEPS = Object.freeze([
   {
     id: 'place',
     title: 'Place sur le canvas',
-    body: 'Clique un élément puis clique la page pour le poser. Échap annule. « Importer » sert aux images uniquement.',
+    body: 'Clique un élément puis la page pour le poser. Échap annule. L’onglet Importer ajoute des images, pas un fichier CV.',
   },
 ]);
 

--- a/frontend/tests/unit/designModeBridge.test.js
+++ b/frontend/tests/unit/designModeBridge.test.js
@@ -62,6 +62,13 @@ test('buildStableToBetaOffer only when canvas empty + projectable template', () 
   assert.ok(offer);
   assert.equal(offer.direction, 'stable_to_beta');
   assert.equal(offer.templateId, 'minimal');
+  assert.equal(offer.title, 'Appliquer ce design ?');
+  assert.match(offer.copy, /contenu reste/i);
+  assert.deepEqual(offer.warnings, []);
+  assert.doesNotMatch(
+    `${offer.title} ${offer.copy}`,
+    /migration|projection|pixel-perfect|HTML/i,
+  );
 
   const filled = {
     ...blank,
@@ -80,6 +87,11 @@ test('buildBetaToStableOffer when theme template differs', () => {
   assert.ok(offer);
   assert.equal(offer.direction, 'beta_to_stable');
   assert.equal(offer.templateId, 'modern');
+  assert.equal(offer.title, 'Utiliser ce design ?');
+  assert.doesNotMatch(
+    `${offer.title} ${offer.copy} ${offer.warnings.join(' ')}`,
+    /migration|projection|pixel-perfect|HTML|mm\b/i,
+  );
 });
 
 test('suggestStableTemplateIdFromLayout reads theme', () => {


### PR DESCRIPTION
## Summary
- Design Bridge : « Appliquer ce design ? » / « Plus tard » / « Appliquer » — plus de migration/projection/pixel-perfect
- Import CV + chooser, onboarding étape 3, notice Word, startup — textes courts
- Tests copy sans jargon

Fixes AXE-348
Closes #120

## Test plan
- [ ] Canvas vide + modèle Stable → modal Design : copy courte, CTAs Plus tard / Appliquer
- [ ] Importer un CV : modal sans OCR/jargon
- [ ] Après import : chooser « Choisis une mise en page »
- [ ] Export Word : notice courte
- [ ] Tour onboarding étape 3 : Importer = images, pas fichier CV


Made with [Cursor](https://cursor.com)