### PR TITLE
feat: .env Cloud Agents depuis les secrets Cursor

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,4 +1,4 @@
 {
-  "install": "python3 -m venv .venv\n.venv/bin/python -m pip install --upgrade pip\n.venv/bin/pip install -r backend/requirements.txt -r backend/requirements-dev.txt\nnpm ci --prefix frontend\n.venv/bin/python scripts/materialize_dotenv.py --root .",
+  "install": "sudo apt-get update -o Acquire::Retries=3\nsudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3.12-venv libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 libffi-dev shared-mime-info fonts-dejavu-core\npython3 -m venv .venv\n.venv/bin/python -m pip install --upgrade pip\n.venv/bin/pip install -r backend/requirements.txt -r backend/requirements-dev.txt\nnpm ci --prefix frontend\n.venv/bin/python scripts/materialize_dotenv.py --root .",
   "start": "bash scripts/dev.sh"
 }

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "install": "python3 -m venv .venv\n.venv/bin/python -m pip install --upgrade pip\n.venv/bin/pip install -r backend/requirements.txt -r backend/requirements-dev.txt\nnpm ci --prefix frontend\n.venv/bin/python scripts/materialize_dotenv.py --root .",
+  "start": "bash scripts/dev.sh"
+}

--- a/README.md
+++ b/README.md
@@ -144,6 +144,19 @@ npm run dev
 
 [http://localhost:5173](http://localhost:5173)
 
+Linux / macOS / Cursor Cloud : `bash scripts/setup-dev.sh` puis `bash scripts/dev.sh` (API `:8000` + front `:5173`).
+
+### Cursor Cloud Agents (n'importe quel PC)
+
+Les secrets **ne vont pas dans Git** et **ne se copient pas** sur tes laptops. Ils sont injectes dans les VMs Cloud Agent depuis le dashboard Cursor (Environment → Secrets), puis `scripts/materialize_dotenv.py` ecrit `.env` et `frontend/.env` au boot.
+
+| Ou | Quoi faire |
+| --- | --- |
+| Agent Cloud (web / n'importe quel PC) | Ajouter les secrets dans Cursor (noms identiques au `.env.example`). `.cursor/environment.json` installe les deps et lance `bash scripts/dev.sh`. |
+| PC physique | `cp .env.example .env` et `cp frontend/.env.example frontend/.env`, ou exporter les memes variables puis `python scripts/materialize_dotenv.py`. |
+
+Secrets minimum pour un local utile : `GEMINI_API_KEY`, `SUPABASE_URL`, `SUPABASE_SERVICE_KEY`, `SUPABASE_JWT_SECRET`, `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`.
+
 ---
 
 ## Variables d'environnement

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Point d'entree de la documentation technique, securite et operations.
 | Spike import PDF/Word → CV scoré (AXE-41) | [docs/axe-41-import-pipeline-spike.md](axe-41-import-pipeline-spike.md) |
 | Verifier la Definition of Done engineering | `docs/engineering-standards.md` |
 | Appliquer la baseline securite | `docs/security.md` |
+| Secrets Cursor Cloud / `.env` local | [README.md](../README.md) (section Cursor Cloud Agents) + `scripts/materialize_dotenv.py` |
 | Deployer en production | `docs/deploy.md` |
 | Utiliser les commandes ops courantes | `docs/ops-commands.md` |
 | Acceder a la version courte des commandes | `docs/COMMANDS.md` |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -30,6 +30,10 @@ Flux recommande pour produire des PR petites, lisibles et faciles a merger.
 
 ## 2) Setup local
 
+Linux / macOS : `bash scripts/setup-dev.sh` (venv, hooks, materialise `.env` depuis l'environnement si present).
+
+Les secrets Cursor Cloud ne remplacent pas un `.env` sur un PC physique.
+
 ### Backend (Python)
 
 ```powershell

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Dev local / Cursor Cloud : materialise .env puis lance API + frontend.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+export PYTHONPATH="$REPO_ROOT${PYTHONPATH:+:$PYTHONPATH}"
+
+if [[ -x "$REPO_ROOT/.venv/bin/python" ]]; then
+  PYTHON="$REPO_ROOT/.venv/bin/python"
+else
+  PYTHON="${PYTHON:-python3}"
+fi
+
+"$PYTHON" "$REPO_ROOT/scripts/materialize_dotenv.py" --root "$REPO_ROOT"
+
+UVICORN="$REPO_ROOT/.venv/bin/uvicorn"
+if [[ ! -x "$UVICORN" ]]; then
+  UVICORN="uvicorn"
+fi
+
+"$UVICORN" backend.main:app --reload --host 0.0.0.0 --port 8000 &
+BACK_PID=$!
+cleanup() {
+  kill "$BACK_PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+npm --prefix frontend run dev -- --host 0.0.0.0 --port 5173

--- a/scripts/materialize_dotenv.py
+++ b/scripts/materialize_dotenv.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Write `.env` and `frontend/.env` from process env (Cursor Cloud secrets).
+
+Never prints secret values. Existing files are merged: injected env vars win,
+then already-set file values, then safe local-dev defaults.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+ASSIGN_RE = re.compile(r"^(\s*#\s*)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
+
+DEV_DEFAULTS = {
+    "ENVIRONMENT": "development",
+    "VITE_API_URL": "http://localhost:8000",
+    "CV_BOT_API_BASE_URL": "http://localhost:8000",
+    "CV_BOT_FRONTEND_URL": "http://localhost:5173",
+}
+
+# Public Vite URL is the same project URL as the backend secret.
+ALIASES = {
+    "VITE_SUPABASE_URL": "SUPABASE_URL",
+}
+
+TARGETS = (
+    (".env.example", ".env"),
+    (os.path.join("frontend", ".env.example"), os.path.join("frontend", ".env")),
+)
+
+
+def _clean(value: str) -> str:
+    return value.replace("\r", "").replace("\n", "").strip()
+
+
+def parse_assignments(text: str) -> dict[str, str]:
+    found: dict[str, str] = {}
+    for raw in text.splitlines():
+        match = ASSIGN_RE.match(raw)
+        if not match:
+            continue
+        _prefix, key, value = match.groups()
+        if key not in found:
+            found[key] = _clean(value)
+    return found
+
+
+def resolve_value(
+    key: str,
+    *,
+    example_value: str,
+    was_commented: bool,
+    existing: Mapping[str, str],
+    environ: Mapping[str, str],
+) -> str | None:
+    """Return the value to write, or None to keep the original example line."""
+    env_val = _clean(environ.get(key, ""))
+    if env_val:
+        return env_val
+
+    existing_val = _clean(existing.get(key, ""))
+    if existing_val:
+        return existing_val
+
+    alias = ALIASES.get(key)
+    if alias:
+        alias_val = _clean(environ.get(alias, "")) or _clean(existing.get(alias, ""))
+        if alias_val:
+            return alias_val
+
+    default = DEV_DEFAULTS.get(key)
+    if default and (was_commented or not _clean(example_value)):
+        return default
+
+    if was_commented:
+        return None
+    return example_value
+
+
+def fill_template(example: str, existing_text: str | None, environ: Mapping[str, str]) -> str:
+    existing = parse_assignments(existing_text or "")
+    lines_out: list[str] = []
+    for raw in example.splitlines():
+        match = ASSIGN_RE.match(raw)
+        if not match:
+            lines_out.append(raw)
+            continue
+        prefix, key, example_value = match.groups()
+        was_commented = bool(prefix)
+        value = resolve_value(
+            key,
+            example_value=example_value,
+            was_commented=was_commented,
+            existing=existing,
+            environ=environ,
+        )
+        if value is None:
+            lines_out.append(raw)
+            continue
+        lines_out.append(f"{key}={value}")
+    return "\n".join(lines_out) + "\n"
+
+
+def summarize(text: str) -> tuple[int, int]:
+    filled = 0
+    empty = 0
+    for raw in text.splitlines():
+        match = ASSIGN_RE.match(raw)
+        if not match or match.group(1):
+            continue
+        if _clean(match.group(3)):
+            filled += 1
+        else:
+            empty += 1
+    return filled, empty
+
+
+def materialize(root: Path, environ: Mapping[str, str]) -> list[Path]:
+    written: list[Path] = []
+    for example_rel, dest_rel in TARGETS:
+        example_path = root / example_rel
+        dest_path = root / dest_rel
+        if not example_path.is_file():
+            raise FileNotFoundError(f"Template manquant: {example_path}")
+        example = example_path.read_text(encoding="utf-8")
+        existing = dest_path.read_text(encoding="utf-8") if dest_path.is_file() else None
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        dest_path.write_text(fill_template(example, existing, environ), encoding="utf-8")
+        written.append(dest_path)
+        filled, empty = summarize(dest_path.read_text(encoding="utf-8"))
+        print(f"Wrote {dest_rel} ({filled} keys set, {empty} still empty)")
+    return written
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Repository root (default: current directory)",
+    )
+    args = parser.parse_args(argv)
+    root = Path(args.root).resolve()
+    try:
+        materialize(root, os.environ)
+    except FileNotFoundError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -26,8 +26,14 @@ if command -v pre-commit >/dev/null 2>&1; then
 fi
 
 echo ""
+echo "=== .env (depuis secrets shell / Cursor Cloud, sans ecraser les valeurs deja posees) ==="
+python "$REPO_ROOT/scripts/materialize_dotenv.py" --root "$REPO_ROOT"
+
+echo ""
 echo "=== Cursor ==="
 echo "Les hooks projet sont dans .cursor/hooks.json (bloque git push si la CI locale échoue)."
 echo "Règle agent : .cursor/rules/pre-push-ci.mdc"
+echo "Secrets Cloud Agents : dashboard Cursor → Environment secrets (jamais dans Git)."
 echo ""
 echo "OK - setup dev terminé. Tester : bash scripts/pre-push.sh --skip-extras --skip-gitleaks"
+echo "Lancer l'app : bash scripts/dev.sh"

--- a/tests/test_materialize_dotenv.py
+++ b/tests/test_materialize_dotenv.py
@@ -1,0 +1,94 @@
+"""Tests for scripts/materialize_dotenv.py (Cursor Cloud / local .env merge)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "materialize_dotenv.py"
+
+
+def load_mod():
+    spec = importlib.util.spec_from_file_location("materialize_dotenv", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def dotenv():
+    return load_mod()
+
+
+def test_fill_injects_secrets_and_keeps_comments(dotenv):
+    example = (
+        "# header\n"
+        "GEMINI_API_KEY=\n"
+        "# GEMINI_MODEL=gemini-2.5-flash-lite\n"
+        "SUPABASE_URL=\n"
+        "ENVIRONMENT=development\n"
+    )
+    out = dotenv.fill_template(example, None, {"GEMINI_API_KEY": "secret-abc"})
+    assert "GEMINI_API_KEY=secret-abc" in out
+    assert "# GEMINI_MODEL=gemini-2.5-flash-lite" in out
+    assert "# header" in out
+    assert "ENVIRONMENT=development" in out
+
+
+def test_existing_file_wins_over_empty_env(dotenv):
+    example = "GEMINI_API_KEY=\nSUPABASE_URL=\n"
+    existing = "GEMINI_API_KEY=keep-me\nSUPABASE_URL=\n"
+    out = dotenv.fill_template(example, existing, {})
+    assert "GEMINI_API_KEY=keep-me" in out
+
+
+def test_process_env_overrides_existing_file(dotenv):
+    example = "GEMINI_API_KEY=\n"
+    existing = "GEMINI_API_KEY=old\n"
+    out = dotenv.fill_template(example, existing, {"GEMINI_API_KEY": "new-from-cloud"})
+    assert "GEMINI_API_KEY=new-from-cloud" in out
+    assert "old" not in out
+
+
+def test_vite_supabase_url_aliases_backend_url(dotenv):
+    example = "VITE_SUPABASE_URL=\nSUPABASE_URL=\n"
+    out = dotenv.fill_template(example, None, {"SUPABASE_URL": "https://proj.supabase.co"})
+    assert "VITE_SUPABASE_URL=https://proj.supabase.co" in out
+    assert "SUPABASE_URL=https://proj.supabase.co" in out
+
+
+def test_dev_defaults_for_local_urls(dotenv):
+    example = "VITE_API_URL=\nCV_BOT_FRONTEND_URL=\nENVIRONMENT=\n"
+    out = dotenv.fill_template(example, None, {})
+    assert "VITE_API_URL=http://localhost:8000" in out
+    assert "CV_BOT_FRONTEND_URL=http://localhost:5173" in out
+    assert "ENVIRONMENT=development" in out
+
+
+def test_does_not_print_secret_values(dotenv, tmp_path, capsys):
+    (tmp_path / ".env.example").write_text("GEMINI_API_KEY=\n", encoding="utf-8")
+    frontend = tmp_path / "frontend"
+    frontend.mkdir()
+    (frontend / ".env.example").write_text("VITE_API_URL=\n", encoding="utf-8")
+    dotenv.materialize(tmp_path, {"GEMINI_API_KEY": "super-secret-value"})
+    captured = capsys.readouterr()
+    assert "super-secret-value" not in captured.out
+    assert "super-secret-value" not in captured.err
+    assert (tmp_path / ".env").read_text(encoding="utf-8").count("super-secret-value") == 1
+
+
+def test_materialize_writes_both_env_files(dotenv, tmp_path):
+    (tmp_path / ".env.example").write_text("GEMINI_API_KEY=\n", encoding="utf-8")
+    frontend = tmp_path / "frontend"
+    frontend.mkdir()
+    (frontend / ".env.example").write_text("VITE_SUPABASE_ANON_KEY=\n", encoding="utf-8")
+    written = dotenv.materialize(
+        tmp_path,
+        {"GEMINI_API_KEY": "k", "VITE_SUPABASE_ANON_KEY": "anon"},
+    )
+    assert [p.name for p in written] == [".env", ".env"]
+    assert "GEMINI_API_KEY=k" in (tmp_path / ".env").read_text(encoding="utf-8")
+    assert "VITE_SUPABASE_ANON_KEY=anon" in (frontend / ".env").read_text(encoding="utf-8")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

- Ajout de `.cursor/environment.json` (install deps + `scripts/dev.sh`) pour les Cloud Agents.
- Nouveau script `scripts/materialize_dotenv.py` : écrit `.env` et `frontend/.env` depuis les variables injectées (secrets Cursor), sans les afficher ni les committer.
- `bash scripts/dev.sh` lance API (`:8000`) + frontend (`:5173`).
- `setup-dev.sh` materialise aussi le `.env` si les variables sont déjà dans le shell.
- L’install Cloud installe aussi `python3-venv` et les libs WeasyPrint (Pango).

## Why

Pouvoir lancer l’app depuis n’importe quel PC via un Cloud Agent, sans coller un `.env` dans Git. Les secrets restent dans le dashboard Cursor (Environment secrets) et ne se copient **pas** automatiquement sur les laptops.

## Validation

- [x] Backend lint passes (`ruff`, `black`, `mypy`)
- [x] Backend tests pass (`pytest`)
- [x] Coverage threshold passes (backend >= 60%)
- [ ] Backend security checks pass (`bandit`, `pip-audit`) — skippés via `--skip-extras` comme la CI locale habituelle
- [x] Frontend lint passes (`npm --prefix frontend run lint`)
- [x] Docs updated if needed
- [x] No secrets committed

`bash scripts/pre-push.sh --skip-extras --skip-gitleaks` : OK.

Draft environment build en cours : `bld-20260820-796eeaeb-1215-48ad-a389-4f2f6347fabf` (branche `cursor/cloud-env-secrets-eec2`, non promotable tant que ce n’est pas `main`).

## Risk and rollback

- Risk: faible (scripts nouveaux + docs). Un Cloud Agent sans secrets aura un `.env` avec des clés vides (comportement déjà documenté via `.env.example`).
- Rollback: revert de la PR ; les secrets dashboard restent indépendants.

## Action requise après merge

Ajouter les secrets app dans Cursor (Environment → Secrets), noms identiques au `.env.example` : `GEMINI_API_KEY`, `SUPABASE_URL`, `SUPABASE_SERVICE_KEY`, `SUPABASE_JWT_SECRET`, `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`.

Linear MCP : l’auth dashboard s’applique aux **nouveaux** agents. Ce run-ci reste `needsAuth`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout d’un démarrage local simplifié pour l’API et le frontend.
  * Génération automatique des fichiers de configuration à partir des variables d’environnement, avec conservation des valeurs existantes.
  * Prise en charge du démarrage dans Cursor Cloud Agents.

* **Documentation**
  * Documentation enrichie sur l’installation locale, les secrets et le démarrage de l’application.

* **Tests**
  * Ajout de tests couvrant la génération de configuration, les priorités de valeurs et la protection des secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->