### PR TITLE
fix(AXE-350): malus ATS si contenu coupé hors A4

### DIFF
--- a/backend/services/ats_score/rules/__init__.py
+++ b/backend/services/ats_score/rules/__init__.py
@@ -28,6 +28,7 @@ parsing_rules: tuple = (
     # AXE-336 : plus de malus systematique « positions libres »
     # (layout.rule_free_canvas_text_positions est un no-op conserve pour API).
     free_canvas.rule_free_canvas_no_semantic_blocks,
+    free_canvas.rule_free_canvas_page_overflow,
     free_canvas.rule_free_canvas_missing_profile_sections,
     free_canvas.rule_free_canvas_reading_order,
     free_canvas.rule_identity_not_first_in_reading,

--- a/backend/services/ats_score/rules/free_canvas.py
+++ b/backend/services/ats_score/rules/free_canvas.py
@@ -24,6 +24,11 @@ from backend.services.ats_score.rules._helpers import (
 )
 from backend.services.ats_score.types import Rule, RuleSeverity
 
+# Aligné sur frontend/src/lib/cvLayoutModelV3.js et layout_renderer.PAGE_HEIGHT_MM.
+PAGE_HEIGHT_MM = 297.0
+OVERFLOW_EPS_MM = 0.01
+MALUS_PAGE_OVERFLOW = -25
+
 # Ordre canonique recommande pour un CV ATS (sections semantiques).
 _CANONICAL_READ_ORDER: tuple[str, ...] = (
     "identity",
@@ -285,3 +290,48 @@ def rule_contact_far_from_top(cv: dict[str, Any], layout: dict[str, Any]) -> Rul
                 ),
             )
     return None
+
+
+def _overflowing_blocks(layout: dict[str, Any]) -> list[dict[str, Any]]:
+    found: list[dict[str, Any]] = []
+    for block in iter_blocks(layout):
+        try:
+            y = float(block.get("y", 0))
+            h = float(block.get("h", 0))
+        except (TypeError, ValueError):
+            continue
+        if y + h > PAGE_HEIGHT_MM + OVERFLOW_EPS_MM:
+            found.append(block)
+    return found
+
+
+def rule_free_canvas_page_overflow(cv: dict[str, Any], layout: dict[str, Any]) -> Rule | None:
+    """Penalise un bloc dont le bas depasse la hauteur A4 (contenu coupe).
+
+    AXE-350 : un skills (ou autre) colle au bord inferieur etait encore compte
+    « present » → score 100 trompeur. Aligne le backend sur
+    ``layoutHasPageOverflow`` du frontend.
+    """
+    del cv
+    if get_grid(layout) != "free":
+        return None
+    overflowing = _overflowing_blocks(layout)
+    if not overflowing:
+        return None
+    ids: list[str] = []
+    for block in overflowing:
+        bid = block.get("id")
+        if isinstance(bid, str) and bid and bid not in ids:
+            ids.append(bid)
+    return Rule(
+        id="malus_page_overflow_clipped",
+        label="Contenu coupe en bas de page (hors zone A4)",
+        delta=MALUS_PAGE_OVERFLOW,
+        severity=RuleSeverity.ERROR,
+        block_ids=tuple(ids[:6]),
+        advice=(
+            "Un bloc depasse le bas de la page A4 : le contenu est coupe a l'impression. "
+            "Deplace-le sur la page suivante ou reduis sa hauteur. "
+            "Un score 100 n'est pas credible avec du texte hors zone imprimable."
+        ),
+    )

--- a/backend/services/ats_score/version.py
+++ b/backend/services/ats_score/version.py
@@ -9,4 +9,4 @@ les scores produits. Permet de :
 Format : ``YYYY.MM`` ou ``YYYY.MM.patch`` pour les corrections mineures.
 """
 
-SCORING_VERSION = "2026.08.1"
+SCORING_VERSION = "2026.08.2"

--- a/docs/ats-coach-actionable-fixes.md
+++ b/docs/ats-coach-actionable-fixes.md
@@ -14,6 +14,7 @@ une règle a un `fixKind` qui **modifie vraiment** le layout.
 | `fix-font` | Polices → Arial |
 | `fix-body-font-size` | Corps → 10 pt |
 | `single-column` | Free : même `x` ; template : `sidebar_ratio=0` |
+| `spill-overflow` | Déplace les blocs hors A4 vers la page suivante (`applyLayoutPagination`) |
 
 Si `fixKind` est `null`, l’UI affiche **`notApplicableReason`**
 (ex. « À remplir dans le contenu du profil »).

--- a/docs/ats-score-cv-vs-layout.md
+++ b/docs/ats-score-cv-vs-layout.md
@@ -31,6 +31,8 @@ Dans `backend/services/ats_score/rules/content.py` :
   positions absolues (AXE-336). On score plutôt :
   - aucun bloc sémantique / profil non affiché
   - ordre de lecture ambigu, identité pas en tête, contact trop bas
+  - contenu coupé hors A4 (`y + h > 297 mm`, AXE-350) — un bloc présent
+    mais hors zone imprimable ne doit pas laisser le score à 100
   - multicolonnes détectées via clusters `x`
 - Verify-pdf reste le filet pour un export réellement illisible.
 

--- a/docs/canva-editor-audit.md
+++ b/docs/canva-editor-audit.md
@@ -66,7 +66,8 @@ Pieces principales :
 - `save_cv_base` preserve `layout` si le payload ne l'envoie pas.
 - `POST /api/pdf` utilise `layout_renderer.py` si un layout est fourni.
 - `layout_renderer.py` produit un HTML A4 absolu en mm.
-- `free_canvas.py` ajoute des regles ATS basees sur l'ordre spatial des blocs.
+- `free_canvas.py` ajoute des regles ATS basees sur l'ordre spatial des blocs
+  (dont overflow A4 : `malus_page_overflow_clipped`, AXE-350).
 
 ## Avis Produit Detaille
 

--- a/docs/editor-vision.md
+++ b/docs/editor-vision.md
@@ -454,6 +454,7 @@ Base : **100**. Plancher : **0**. Plafond : **100**.
 | Dates au format exotique | −1 par occurrence (plafond −5) | Regex stricte sur `cv.experiences[].date_*` |
 | Police "exotique" (script, decorative) | −5 | Allowlist : Arial, Calibri, Helvetica, Inter, Plus Jakarta Sans, Georgia, Times |
 | Taille de corps < 9pt ou > 12pt | −3 | `layout.theme.font_size_body` |
+| Contenu coupé hors A4 (canvas libre) | −25 | AXE-350 : `grid == "free"` et `y + h > PAGE_HEIGHT_MM` (297 mm). Un bloc `skills` collé au bord inférieur ne doit plus laisser le score à 100. |
 
 #### 9.2.3 Pénalités légères (préférences ATS)
 
@@ -1807,9 +1808,12 @@ autres blocs), priorité magnétique sur la grille. Fichiers :
 | `malus_identity_not_first` | −5 si l’identité n’est pas lue en premier |
 | `malus_experiences_before_resume` | −5 si expériences avant le résumé |
 | `malus_contact_low_on_page` | −3 si contact sous 30 % hauteur page |
+| `malus_free_canvas_no_semantic_blocks` | −20 si aucun bloc sémantique |
+| `malus_free_canvas_missing_profile_sections` | malus si le profil n’est pas affiché |
+| `malus_page_overflow_clipped` | −25 si un bloc dépasse 297 mm (AXE-350) |
 
 Le badge ATS en mode canvas libre envoie le `layout` v3 courant (plus le
-`template_id`). Version scoring : `2026.05.1`.
+`template_id`). Version scoring : `2026.08.2`.
 
 #### 14.5.9 Robustesse ATS + P3.10 pagination (livré)
 
@@ -1817,8 +1821,11 @@ Le badge ATS en mode canvas libre envoie le `layout` v3 courant (plus le
 pause pendant drag/resize, conservation du dernier score en erreur, bouton
 réessayer. Fichiers : `useAtsScoreFetching.js`, `atsScoreLayoutFingerprint.js`.
 
-**P3.10** : `layoutPagination.js` - blocs dont le bas dépasse 297 mm sont
-déplacés sur la page suivante à la fin du drag/resize (`pagination:auto`).
+**P3.10** : `layoutPagination.js` — helper `layoutHasPageOverflow` /
+`applyLayoutPagination` (spill vers la page suivante). AXE-350 : le scoring
+backend pénalise l’overflow (`malus_page_overflow_clipped`) ; le coach
+« Corriger » et la bannière canvas appellent le spill. Pas de spill silencieux
+à chaque drag (l’utilisateur garde le contrôle).
 
 #### 14.5.10 Bilan P3 (état livré)
 

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -113,6 +113,7 @@ import { isAtsSafe, sortTemplatesForEditor } from '../../lib/editorTemplateUtils
 import { resetTemplateOptionsToDefaults } from '../../lib/templateOptionsSchema.js';
 import { reflowColumnBlocksOnPage } from '../../lib/layoutReflow.js';
 import { moveBlockToPage } from '../../lib/canvasPageTransfer.js';
+import { applyLayoutPagination } from '../../lib/layoutPagination.js';
 import { useAutoSave } from '../../lib/useAutoSave.js';
 import { useLayoutHistory } from '../../lib/useLayoutHistory.js';
 import FreeCanvas from './FreeCanvas.jsx';
@@ -1022,6 +1023,16 @@ function CvEditorBeta({
     if (!layout || !canAppendBlankPage(layout)) return;
     const next = appendBlankPage(layout);
     commitLayout(next, { groupKey: 'page:add' });
+    setSelectedBlockIds([]);
+    setEditingBlockId(null);
+    if (cv) autoSave.schedule(cv);
+  }, [layout, commitLayout, cv, autoSave]);
+
+  const handleSpillOverflow = useCallback(() => {
+    if (!layout) return;
+    const next = applyLayoutPagination(layout);
+    if (next === layout) return;
+    commitLayout(next, { groupKey: 'page:spill-overflow' });
     setSelectedBlockIds([]);
     setEditingBlockId(null);
     if (cv) autoSave.schedule(cv);
@@ -2372,6 +2383,7 @@ function CvEditorBeta({
               onBlockAutoHeight={handleBlockAutoHeight}
               onAddPage={handleAddCanvasPage}
               onRemovePage={handleRemoveCanvasPage}
+              onSpillOverflow={handleSpillOverflow}
               onEmptyAddSection={handleEmptyAddSection}
               onEmptyChooseTemplate={handleEmptyChooseTemplate}
             />

--- a/frontend/src/components/editor/FreeCanvas.jsx
+++ b/frontend/src/components/editor/FreeCanvas.jsx
@@ -9,6 +9,8 @@ import {
 import { clampBlockPositionOnPage } from '../../lib/canvasPageTransfer.js';
 import { canAppendBlankPage, findBlock } from '../../lib/cvLayoutModelV3.js';
 import { PAGE_HEIGHT_MM, PAGE_WIDTH_MM } from '../../lib/cvLayoutModelV3.js';
+import { layoutHasPageOverflow } from '../../lib/layoutPagination.js';
+import Button from '../ui/Button.jsx';
 import {
   clientDeltaToMmDelta,
   dragGroupKey,
@@ -136,6 +138,7 @@ export default function FreeCanvas({
   onDropBlockPreset,
   onAddPage,
   onRemovePage,
+  onSpillOverflow,
   onEmptyAddSection,
   onEmptyChooseTemplate,
 }) {
@@ -688,6 +691,7 @@ export default function FreeCanvas({
     if (event.target?.closest?.('.free-canvas-block')) return;
     if (event.target?.closest?.('.free-canvas-page')) return;
     if (event.target?.closest?.('.free-canvas-add-page-row')) return;
+    if (event.target?.closest?.('.free-canvas-overflow-banner')) return;
     const match = findPageForMarquee(event.clientX, event.clientY);
     if (!match) {
       commitEditingBlock();
@@ -715,6 +719,8 @@ export default function FreeCanvas({
   const showRemovePageBtns = interactable
     && typeof onRemovePage === 'function'
     && pages.length > 1;
+  const hasPageOverflow = interactable && layoutHasPageOverflow(layout);
+  const showSpillOverflowBtn = hasPageOverflow && typeof onSpillOverflow === 'function';
 
   const placeLabel = placementPreset?.placementMode === 'draw-rect'
     ? 'Dessinez la zone'
@@ -745,6 +751,48 @@ export default function FreeCanvas({
               ? 'Glissez pour dessiner · Échap annule'
               : 'Cliquez pour placer · Échap annule'}
           </span>
+        </div>
+      )}
+      {hasPageOverflow && (
+        <div
+          className="free-canvas-overflow-banner"
+          role="status"
+          data-testid="free-canvas-overflow-banner"
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          <p className="free-canvas-overflow-banner__title ds-label-md">
+            Contenu coupé en bas de page
+          </p>
+          <p className="free-canvas-overflow-banner__text ds-body-md">
+            Un bloc dépasse la zone A4 imprimable. Le score ATS ne peut pas rester à 100.
+          </p>
+          <div className="free-canvas-overflow-banner__actions">
+            {showSpillOverflowBtn && (
+              <Button
+                variant="primary"
+                size="md"
+                data-testid="free-canvas-spill-overflow"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onSpillOverflow();
+                }}
+              >
+                Déplacer sur la page suivante
+              </Button>
+            )}
+            {showAddPageBtn && (
+              <Button
+                variant="secondary"
+                size="md"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onAddPage();
+                }}
+              >
+                Ajouter une page vide
+              </Button>
+            )}
+          </div>
         </div>
       )}
       <div className="free-canvas-pages-stack">
@@ -923,7 +971,9 @@ export default function FreeCanvas({
             </svg>
           </button>
           <span className="free-canvas-add-page-hint">
-            Page {pages.length} - ajouter la page {pages.length + 1}
+            {hasPageOverflow
+              ? 'Contenu coupé — ajoute une page ou déplace le bloc'
+              : `Page ${pages.length} - ajouter la page ${pages.length + 1}`}
           </span>
         </div>
       )}

--- a/frontend/src/lib/atsCoachAdvice.js
+++ b/frontend/src/lib/atsCoachAdvice.js
@@ -6,7 +6,7 @@
  */
 
 /**
- * @typedef {'reading-order' | 'contact-up' | 'add-missing-sections' | 'hide-photo' | 'fix-font' | 'fix-body-font-size' | 'single-column' | null} AtsCoachFixKind
+ * @typedef {'reading-order' | 'contact-up' | 'add-missing-sections' | 'hide-photo' | 'fix-font' | 'fix-body-font-size' | 'single-column' | 'spill-overflow' | null} AtsCoachFixKind
  */
 
 /**
@@ -53,6 +53,13 @@ export const ATS_COACH_ADVICE = {
     explanation:
       'Des infos du profil ne sont pas affichées. Ajoute les blocs manquants depuis la sidebar.',
     fixKind: 'add-missing-sections',
+    designTradeoff: false,
+  },
+  malus_page_overflow_clipped: {
+    title: 'Contenu coupé en bas de page',
+    explanation:
+      'Un bloc dépasse la zone A4 imprimable. Déplace-le sur la page suivante ou réduis sa hauteur.',
+    fixKind: 'spill-overflow',
     designTradeoff: false,
   },
   malus_free_canvas_no_semantic_blocks: {

--- a/frontend/src/lib/atsCoachFixes.js
+++ b/frontend/src/lib/atsCoachFixes.js
@@ -12,6 +12,7 @@ import {
   optimizeSafeFonts,
   optimizeSingleColumnFreeCanvas,
 } from './atsLayoutOptimize.js';
+import { applyLayoutPagination } from './layoutPagination.js';
 import { getAtsCoachAdvice } from './atsCoachAdvice.js';
 
 /**
@@ -47,6 +48,9 @@ export function applyAtsCoachFix(layout, ruleId, options = {}) {
       return optimizeSingleColumnFreeCanvas(layout);
     }
     return optimizeRemoveSidebar(layout);
+  }
+  if (fixKind === 'spill-overflow') {
+    return applyLayoutPagination(layout);
   }
   return layout;
 }

--- a/frontend/src/styles/FreeCanvas.css
+++ b/frontend/src/styles/FreeCanvas.css
@@ -24,6 +24,34 @@
   max-width: 42rem;
 }
 
+.free-canvas-overflow-banner {
+  width: min(100%, 42rem);
+  margin: 0 0 var(--ds-space-md);
+  padding: var(--ds-space-md) var(--ds-space-lg);
+  background: var(--ds-color-feedback-error-subtle);
+  color: var(--ds-color-text-default);
+  border: 1px solid var(--ds-color-border-default);
+  border-radius: var(--ds-radius-sm);
+  text-align: left;
+}
+
+.free-canvas-overflow-banner__title {
+  margin: 0 0 var(--ds-space-xs);
+  color: var(--ds-color-text-danger);
+}
+
+.free-canvas-overflow-banner__text {
+  margin: 0 0 var(--ds-space-md);
+  color: var(--ds-color-text-muted);
+}
+
+.free-canvas-overflow-banner__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ds-space-sm);
+  align-items: center;
+}
+
 .free-canvas-pages-stack {
   display: flex;
   flex-direction: column;

--- a/frontend/tests/unit/atsCoachAdvice.test.js
+++ b/frontend/tests/unit/atsCoachAdvice.test.js
@@ -48,6 +48,14 @@ test('getAtsCoachAdvice mappe les règles clés en langage clair', () => {
     getAtsCoachAdvice({ id: 'malus_experiences_before_resume' }).fixKind,
     'reading-order',
   );
+  assert.match(
+    getAtsCoachAdvice({ id: 'malus_page_overflow_clipped' }).title,
+    /coup[eé]/i,
+  );
+  assert.equal(
+    getAtsCoachAdvice({ id: 'malus_page_overflow_clipped' }).fixKind,
+    'spill-overflow',
+  );
 });
 
 test('getAtsCoachAdvice préfère advice API si fourni', () => {
@@ -63,6 +71,7 @@ test('isAtsCoachRuleFixable pour contact, ordre, sections, photo', () => {
   assert.equal(isAtsCoachRuleFixable('malus_identity_not_first'), true);
   assert.equal(isAtsCoachRuleFixable('malus_free_canvas_missing_profile_sections'), true);
   assert.equal(isAtsCoachRuleFixable('malus_photo_present'), true);
+  assert.equal(isAtsCoachRuleFixable('malus_page_overflow_clipped'), true);
   assert.equal(isAtsCoachRuleFixable('malus_missing_identity'), false);
 });
 
@@ -203,6 +212,31 @@ test('applyAtsCoachFix fix-font et body size changent le theme', () => {
   assert.equal(fonts.theme.font_body, 'Arial');
   const size = applyAtsCoachFix(layout, 'malus_body_font_size_out_of_range');
   assert.equal(size.theme.font_size_body, 10);
+});
+
+test('applyAtsCoachFix spill-overflow envoie le bloc hors A4 sur la page 2', () => {
+  const layout = {
+    version: 3,
+    format: 'A4',
+    grid: 'free',
+    unit: 'mm',
+    theme: {},
+    pages: [{
+      id: 'page-1',
+      blocks: [
+        { id: 'id', type: 'identity', x: 10, y: 8, w: 180, h: 18, z: 1, style: {} },
+        { id: 'sk', type: 'skills', x: 10, y: 292, w: 180, h: 30, z: 2, style: {} },
+      ],
+    }],
+  };
+  const next = applyAtsCoachFix(layout, 'malus_page_overflow_clipped');
+  assert.equal(isAtsCoachRuleFixable('malus_page_overflow_clipped'), true);
+  assert.ok(next.pages.length >= 2);
+  const page1Ids = next.pages[0].blocks.map((b) => b.id);
+  const page2Ids = next.pages[1].blocks.map((b) => b.id);
+  assert.equal(page1Ids.includes('sk'), false);
+  assert.ok(page2Ids.includes('sk'));
+  assert.equal(didAtsCoachFixChangeLayout(layout, next), true);
 });
 
 test('applyAtsCoachFix single-column retire la sidebar template', () => {

--- a/tests/fixtures/ats_score/README.md
+++ b/tests/fixtures/ats_score/README.md
@@ -21,7 +21,7 @@ Le snapshot comporte au minimum :
 
 ```json
 {
-  "scoring_version": "2026.08.1",
+  "scoring_version": "2026.08.2",
   "total": 92,
   "rule_ids": ["bonus_mono_column", "bonus_standard_section_titles", "..."]
 }

--- a/tests/test_api_ats_route.py
+++ b/tests/test_api_ats_route.py
@@ -34,7 +34,7 @@ class TestRouteHappyPath(unittest.TestCase):
         self.assertEqual(payload["kind"], "parsing")
         self.assertIn("total", payload)
         self.assertIn("rules", payload)
-        self.assertEqual(payload["version"], "2026.08.1")
+        self.assertEqual(payload["version"], "2026.08.2")
 
     def test_route_returns_payload_for_explicit_layout(self):
         body = ScoreParsingBody(layout={"grid": "single-or-sidebar", "sidebar_ratio": 0.0})

--- a/tests/test_ats_score_rules_free_canvas.py
+++ b/tests/test_ats_score_rules_free_canvas.py
@@ -123,6 +123,92 @@ class TestContactFarFromTop(unittest.TestCase):
         self.assertIsNone(fc_rules.rule_contact_far_from_top(cv, layout))
 
 
+class TestPageOverflowClipped(unittest.TestCase):
+    """AXE-350 : bloc hors A4 → malus, score < 100, coach lisible."""
+
+    def test_skills_past_page_bottom_penalized(self):
+        layout = _free_layout(
+            [
+                {"id": "id", "type": "identity", "x": 10, "y": 10, "w": 180, "h": 20},
+                {
+                    "id": "sk",
+                    "type": "skills",
+                    "x": 10,
+                    "y": fc_rules.PAGE_HEIGHT_MM - 5,
+                    "w": 180,
+                    "h": 30,
+                },
+            ]
+        )
+        rule = fc_rules.rule_free_canvas_page_overflow({}, layout)
+        self.assertIsNotNone(rule)
+        self.assertEqual(rule.id, "malus_page_overflow_clipped")
+        self.assertEqual(rule.delta, -25)
+        self.assertIn("sk", rule.block_ids)
+        self.assertRegex(rule.advice.lower(), r"coupe|coupé")
+
+    def test_block_fully_on_page_no_penalty(self):
+        layout = _free_layout(
+            [{"id": "sk", "type": "skills", "x": 10, "y": 200, "w": 180, "h": 40}]
+        )
+        self.assertIsNone(fc_rules.rule_free_canvas_page_overflow({}, layout))
+
+    def test_template_grid_ignored(self):
+        layout = {
+            "version": 3,
+            "grid": "single-or-sidebar",
+            "pages": [
+                {
+                    "id": "p1",
+                    "blocks": [
+                        {
+                            "id": "sk",
+                            "type": "skills",
+                            "x": 10,
+                            "y": fc_rules.PAGE_HEIGHT_MM - 5,
+                            "w": 180,
+                            "h": 30,
+                        }
+                    ],
+                }
+            ],
+        }
+        self.assertIsNone(fc_rules.rule_free_canvas_page_overflow({}, layout))
+
+    def test_score_cannot_be_100_with_clipped_skills(self):
+        from backend.services.ats_score import score_parsing
+
+        cv = {
+            "prenom": "Alice",
+            "nom": "Martin",
+            "email": "alice@example.com",
+            "telephone": "0600000000",
+            "experiences": [{"poste": "Dev", "debut": "2020", "fin": "2024"}],
+            "formations": [{"diplome": "Master"}],
+            "competences": {"techniques": ["Python"]},
+        }
+        layout = _free_layout(
+            [
+                {"id": "id", "type": "identity", "x": 10, "y": 8, "w": 180, "h": 18},
+                {"id": "co", "type": "contact", "x": 10, "y": 28, "w": 180, "h": 12},
+                {"id": "ex", "type": "experiences", "x": 10, "y": 44, "w": 180, "h": 50},
+                {"id": "fo", "type": "formations", "x": 10, "y": 98, "w": 180, "h": 30},
+                {
+                    "id": "sk",
+                    "type": "skills",
+                    "x": 10,
+                    "y": fc_rules.PAGE_HEIGHT_MM - 4,
+                    "w": 180,
+                    "h": 28,
+                },
+            ]
+        )
+        result = score_parsing(cv, layout)
+        ids = {r.id for r in result.rules}
+        self.assertIn("malus_page_overflow_clipped", ids)
+        self.assertLess(result.total, 100)
+
+
 class TestSpatialReorganizationImprovesScore(unittest.TestCase):
     """AXE-37 : une réorganisation spatiale (y) doit lever les malus free_canvas."""
 

--- a/tests/test_ats_score_templates_golden.py
+++ b/tests/test_ats_score_templates_golden.py
@@ -42,7 +42,7 @@ def _load_template_meta(template_id: str) -> dict:
     return _load_json(TEMPLATES_DIR / template_id / "meta.json")
 
 
-# Snapshot des scores attendus pour SCORING_VERSION="2026.08.1".
+# Snapshot des scores attendus pour SCORING_VERSION="2026.08.2".
 # Recalibrer ces valeurs **uniquement** en bumpant SCORING_VERSION dans
 # ``backend/services/ats_score/version.py`` et en commitant ensemble.
 EXPECTED: dict[str, dict] = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes AXE-350
Closes #122

## Summary

- Règle ATS `malus_page_overflow_clipped` (−25) si un bloc canvas libre dépasse 297 mm.
- Score **< 100** dès qu’une section (ex. compétences) est coupée en bas de page.
- Coach « contenu coupé » + **Corriger** = spill page suivante (`applyLayoutPagination`).
- Bannière canvas (tokens `--ds-*`) : **Déplacer sur la page suivante** / **Ajouter une page vide**.
- Doc : `docs/editor-vision.md` §9.2 / P3.9–P3.10, `docs/ats-score-cv-vs-layout.md`, `docs/ats-coach-actionable-fixes.md`.
- `SCORING_VERSION` → `2026.08.2`.

## Linear

Fixes AXE-350

## GitHub issue

Closes #122

## What changed

- Scoring backend : `y + h > PAGE_HEIGHT_MM` sur `grid == "free"`.
- Coach + CTA canvas branchés sur le helper de pagination déjà présent.
- Documentation fonctionnelle des règles ATS alignée.

## Why

Un bloc collé au bord inférieur comptait comme « présent » → 100/100 trompeur alors que le rendu A4 clippe (`overflow: hidden`).

## Test plan

- [x] Repro : `skills` à `y = 297 − 4`, `h = 28` → règle listée, total < 100
- [x] Coach `malus_page_overflow_clipped` → `spill-overflow` déplace le bloc page 2
- [x] Templates golden inchangés (règle limitée au canvas libre)
- [x] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks` OK

## Validation

- [x] Backend lint passes (`ruff`, `black`, `mypy`)
- [x] Backend tests pass (`pytest`)
- [x] Coverage threshold passes (backend >= 60%)
- [x] Frontend lint passes (`npm --prefix frontend run lint`)
- [x] Docs updated if needed
- [x] No secrets committed
- [ ] Backend security checks pass (`bandit`, `pip-audit`) — CI Security (pré-push local `--skip-extras`)

## Risk and rollback

- Risk : malus −25 peut faire baisser des scores canvas trop remplis page 1 (voulu).
- Rollback : revert de la PR ; scoring `2026.08.1` ne pénalise pas l’overflow.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

