### PR TITLE
fix(AXE-372): /login ne reste plus bloqué sur Chargement

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -166,11 +166,15 @@ a.button,a.btn{text-decoration:none}
           document.documentElement.appendChild(s);
           var root = document.getElementById('root');
           if (root) root.innerHTML = '<div style="min-height:100vh;display:flex;align-items:center;justify-content:center;font-family:\'Plus Jakarta Sans\',sans-serif;color:#64748b;">Chargement…</div>';
-          var isDev = window.location.hostname === 'localhost' && (window.location.port === '5173' || window.location.port === '');
-          if (!isDev && typeof __APP_CSS__ === 'string' && __APP_CSS__) {
+          var cssName = typeof window.__APP_CSS__ === 'string' ? window.__APP_CSS__ : '';
+          var cssReady = cssName && cssName.indexOf('__APP') === -1;
+          var isViteDev = window.location.port === '5173'
+            || window.location.hostname === 'localhost'
+            || window.location.hostname === '127.0.0.1';
+          if (!isViteDev && cssReady) {
             var link = document.createElement('link');
             link.rel = 'stylesheet';
-            link.href = '/assets/' + __APP_CSS__;
+            link.href = '/assets/' + cssName;
             document.head.appendChild(link);
           }
         }

--- a/frontend/public/login.html
+++ b/frontend/public/login.html
@@ -8,7 +8,8 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400&display=optional" rel="stylesheet" media="print" onload="this.media='all'" />
+  <noscript><link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400&display=optional" rel="stylesheet" /></noscript>
   <title>Connexion | AxeL Job - CV adapté à chaque offre</title>
   <meta name="description" content="Connecte-toi à AxeL Job pour adapter ton CV à chaque offre d'emploi en un clic avec l'IA. Essai gratuit." />
   <link rel="canonical" href="https://job.axelproject.fr/login" />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -19,6 +19,7 @@ import { ensureAnalyticsFirstTouch, getStoredAttribution } from './analyticsSess
 import { resetTemplateOptionsToDefaults } from './lib/templateOptionsSchema.js';
 import { useViewAnalytics } from './useViewAnalytics';
 import { supabase } from './lib/supabase';
+import { fetchAuthSessionWithTimeout } from './lib/supabaseAuthSession';
 import AuthForm from './components/AuthForm';
 import AppTopbar from './components/AppTopbar';
 import CompanyLogo from './components/CompanyLogo';
@@ -1046,11 +1047,15 @@ export default function App() {
       setAuthToken(null);
       supabase.auth.signOut();
     });
-    supabase.auth.getSession().then(({ data: { session: s } }) => {
-      setSession(s);
-      setAuthToken(s?.access_token ?? null);
-      setAuthLoading(false);
-    });
+    fetchAuthSessionWithTimeout(supabase)
+      .then((s) => {
+        setSession(s);
+        setAuthToken(s?.access_token ?? null);
+        setAuthLoading(false);
+      })
+      .catch(() => {
+        setAuthLoading(false);
+      });
     const { data: { subscription } } = supabase.auth.onAuthStateChange((event, s) => {
       setSession(s);
       setAuthToken(s?.access_token ?? null);
@@ -2934,8 +2939,8 @@ export default function App() {
     );
   }
 
-  /* Non connecté : landing (/) ou login (/login) */
-  if (!authLoading && !session) {
+  /* Non connecté : login visible tout de suite (AXE-372), sans attendre getSession. */
+  if (!session) {
     if (pathname === '/login') {
       return (
         <div className="login-screen">
@@ -2956,12 +2961,14 @@ export default function App() {
         </div>
       );
     }
-    const marketing = renderPublicMarketingPage(pathname, navigate);
-    if (marketing) return marketing;
     if (pathname === '/') {
       return <Suspense fallback={<div className="landing" style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center' }}><span aria-hidden>Chargement…</span></div>}><LandingPage onCtaClick={() => navigate('/login')} onProClick={() => navigate('/login?plan=pro')} /></Suspense>;
     }
-    return <NotFoundPage />;
+    const marketing = renderPublicMarketingPage(pathname, navigate);
+    if (marketing) return marketing;
+    if (!authLoading) {
+      return <NotFoundPage />;
+    }
   }
 
   /* Connecté : redirection / ou /login vers /app (useEffect) ; pages publiques hors /app ; sinon 404 */

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2966,9 +2966,14 @@ export default function App() {
     }
     const marketing = renderPublicMarketingPage(pathname, navigate);
     if (marketing) return marketing;
-    if (!authLoading) {
-      return <NotFoundPage />;
+    if (authLoading || pathname.startsWith('/app')) {
+      return (
+        <div className="landing" style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <span aria-live="polite">Chargement…</span>
+        </div>
+      );
     }
+    return <NotFoundPage />;
   }
 
   /* Connecté : redirection / ou /login vers /app (useEffect) ; pages publiques hors /app ; sinon 404 */

--- a/frontend/src/lib/supabaseAuthSession.js
+++ b/frontend/src/lib/supabaseAuthSession.js
@@ -1,0 +1,35 @@
+/**
+ * Résolution de session Auth avec timeout (AXE-372).
+ * Sans ça, `/login` reste sur « Chargement… » si `getSession()` ne se résout pas
+ * (réseau, iframe, preview hors localhost).
+ */
+
+export const AUTH_SESSION_TIMEOUT_MS = 8000;
+
+/**
+ * @param {{ auth?: { getSession?: () => Promise<{ data?: { session?: object | null } }> } } | null} client
+ * @param {number} [timeoutMs]
+ * @returns {Promise<object | null>}
+ */
+export function fetchAuthSessionWithTimeout(client, timeoutMs = AUTH_SESSION_TIMEOUT_MS) {
+  if (!client?.auth?.getSession) return Promise.resolve(null);
+  return new Promise((resolve) => {
+    let done = false;
+    const finish = (session) => {
+      if (done) return;
+      done = true;
+      resolve(session ?? null);
+    };
+    const timer = setTimeout(() => finish(null), timeoutMs);
+    Promise.resolve()
+      .then(() => client.auth.getSession())
+      .then((result) => {
+        clearTimeout(timer);
+        finish(result?.data?.session ?? null);
+      })
+      .catch(() => {
+        clearTimeout(timer);
+        finish(null);
+      });
+  });
+}

--- a/frontend/tests/unit/supabaseAuthSession.test.js
+++ b/frontend/tests/unit/supabaseAuthSession.test.js
@@ -1,0 +1,46 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  AUTH_SESSION_TIMEOUT_MS,
+  fetchAuthSessionWithTimeout,
+} from '../../src/lib/supabaseAuthSession.js';
+
+test('fetchAuthSessionWithTimeout retourne null sans client', async () => {
+  assert.equal(await fetchAuthSessionWithTimeout(null), null);
+  assert.equal(await fetchAuthSessionWithTimeout({}), null);
+});
+
+test('fetchAuthSessionWithTimeout propage la session', async () => {
+  const session = { access_token: 'tok' };
+  const client = {
+    auth: {
+      getSession: async () => ({ data: { session } }),
+    },
+  };
+  assert.equal(await fetchAuthSessionWithTimeout(client), session);
+});
+
+test('fetchAuthSessionWithTimeout catch → null', async () => {
+  const client = {
+    auth: {
+      getSession: async () => {
+        throw new Error('network');
+      },
+    },
+  };
+  assert.equal(await fetchAuthSessionWithTimeout(client), null);
+});
+
+test('fetchAuthSessionWithTimeout abandonne si getSession pend', async () => {
+  const client = {
+    auth: {
+      getSession: () => new Promise(() => {}),
+    },
+  };
+  const t0 = Date.now();
+  const session = await fetchAuthSessionWithTimeout(client, 40);
+  assert.equal(session, null);
+  assert.ok(Date.now() - t0 < 500);
+  assert.ok(AUTH_SESSION_TIMEOUT_MS >= 1000);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes AXE-372
Closes #137

## Summary

- `/login` affiche le formulaire **sans attendre** `supabase.auth.getSession()`.
- Timeout 8s + catch si Auth ne répond pas (plus de « Chargement… » infini).
- Ne plus charger `/assets/__APP_CSS_FILENAME__` en preview Vite (placeholder).
- Fonts de `login.html` non bloquantes, comme la landing.
- Review : une URL inconnue pendant `authLoading` ne tombe plus dans le shell `/app` sans session.

## Linear

Fixes AXE-372

## GitHub issue

Closes #137

## Why

Sur la VM / preview, `/` laisse le HTML statique visible. `/login` le masque tout de suite puis `App.jsx` n’affichait le formulaire que si `!authLoading`. Un `getSession()` qui pend = page blanche / spinner.

## Test plan

- [x] `node --test tests/unit/supabaseAuthSession.test.js`
- [x] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks`
- [x] Review CodeRabbit : fallback public si route inconnue pendant authLoading
- [ ] Smoke : ouvrir `/` puis `/login` sur la preview VM — formulaire visible

## Validation

- [x] Backend lint / tests (pre-push)
- [x] Frontend lint / unit / build (pre-push)
- [x] Docs : ticket Linear + GitHub (bug UX, pas de contrat scoring)
- [x] No secrets committed

## Risk and rollback

- Risk : le formulaire apparaît avant confirmation « pas de session » ; si une session existe, redirect `/app` dès que Auth répond.
- Rollback : revert de la PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * La page de connexion ou d’accueil s’affiche désormais plus rapidement pour les visiteurs non connectés.
  * La vérification de session gère mieux les erreurs et les délais d’attente, évitant les blocages prolongés.
  * Le routage des pages publiques et de la page d’accueil est plus fiable.
  * Le chargement des styles et de la police est optimisé pour améliorer les performances initiales.
* **Tests**
  * Ajout de tests couvrant les sessions valides, les erreurs et les délais d’attente.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->