### PR TITLE
improve(AXE-342): CTA « Compléter mon profil » en texte souligné

### DIFF
--- a/frontend/src/components/OnboardingWizard.jsx
+++ b/frontend/src/components/OnboardingWizard.jsx
@@ -258,10 +258,10 @@ export default function OnboardingWizard({ session, onComplete }) {
             </p>
             <div className="onb-actions">
               <button type="button" className="button button-primary button--lg" onClick={handleLaunch}>
-                Lancer ma première candidature
+                Créer mon CV adapté
               </button>
-              <button type="button" className="button button-secondary" onClick={handleGoToProfile}>
-                Compléter mon profil d'abord
+              <button type="button" className="button ds-button ds-button--link onb-actions__link" onClick={handleGoToProfile}>
+                Compléter mon profil d&apos;abord
               </button>
             </div>
           </div>

--- a/frontend/src/styles/OnboardingWizard.css
+++ b/frontend/src/styles/OnboardingWizard.css
@@ -306,6 +306,11 @@
   font-size: 1rem;
 }
 
+.onb-actions__link {
+  margin-top: 0.15rem;
+  font-size: 0.875rem;
+}
+
 /* Ready state */
 .onb-content--ready {
   padding-top: 1.5rem;


### PR DESCRIPTION
## Summary
- Sur l’écran onboarding « Ton profil est prêt », « Compléter mon profil » devient un lien souligné (ds-button--link).
- Un seul CTA primaire : « Créer mon CV adapté » (parcours candidature).

Fixes AXE-342
Closes #114

## Test plan
- [ ] Finir l’onboarding jusqu’à « Ton profil est prêt »
- [ ] Vérifier un seul bouton primaire + lien souligné pour le profil
- [ ] Primary → `/app/cv` ; lien → `/app/profil`


Made with [Cursor](https://cursor.com)