### PR TITLE
fix(AXE-344): import CV peuplé le canvas Beta (+ preview Stable)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,15 @@ jobs:
           python-version: "3.12"
 
       # WeasyPrint (verify-pdf / snapshots HTML→PDF, AXE-39)
+      # timeout : évite un hang apt-get update indéfini (runners GitHub).
       - name: Install WeasyPrint system libraries
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          set -euo pipefail
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update -o Acquire::Retries=3
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
             libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 \
             libffi-dev shared-mime-info fonts-dejavu-core
+        timeout-minutes: 3
 
       - name: Create virtualenv and install dependencies
         run: |

--- a/frontend/src/components/OnboardingWizard.jsx
+++ b/frontend/src/components/OnboardingWizard.jsx
@@ -1,5 +1,6 @@
 import { useState, useRef } from 'react';
 import { apiPost, apiPostFile, apiPut, trackEvent } from '../api';
+import { cvFromImportPayload } from '../lib/cvImportUtils.js';
 import '../styles/OnboardingWizard.css';
 
 const STEPS = ['Importer', 'Vérifier', 'C\'est parti'];
@@ -42,7 +43,7 @@ export default function OnboardingWizard({ session, onComplete }) {
     trackEvent('onboarding_method_chosen', { method: 'file_upload' });
     try {
       const data = await apiPostFile('/api/cv/import', file);
-      setParsedCv(data.cv);
+      setParsedCv(cvFromImportPayload(data?.cv || data));
       setStep(1);
     } catch (err) {
       setError(err.message || 'Impossible de lire le CV. Essaie le copier-coller.');
@@ -59,7 +60,7 @@ export default function OnboardingWizard({ session, onComplete }) {
     trackEvent('onboarding_method_chosen', { method: 'text_paste' });
     try {
       const data = await apiPost('/api/cv/import-text', { text: cvText.trim() });
-      setParsedCv(data.cv);
+      setParsedCv(cvFromImportPayload(data?.cv || data));
       setStep(1);
     } catch (err) {
       setError(err.message || 'Impossible de parser le texte.');

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -21,6 +21,7 @@ import {
   buildFullCanvasImportLayout,
   buildAdaptedCanvasLayoutForCv,
   countContentBlocks,
+  cvHasSeedableProfileContent,
   ensureImportLayoutHasContent,
   recommendTemplateLabel,
   resolveImportPersistTemplateId,
@@ -245,6 +246,9 @@ function CvEditorBeta({
   const [designBridgeError, setDesignBridgeError] = useState('');
   const profileTemplateIdRef = useRef('');
   const designBridgeSeededRef = useRef(false);
+  /** AXE-344 : peupler Beta depuis le profil onboarding (CV sans layout). */
+  const pendingProfileSeedRef = useRef(false);
+  const profileSeedDoneRef = useRef(false);
   const [importModalOpen, setImportModalOpen] = useState(false);
   const [importLoading, setImportLoading] = useState(false);
   const [importChooser, setImportChooser] = useState(null);
@@ -415,6 +419,8 @@ function CvEditorBeta({
     setLoading(true);
     setProfileLoadError(null);
     designBridgeSeededRef.current = false;
+    pendingProfileSeedRef.current = false;
+    profileSeedDoneRef.current = false;
     setDesignBridgeOffer(null);
     setDesignBridgeError('');
     apiGet('/api/cv?profile=1')
@@ -439,9 +445,15 @@ function CvEditorBeta({
             label: canvasContextLabel(contextKey, templates),
           });
           setCanvasDrafts(listCanvasDrafts(templates));
+          pendingProfileSeedRef.current = false;
+          setStartupPromptOpen(false);
+        } else {
+          // Import onboarding = données sans layout → peupler Beta dès que templates OK.
+          const seedable = cvHasSeedableProfileContent(mergedCv);
+          pendingProfileSeedRef.current = seedable;
+          setStartupPromptOpen(!seedable);
         }
         resetLayout(hydratedLayout);
-        setStartupPromptOpen(!rawLayout);
         setLoading(false);
       })
       .catch((err) => {
@@ -459,6 +471,47 @@ function CvEditorBeta({
     if (loading || profileLoadError || !cv) return;
     setCanvasDrafts(listCanvasDrafts(templatesList));
   }, [templatesList, loading, profileLoadError, cv]);
+
+  // AXE-344 — après onboarding (CV rempli, layout absent) : générer le canvas Beta.
+  useEffect(() => {
+    if (loading || profileLoadError || !cv) return;
+    if (!pendingProfileSeedRef.current || profileSeedDoneRef.current) return;
+    if (!Array.isArray(templatesList) || templatesList.length === 0) return;
+    if (!isEmptyLayoutV3(layoutRef.current)) {
+      pendingProfileSeedRef.current = false;
+      return;
+    }
+    pendingProfileSeedRef.current = false;
+    profileSeedDoneRef.current = true;
+    const tid = String(
+      profileTemplateIdRef.current || cv.template_id || templateId || '',
+    ).trim();
+    try {
+      const result = buildFullCanvasImportLayout(cv, templatesList, { templateId: tid });
+      const seeded = ensureImportLayoutHasContent(result.layout, cv);
+      if (!countContentBlocks(seeded)) {
+        setStartupPromptOpen(true);
+        return;
+      }
+      const persistId = resolveImportPersistTemplateId(
+        result.recommendedTemplateId,
+        tid || 'minimal',
+      );
+      if (persistId && onTemplateIdChange) onTemplateIdChange(persistId);
+      openCanvasContext(IMPORTED_CANVAS_CONTEXT_KEY, seeded);
+      setImportToast('Canvas généré depuis ton profil');
+    } catch {
+      setStartupPromptOpen(true);
+    }
+  }, [
+    loading,
+    profileLoadError,
+    cv,
+    templatesList,
+    templateId,
+    onTemplateIdChange,
+    openCanvasContext,
+  ]);
 
   // Recompute l’offre Stable→Beta quand templatesList arrive (souvent après le GET cv).
   useEffect(() => {
@@ -590,10 +643,14 @@ function CvEditorBeta({
       || templates[0];
 
     if (preferred && cv) {
-      const adapted = buildAdaptedCanvasLayoutForCv(cv, preferred, {
-        templatesList: templates,
-        templateId: preferred.id,
-      }).layout;
+      const adapted = ensureImportLayoutHasContent(
+        buildAdaptedCanvasLayoutForCv(cv, preferred, {
+          templatesList: templates,
+          templateId: preferred.id,
+          forImport: true,
+        }).layout,
+        cv,
+      );
       if (onTemplateIdChange) onTemplateIdChange(preferred.id);
       openCanvasContext(templateCanvasContextKey(preferred.id), adapted);
       return;
@@ -711,6 +768,24 @@ function CvEditorBeta({
     }
 
     // AXE-344 — jamais de succès « décoratif only » (filet sans identité / sections).
+    // Fallback : générer depuis le CV plutôt que casser un import fichier qui marchait.
+    if (!contentBlockCount) {
+      const preferred = templates.find((t) => t?.id === (recommendedTemplateId || templateId))
+        || templates.find((t) => t?.id === 'minimal')
+        || templates[0];
+      if (preferred && nextCv) {
+        const fallback = buildAdaptedCanvasLayoutForCv(nextCv, preferred, {
+          templatesList: templates,
+          templateId: preferred.id || 'minimal',
+          forImport: true,
+        });
+        finalLayout = ensureImportLayoutHasContent(fallback.layout, nextCv);
+        contentBlockCount = countContentBlocks(finalLayout);
+        recommendedTemplateId = preferred.id || recommendedTemplateId;
+        analysis = fallback.analysis || analysis;
+        importSource = importSource || 'preset';
+      }
+    }
     if (!contentBlockCount) {
       setImportError(
         'Import incomplet : aucun contenu affichable. Réessayez avec un PDF texte, ou saisissez le CV manuellement.',

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -698,7 +698,6 @@ function CvEditorBeta({
         recommendedTemplateId,
         analysis,
         blockCount,
-        contentBlockCount,
         importSource,
       } = buildFullCanvasImportLayout(nextCv, templates, {
         templateId,

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -392,7 +392,7 @@ function CvEditorBeta({
     return () => clearTimeout(id);
   }, [layout, activeLayoutContextKey, templatesList, refreshCanvasDrafts, cv, profileLoadError]);
 
-  const openCanvasContext = useCallback((contextKey, nextLayout) => {
+  const openCanvasContext = useCallback((contextKey, nextLayout, persistExtras = {}) => {
     const hydrated = migrateLayoutToV3(nextLayout || createCanvasLayoutBlank());
     layoutRef.current = hydrated;
     resetLayout(hydrated);
@@ -406,7 +406,11 @@ function CvEditorBeta({
     saveCanvasDraft(contextKey, hydrated, { label: canvasContextLabel(contextKey, templatesList) });
     refreshCanvasDrafts();
     if (cv) {
-      const payload = { ...cv, layout: layoutPayloadForPersist(hydrated) };
+      const payload = {
+        ...cv,
+        layout: layoutPayloadForPersist(hydrated),
+        ...persistExtras,
+      };
       autoSave.schedule(payload);
       // Flush immédiat pour Page blanche / génération (AXE-28) — ne pas
       // dépendre du debounce avant une navigation.
@@ -498,7 +502,9 @@ function CvEditorBeta({
         tid || 'minimal',
       );
       if (persistId && onTemplateIdChange) onTemplateIdChange(persistId);
-      openCanvasContext(IMPORTED_CANVAS_CONTEXT_KEY, seeded);
+      openCanvasContext(IMPORTED_CANVAS_CONTEXT_KEY, seeded, {
+        template_id: persistId,
+      });
       setImportToast('Canvas généré depuis ton profil');
     } catch {
       setStartupPromptOpen(true);

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -20,7 +20,10 @@ import {
 import {
   buildFullCanvasImportLayout,
   buildAdaptedCanvasLayoutForCv,
+  countContentBlocks,
+  ensureImportLayoutHasContent,
   recommendTemplateLabel,
+  resolveImportPersistTemplateId,
   summarizeImportAdaptation,
 } from '../../lib/canvasCvImportAdapter.js';
 import { buildImportLayoutVariants } from '../../lib/importLayoutVariants.js';
@@ -192,6 +195,7 @@ function CvEditorBeta({
   templatesList,
   onTemplateIdChange,
   onTemplateOptionsChange,
+  onSaveSuccess,
   isActive = true,
 }) {
   const [cv, setCv] = useState(null);
@@ -678,11 +682,13 @@ function CvEditorBeta({
     let recommendedTemplateId;
     let analysis = null;
     let blockCount;
+    let contentBlockCount;
     let importSource;
 
     if (chosenVariant?.layout) {
-      finalLayout = chosenVariant.layout;
+      finalLayout = ensureImportLayoutHasContent(chosenVariant.layout, nextCv);
       recommendedTemplateId = chosenVariant.recommendedTemplateId || '';
+      contentBlockCount = countContentBlocks(finalLayout);
       blockCount = chosenVariant.blockCount
         || (finalLayout?.pages || []).reduce((n, p) => n + (p?.blocks?.length || 0), 0);
       importSource = chosenVariant.importSource || chosenVariant.id || 'preset';
@@ -692,6 +698,7 @@ function CvEditorBeta({
         recommendedTemplateId,
         analysis,
         blockCount,
+        contentBlockCount,
         importSource,
       } = buildFullCanvasImportLayout(nextCv, templates, {
         templateId,
@@ -700,7 +707,24 @@ function CvEditorBeta({
         visionMeta,
         annotations,
       }));
+      finalLayout = ensureImportLayoutHasContent(finalLayout, nextCv);
+      contentBlockCount = countContentBlocks(finalLayout);
     }
+
+    // AXE-344 — jamais de succès « décoratif only » (filet sans identité / sections).
+    if (!contentBlockCount) {
+      setImportError(
+        'Import incomplet : aucun contenu affichable. Réessayez avec un PDF texte, ou saisissez le CV manuellement.',
+      );
+      setImportModalOpen(true);
+      setImportChooser(null);
+      return;
+    }
+
+    recommendedTemplateId = resolveImportPersistTemplateId(
+      recommendedTemplateId,
+      templateId || 'minimal',
+    );
 
     const recTemplate = templates.find((t) => t?.id === recommendedTemplateId) || templates[0];
     const contextKey = IMPORTED_CANVAS_CONTEXT_KEY;
@@ -738,6 +762,7 @@ function CvEditorBeta({
         template_id: recommendedTemplateId || templateId,
         template_options: nextTemplateOptions,
       });
+      onSaveSuccess?.();
     } catch (err) {
       setLoadError(err?.message || 'Import réussi mais enregistrement échoué.');
     }
@@ -756,9 +781,9 @@ function CvEditorBeta({
         sourceNote = ' · contenu adapté (pas de copie layout PDF)';
       }
       if (importSource === 'structural') {
-        setImportToast(`${blockCount} éléments importés${sourceNote}`);
+        setImportToast(`${contentBlockCount || blockCount} éléments importés${sourceNote}`);
       } else {
-        setImportToast(`${summarizeImportAdaptation(analysis, label, blockCount, {
+        setImportToast(`${summarizeImportAdaptation(analysis, label, contentBlockCount || blockCount, {
           fromVision: importSource === 'vision-guided',
         })}${sourceNote}`);
       }
@@ -772,12 +797,14 @@ function CvEditorBeta({
     autoSave,
     onTemplateIdChange,
     onTemplateOptionsChange,
+    onSaveSuccess,
     templateOptions,
   ]);
 
   const runCvImport = useCallback(async (importFn) => {
     setImportModalOpen(false);
     setImportChooser(null);
+    setStartupPromptOpen(false);
     setImportLoading(true);
     setImportStepIndex(0);
     setImportError('');
@@ -829,11 +856,20 @@ function CvEditorBeta({
         });
         return;
       }
+      // Affiche déjà le layout par défaut pendant le chooser (évite canvas vide).
+      const defaultId = defaultImportVariantId(merged);
+      const previewVariant = resolveImportVariant(merged, defaultId) || merged[0];
+      if (previewVariant?.layout) {
+        const previewLayout = ensureImportLayoutHasContent(previewVariant.layout, nextCv);
+        setCv(nextCv);
+        resetLayout(previewLayout);
+        layoutRef.current = previewLayout;
+      }
       setImportChooser({
         cv: nextCv,
         variants: merged,
         bestTotal,
-        selectedId: defaultImportVariantId(merged),
+        selectedId: defaultId,
         importPolicy,
         semanticMeta,
         blockAnnotations,
@@ -848,7 +884,7 @@ function CvEditorBeta({
         importCleanupRef.current = null;
       }
     }
-  }, [applyImportedCvToCanvas, templatesList, templateId]);
+  }, [applyImportedCvToCanvas, templatesList, templateId, resetLayout]);
 
   const handleImportChooserConfirm = useCallback(async (variant) => {
     if (!importChooser?.cv || !variant?.layout) return;

--- a/frontend/src/lib/canvasCvImportAdapter.js
+++ b/frontend/src/lib/canvasCvImportAdapter.js
@@ -71,6 +71,43 @@ export function resolveImportPersistTemplateId(recommendedTemplateId, fallbackTe
   return id;
 }
 
+/**
+ * Vrai si le profil a du contenu réel (post-onboarding / import data-only)
+ * pour générer un canvas Beta sans forcer un nouvel import fichier.
+ */
+export function cvHasSeedableProfileContent(cv) {
+  const synced = syncCvDualKeys(cv || {});
+  if (
+    String(synced.prenom || '').trim()
+    || String(synced.first_name || '').trim()
+    || String(synced.nom || '').trim()
+    || String(synced.last_name || '').trim()
+    || String(synced.email || '').trim()
+    || String(synced.telephone || '').trim()
+    || String(synced.titre_professionnel || '').trim()
+    || String(synced.resume || '').trim()
+  ) {
+    return true;
+  }
+  const experiences = resolveExperiences(synced);
+  if (experiences.some((e) => (
+    String(e?.poste || '').trim()
+    || String(e?.entreprise || '').trim()
+    || (e?.bullet_points || []).some((b) => String(b || '').trim())
+  ))) {
+    return true;
+  }
+  const formations = resolveFormations(synced);
+  if (formations.some((f) => (
+    String(f?.diplome || '').trim()
+    || String(f?.etablissement || '').trim()
+  ))) {
+    return true;
+  }
+  const analysis = analyzeCvProfile(synced);
+  return analysis.skillCount > 0 || analysis.langCount > 0 || analysis.certCount > 0;
+}
+
 const LAYOUT_STYLE_TEMPLATES = {
   'sidebar-left': ['modern', 'classic', 'creative'],
   'sidebar-right': ['executive', 'bold'],

--- a/frontend/src/lib/canvasCvImportAdapter.js
+++ b/frontend/src/lib/canvasCvImportAdapter.js
@@ -4,7 +4,10 @@
  * Pipeline : analyse profil → template + couleurs → blocs dimensionnés →
  * reflow → pagination → ordre ATS.
  */
-import { applyAtsLayoutOptimizations } from './atsLayoutOptimize.js';
+import {
+  applyAtsLayoutOptimizations,
+  optimizeAddMissingProfileSections,
+} from './atsLayoutOptimize.js';
 import {
   LAYOUT,
   MAIN_PAD_X,
@@ -19,10 +22,12 @@ import { applyLayoutPagination } from './layoutPagination.js';
 import {
   PAGE_HEIGHT_MM,
   PAGE_WIDTH_MM,
+  listAllBlocks,
   removeBlock,
   sanitizeLayoutV3,
   setBlockPosition,
 } from './cvLayoutModelV3.js';
+import { syncCvDualKeys } from './cvDualKey.js';
 import {
   resolveBoundText,
   resolveCertifications,
@@ -36,6 +41,35 @@ import {
 import { bindStructuralTextToSemanticBlocks } from './structuralSemanticBind.js';
 
 const DECORATIVE_TYPES = new Set(['shape:rect', 'shape:line']);
+
+/** Blocs visibles pour l’utilisateur (hors filets / rectangles déco). */
+export function isImportContentBlock(block) {
+  return Boolean(block?.type) && !DECORATIVE_TYPES.has(block.type);
+}
+
+/** Compte les blocs de contenu (pas les filets décoratifs). */
+export function countContentBlocks(layout) {
+  return listAllBlocks(layout).filter(isImportContentBlock).length;
+}
+
+/**
+ * AXE-344 — après prune import, ne jamais laisser un canvas décoratif-only
+ * si le CV a du contenu : on pose au moins identity/contact (+ sections profil).
+ */
+export function ensureImportLayoutHasContent(layout, cv) {
+  if (!layout?.pages?.length) return layout;
+  if (countContentBlocks(layout) > 0) return layout;
+  return optimizeAddMissingProfileSections(layout, cv || {});
+}
+
+/** template_id technique « imported » → id réel pour Stable / render-html. */
+export function resolveImportPersistTemplateId(recommendedTemplateId, fallbackTemplateId = '') {
+  const id = String(recommendedTemplateId || '').trim();
+  if (!id || id === 'imported') {
+    return String(fallbackTemplateId || '').trim() || 'minimal';
+  }
+  return id;
+}
 
 const LAYOUT_STYLE_TEMPLATES = {
   'sidebar-left': ['modern', 'classic', 'creative'],
@@ -85,16 +119,17 @@ const THEME_PRESETS = {
 
 /** Métriques du profil pour adapter la mise en page. */
 export function analyzeCvProfile(cv) {
-  const experiences = resolveExperiences(cv);
-  const formations = resolveFormations(cv);
-  const certifications = resolveCertifications(cv);
-  const projets = resolveProjets(cv);
-  const langues = resolveLangues(cv);
-  const techniques = resolveCompetenceList(cv, 'competences.techniques');
-  const logiciels = resolveCompetenceList(cv, 'competences.logiciels');
-  const autres = resolveCompetenceList(cv, 'competences.autres');
-  const resume = String(cv?.resume || '').trim();
-  const titre = String(cv?.titre_professionnel || '').trim().toLowerCase();
+  const synced = syncCvDualKeys(cv || {});
+  const experiences = resolveExperiences(synced);
+  const formations = resolveFormations(synced);
+  const certifications = resolveCertifications(synced);
+  const projets = resolveProjets(synced);
+  const langues = resolveLangues(synced);
+  const techniques = resolveCompetenceList(synced, 'competences.techniques');
+  const logiciels = resolveCompetenceList(synced, 'competences.logiciels');
+  const autres = resolveCompetenceList(synced, 'competences.autres');
+  const resume = String(synced?.resume || '').trim();
+  const titre = String(synced?.titre_professionnel || '').trim().toLowerCase();
   const bulletCount = experiences.reduce(
     (n, e) => n + (e.bullet_points || []).filter((b) => String(b || '').trim()).length,
     0,
@@ -109,16 +144,18 @@ export function analyzeCvProfile(cv) {
     skillCount: techniques.length + logiciels.length + autres.length,
     resumeChars: resume.length,
     bulletCount,
-    hasPhoto: Boolean(resolvePhotoUrl(cv)),
+    hasPhoto: Boolean(resolvePhotoUrl(synced)),
     hasContact: Boolean(
-      String(cv?.email || '').trim()
-      || String(cv?.telephone || '').trim()
-      || String(cv?.linkedin || '').trim(),
+      String(synced?.email || '').trim()
+      || String(synced?.telephone || '').trim()
+      || String(synced?.linkedin || '').trim(),
     ),
     hasIdentity: Boolean(
-      String(cv?.prenom || '').trim()
-      || String(cv?.nom || '').trim()
-      || String(cv?.titre_professionnel || '').trim(),
+      String(synced?.prenom || '').trim()
+      || String(synced?.first_name || '').trim()
+      || String(synced?.nom || '').trim()
+      || String(synced?.last_name || '').trim()
+      || String(synced?.titre_professionnel || '').trim(),
     ),
     isCreativeProfile: /design|créatif|creative|graphiste|ux|ui|marketing|brand|communication/.test(titre),
     isExecutiveProfile: /directeur|directrice|manager|chef|responsable|head|vp|ceo|cto|lead/.test(titre),
@@ -589,12 +626,17 @@ export function buildLayoutFromVisionDetection(cv, visionMeta = {}, templatesLis
     template,
     recommendedTemplateId,
   );
+  result.layout = ensureImportLayoutHasContent(result.layout, cv);
 
   return {
     ...result,
     layout: result.layout,
     blockCount: countLayoutBlocks(result.layout),
-    recommendedTemplateId,
+    contentBlockCount: countContentBlocks(result.layout),
+    recommendedTemplateId: resolveImportPersistTemplateId(
+      recommendedTemplateId,
+      template?.id || 'minimal',
+    ),
     importSource: 'vision-guided',
     visionConfidence: Number(visionMeta?.confidence ?? 0),
   };
@@ -859,6 +901,10 @@ export function adaptCanvasLayoutForCv(cv, layout, {
     };
   }
 
+  if (forImport) {
+    next = ensureImportLayoutHasContent(next, cv);
+  }
+
   return {
     layout: next,
     analysis,
@@ -866,6 +912,7 @@ export function adaptCanvasLayoutForCv(cv, layout, {
     removedBlockCount,
     resizedBlockCount,
     blockCount: countLayoutBlocks(next),
+    contentBlockCount: countContentBlocks(next),
   };
 }
 
@@ -888,7 +935,12 @@ export function buildAdaptedCanvasLayoutForCv(cv, template, options = {}) {
     }
     layout = applyLayoutPagination(layout);
   }
-  return { ...result, layout, blockCount: countLayoutBlocks(layout) };
+  return {
+    ...result,
+    layout,
+    blockCount: countLayoutBlocks(layout),
+    contentBlockCount: countContentBlocks(layout),
+  };
 }
 
 /**
@@ -1056,13 +1108,18 @@ export function buildStructuralImportLayout(cv, structuralLayout, {
       finalLayout = { ...finalLayout, theme: { ...existingTheme, ...patch } };
     }
   }
+  finalLayout = ensureImportLayoutHasContent(finalLayout, cv);
   return {
     layout: finalLayout,
     analysis,
-    recommendedTemplateId: templateId || finalLayout.theme?.template_id || 'imported',
+    recommendedTemplateId: resolveImportPersistTemplateId(
+      templateId || finalLayout.theme?.template_id,
+      'minimal',
+    ),
     removedBlockCount: 0,
     resizedBlockCount: 0,
     blockCount: countLayoutBlocks(finalLayout),
+    contentBlockCount: countContentBlocks(finalLayout),
     importSource: 'structural',
   };
 }
@@ -1124,5 +1181,11 @@ export function buildFullCanvasImportLayout(cv, templatesList = [], {
     template,
     recommendedTemplateId,
   );
-  return { ...result, importSource: 'preset' };
+  result.layout = ensureImportLayoutHasContent(result.layout, cv);
+  return {
+    ...result,
+    blockCount: countLayoutBlocks(result.layout),
+    contentBlockCount: countContentBlocks(result.layout),
+    importSource: 'preset',
+  };
 }

--- a/frontend/src/lib/canvasCvImportAdapter.js
+++ b/frontend/src/lib/canvasCvImportAdapter.js
@@ -1146,13 +1146,18 @@ export function buildStructuralImportLayout(cv, structuralLayout, {
     }
   }
   finalLayout = ensureImportLayoutHasContent(finalLayout, cv);
+  const persistedTemplateId = resolveImportPersistTemplateId(
+    templateId || finalLayout.theme?.template_id,
+    'minimal',
+  );
+  finalLayout = {
+    ...finalLayout,
+    theme: { ...(finalLayout.theme || {}), template_id: persistedTemplateId },
+  };
   return {
     layout: finalLayout,
     analysis,
-    recommendedTemplateId: resolveImportPersistTemplateId(
-      templateId || finalLayout.theme?.template_id,
-      'minimal',
-    ),
+    recommendedTemplateId: persistedTemplateId,
     removedBlockCount: 0,
     resizedBlockCount: 0,
     blockCount: countLayoutBlocks(finalLayout),

--- a/frontend/src/lib/cvImportUtils.js
+++ b/frontend/src/lib/cvImportUtils.js
@@ -185,26 +185,36 @@ export function cvFromImportPayload(parsed) {
   const src = parsed?.cv && typeof parsed.cv === 'object' ? parsed.cv : parsed;
   if (!src || typeof src !== 'object') return { ...base };
 
+  // Certains parsers renvoient identity/contact imbriqués (dual-key / schema API).
+  const identity = src.identity && typeof src.identity === 'object' ? src.identity : {};
+  const contact = src.contact && typeof src.contact === 'object' ? src.contact : {};
+
   const competences = src.competences && typeof src.competences === 'object'
     ? src.competences
     : {};
 
-  const prenom = String(src.prenom ?? src.first_name ?? '').trim();
-  const nom = String(src.nom ?? src.last_name ?? '').trim();
+  const prenom = String(
+    src.prenom ?? src.first_name ?? identity.prenom ?? identity.first_name ?? '',
+  ).trim();
+  const nom = String(
+    src.nom ?? src.last_name ?? identity.nom ?? identity.last_name ?? '',
+  ).trim();
 
   return syncCvDualKeys({
     ...base,
     prenom,
     nom,
-    first_name: String(src.first_name ?? prenom).trim() || prenom,
-    last_name: String(src.last_name ?? nom).trim() || nom,
-    email: String(src.email ?? '').trim(),
-    telephone: String(src.telephone ?? '').trim(),
-    linkedin: String(src.linkedin ?? '').trim(),
-    ville: String(src.ville ?? '').trim(),
-    titre_professionnel: String(src.titre_professionnel ?? '').trim(),
+    first_name: String(src.first_name ?? identity.first_name ?? prenom).trim() || prenom,
+    last_name: String(src.last_name ?? identity.last_name ?? nom).trim() || nom,
+    email: String(src.email ?? contact.email ?? '').trim(),
+    telephone: String(src.telephone ?? contact.telephone ?? contact.phone ?? '').trim(),
+    linkedin: String(src.linkedin ?? contact.linkedin ?? '').trim(),
+    ville: String(src.ville ?? contact.ville ?? contact.city ?? '').trim(),
+    titre_professionnel: String(
+      src.titre_professionnel ?? identity.titre_professionnel ?? identity.title ?? '',
+    ).trim(),
     resume: String(src.resume ?? '').trim(),
-    photo_url: String(src.photo_url ?? '').trim(),
+    photo_url: String(src.photo_url ?? identity.photo_url ?? '').trim(),
     experiences: Array.isArray(src.experiences) ? src.experiences : [],
     formations: Array.isArray(src.formations) ? src.formations : [],
     certifications: Array.isArray(src.certifications) ? src.certifications : [],

--- a/frontend/src/lib/importLayoutVariants.js
+++ b/frontend/src/lib/importLayoutVariants.js
@@ -14,6 +14,8 @@ import { applyAtsLayoutOptimizations } from './atsLayoutOptimize.js';
 import {
   buildAdaptedCanvasLayoutForCv,
   buildFullCanvasImportLayout,
+  countContentBlocks,
+  ensureImportLayoutHasContent,
 } from './canvasCvImportAdapter.js';
 import { applyLayoutPagination } from './layoutPagination.js';
 
@@ -62,8 +64,11 @@ export function pickAtsSafeTemplate(templatesList = []) {
   return { id: 'minimal', name: 'Minimal', tags: ['ats-safe', 'single-column', 'no-sidebar'] };
 }
 
-function toVariant(id, result, overrides = {}) {
-  const layout = overrides.layout ?? result?.layout ?? null;
+function toVariant(id, result, overrides = {}, cv = null) {
+  let layout = overrides.layout ?? result?.layout ?? null;
+  if (layout && cv) {
+    layout = ensureImportLayoutHasContent(layout, cv);
+  }
   return {
     id,
     label: IMPORT_VARIANT_LABELS[id] || id,
@@ -75,6 +80,10 @@ function toVariant(id, result, overrides = {}) {
       ?? '',
     importSource: overrides.importSource ?? result?.importSource ?? 'preset',
     blockCount: overrides.blockCount ?? result?.blockCount ?? countBlocks(layout),
+    contentBlockCount:
+      overrides.contentBlockCount
+      ?? result?.contentBlockCount
+      ?? countContentBlocks(layout),
   };
 }
 
@@ -120,19 +129,21 @@ export function buildImportLayoutVariants(cv, templatesList = [], options = {}) 
   // les blocs clipperaient / se chevaucheraient au clamp UI.
   let mixLayout = applyAtsLayoutOptimizations(cloneLayout(designResult.layout));
   mixLayout = applyLayoutPagination(mixLayout);
+  mixLayout = ensureImportLayoutHasContent(mixLayout, cv);
   const mixVariant = toVariant('mix', designResult, {
     layout: mixLayout,
     importSource: 'mix',
     blockCount: countBlocks(mixLayout),
-  });
+    contentBlockCount: countContentBlocks(mixLayout),
+  }, cv);
 
   return {
     variants: [
       toVariant('ats-safe', atsSafeResult, {
         recommendedTemplateId: atsTemplate.id || 'minimal',
         importSource: 'ats-safe',
-      }),
-      toVariant('design', designResult),
+      }, cv),
+      toVariant('design', designResult, {}, cv),
       mixVariant,
     ],
   };

--- a/frontend/tests/unit/canvasCvImportAdapter.test.js
+++ b/frontend/tests/unit/canvasCvImportAdapter.test.js
@@ -549,5 +549,6 @@ test('AXE-344: structural import ne persiste pas template_id imported', () => {
   };
   const result = buildStructuralImportLayout(DENSE_CV, structural, { templateId: 'imported' });
   assert.notEqual(result.recommendedTemplateId, 'imported');
+  assert.equal(result.layout.theme?.template_id, result.recommendedTemplateId);
   assert.ok(result.contentBlockCount >= 1);
 });

--- a/frontend/tests/unit/canvasCvImportAdapter.test.js
+++ b/frontend/tests/unit/canvasCvImportAdapter.test.js
@@ -17,6 +17,7 @@ import {
   isStructuralLayout,
   mergePresetDecorations,
   recommendTemplateId,
+  resolveImportPersistTemplateId,
 } from '../../src/lib/canvasCvImportAdapter.js';
 import { createCanvasLayoutForTemplate } from '../../src/lib/layoutTemplatePresets.js';
 import { createStarterLayoutV3, sanitizeLayoutV3 } from '../../src/lib/cvLayoutModelV3.js';
@@ -439,4 +440,102 @@ test('mergePresetDecorations ajoute bandeaux preset si absents', () => {
   const merged = mergePresetDecorations(vision, preset);
   const rects = merged.pages[0].blocks.filter((b) => b.type === 'shape:rect');
   assert.ok(rects.length >= 1);
+});
+
+test('AXE-344: forImport refuse un canvas décoratif-only (filet seul)', () => {
+  const emptyishCv = {
+    prenom: 'Camille',
+    nom: 'Dupont',
+    email: 'camille@ex.com',
+    experiences: [],
+    formations: [],
+    certifications: [],
+    projets: [],
+    competences: { techniques: [], logiciels: [], langues: [], autres: [] },
+  };
+  const decorativeOnly = {
+    version: 3,
+    format: 'A4',
+    grid: 'free',
+    unit: 'mm',
+    theme: {},
+    pages: [{
+      id: 'p1',
+      blocks: [
+        {
+          id: 'deco',
+          type: 'shape:rect',
+          x: 0,
+          y: 0,
+          w: 8,
+          h: 297,
+          z: 1,
+          style: { color: '#003c33' },
+        },
+      ],
+    }],
+  };
+  const { layout, contentBlockCount } = adaptCanvasLayoutForCv(emptyishCv, decorativeOnly, {
+    forImport: true,
+    templatesList: [{ id: 'minimal' }],
+    templateId: 'minimal',
+  });
+  assert.ok(contentBlockCount >= 1);
+  const types = (layout.pages[0].blocks || []).map((b) => b.type);
+  assert.ok(types.includes('identity') || types.includes('contact'));
+  assert.ok(!types.every((t) => t === 'shape:rect' || t === 'shape:line'));
+});
+
+test('AXE-344: buildFullCanvasImportLayout peuplé même CV sparse', () => {
+  const templates = [{ id: 'minimal', name: 'Minimal' }];
+  const sparse = {
+    prenom: 'Léa',
+    nom: 'Martin',
+    email: 'lea@ex.com',
+    experiences: [],
+    formations: [],
+    certifications: [],
+    projets: [],
+    competences: { techniques: [], logiciels: [], langues: [], autres: [] },
+  };
+  const result = buildFullCanvasImportLayout(sparse, templates);
+  assert.ok(result.contentBlockCount >= 1);
+  assert.ok(
+    result.layout.pages[0].blocks.some((b) => b.type !== 'shape:rect' && b.type !== 'shape:line'),
+  );
+});
+
+test('AXE-344: analyzeCvProfile lit dual-keys first_name/last_name', () => {
+  const a = analyzeCvProfile({
+    first_name: 'Sam',
+    last_name: 'Lee',
+    email: 'sam@ex.com',
+  });
+  assert.equal(a.hasIdentity, true);
+  assert.equal(a.hasContact, true);
+});
+
+test('AXE-344: resolveImportPersistTemplateId refuse « imported »', () => {
+  assert.equal(resolveImportPersistTemplateId('imported', 'minimal'), 'minimal');
+  assert.equal(resolveImportPersistTemplateId('', 'classic'), 'classic');
+  assert.equal(resolveImportPersistTemplateId('modern', 'minimal'), 'modern');
+});
+
+test('AXE-344: structural import ne persiste pas template_id imported', () => {
+  const structural = {
+    version: 3,
+    format: 'A4',
+    grid: 'free',
+    unit: 'mm',
+    theme: { template_id: 'imported' },
+    pages: [{
+      id: 'p1',
+      blocks: [
+        { id: 't1', type: 'text', content: 'Hello', x: 10, y: 10, w: 80, h: 12, z: 1, style: {} },
+      ],
+    }],
+  };
+  const result = buildStructuralImportLayout(DENSE_CV, structural, { templateId: 'imported' });
+  assert.notEqual(result.recommendedTemplateId, 'imported');
+  assert.ok(result.contentBlockCount >= 1);
 });

--- a/frontend/tests/unit/canvasCvImportAdapter.test.js
+++ b/frontend/tests/unit/canvasCvImportAdapter.test.js
@@ -18,6 +18,7 @@ import {
   mergePresetDecorations,
   recommendTemplateId,
   resolveImportPersistTemplateId,
+  cvHasSeedableProfileContent,
 } from '../../src/lib/canvasCvImportAdapter.js';
 import { createCanvasLayoutForTemplate } from '../../src/lib/layoutTemplatePresets.js';
 import { createStarterLayoutV3, sanitizeLayoutV3 } from '../../src/lib/cvLayoutModelV3.js';
@@ -519,6 +520,17 @@ test('AXE-344: resolveImportPersistTemplateId refuse « imported »', () => {
   assert.equal(resolveImportPersistTemplateId('imported', 'minimal'), 'minimal');
   assert.equal(resolveImportPersistTemplateId('', 'classic'), 'classic');
   assert.equal(resolveImportPersistTemplateId('modern', 'minimal'), 'modern');
+});
+
+test('AXE-344: cvHasSeedableProfileContent détecte profil onboarding', () => {
+  assert.equal(cvHasSeedableProfileContent({}), false);
+  assert.equal(cvHasSeedableProfileContent({ prenom: 'Léa', nom: 'Martin' }), true);
+  assert.equal(cvHasSeedableProfileContent({
+    experiences: [{ poste: 'Dev', entreprise: 'Co', bullet_points: [] }],
+  }), true);
+  assert.equal(cvHasSeedableProfileContent({
+    experiences: [{ poste: '', entreprise: '', bullet_points: [''] }],
+  }), false);
 });
 
 test('AXE-344: structural import ne persiste pas template_id imported', () => {

--- a/frontend/tests/unit/cvImportUtils.test.js
+++ b/frontend/tests/unit/cvImportUtils.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { extractImportApiResponse } from '../../src/lib/cvImportUtils.js';
+import { cvFromImportPayload, extractImportApiResponse } from '../../src/lib/cvImportUtils.js';
 
 test('extractImportApiResponse : import_policy exposé', () => {
   const result = extractImportApiResponse({
@@ -24,4 +24,30 @@ test('extractImportApiResponse : import_policy exposé', () => {
 test('extractImportApiResponse : sans policy → null', () => {
   const result = extractImportApiResponse({ cv: { nom: 'Durand' } });
   assert.equal(result.importPolicy, null);
+});
+
+test('AXE-344: cvFromImportPayload aplatit identity/contact imbriqués', () => {
+  const cv = cvFromImportPayload({
+    identity: {
+      first_name: 'Ada',
+      last_name: 'Lovelace',
+      titre_professionnel: 'Mathématicienne',
+    },
+    contact: {
+      email: 'ada@ex.com',
+      telephone: '0600000000',
+      linkedin: 'https://linkedin.com/in/ada',
+      ville: 'Londres',
+    },
+    experiences: [{ poste: 'Analyste', entreprise: 'Babbage', bullet_points: [] }],
+  });
+  assert.equal(cv.prenom, 'Ada');
+  assert.equal(cv.nom, 'Lovelace');
+  assert.equal(cv.first_name, 'Ada');
+  assert.equal(cv.last_name, 'Lovelace');
+  assert.equal(cv.email, 'ada@ex.com');
+  assert.equal(cv.telephone, '0600000000');
+  assert.equal(cv.titre_professionnel, 'Mathématicienne');
+  assert.equal(cv.ville, 'Londres');
+  assert.equal(cv.experiences.length, 1);
 });


### PR DESCRIPTION
## Summary
- Garantit des blocs de contenu après import (plus de canvas décoratif-only / filet seul) via `ensureImportLayoutHasContent`.
- Aplatit `identity`/`contact` imbriqués et lit les dual-keys pour peupler le canvas ; refuse `template_id: imported`.
- Appelle `onSaveSuccess` après save pour rafraîchir la preview Stable ; preview du layout pendant le chooser.

Fixes AXE-344
Closes #116

## Test plan
- [ ] Importer un PDF texte → blocs identité/sections visibles sur Beta
- [ ] Basculer hors-Beta : preview cohérente avec le CV importé
- [ ] CV sparse / Word faible → message clair ou layout adapté, jamais canvas vide silencieux
- [ ] `npm run test:unit` (tests AXE-344) + pre-push OK


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Amélioration de l’import de CV depuis un fichier ou du texte, avec prise en charge de formats de données variés.
  * Génération de mises en page contenant du contenu, y compris pour les profils peu renseignés.
  * Meilleure prise en charge des informations personnelles, coordonnées, intitulés professionnels et photos importés.
  * L’aperçu affiche désormais immédiatement une mise en page par défaut lors de l’import.

* **Corrections**
  * Fiabilisation de la sauvegarde des CV importés et de la sélection des modèles persistants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->