### PR TITLE
Improve: réduire la hauteur du page-header Adapter un CV

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3094,7 +3094,7 @@ export default function App() {
               <div className="page-title-row-actions">
                 <button
                   type="button"
-                  className="button button-secondary btn-new-adapt-session"
+                  className="button button-secondary button--sm btn-new-adapt-session"
                   onClick={requestNewCandidatureWorkspace}
                   disabled={adapting}
                   title="Vider le chat et l’aperçu pour adapter ton CV à une autre offre (sans supprimer tes candidatures enregistrées)"
@@ -3103,7 +3103,7 @@ export default function App() {
                 </button>
                 <button
                   type="button"
-                  className="button button-secondary btn-new-adapt-session"
+                  className="button button-secondary button--sm btn-new-adapt-session"
                   onClick={async () => {
                     if (!lastAdaptRunConfig || adapting) return;
                     setChatMessages((prev) => [...prev, { role: 'user', content: 'Relancer la dernière adaptation' }]);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3091,6 +3091,9 @@ export default function App() {
                   ?
                 </button>
               </div>
+              <p className="page-subtitle" title="Colle une offre d'emploi, l'IA adapte ton CV. Affine par chat, puis exporte en PDF.">
+                Colle une offre d&apos;emploi, l&apos;IA adapte ton CV. Affine par chat, puis exporte en PDF.
+              </p>
               <div className="page-title-row-actions">
                 <button
                   type="button"
@@ -3120,7 +3123,6 @@ export default function App() {
                 </button>
               </div>
             </div>
-            <p className="page-subtitle">Colle une offre d'emploi, l'IA adapte ton CV. Affine par chat, puis exporte en PDF.</p>
           </header>
           {usage && usage.plan === 'free' && usage.adaptations_used >= 2 && (
             <div className="free-plan-banner">
@@ -3582,17 +3584,19 @@ export default function App() {
 
         <div id="viewCandidatures" className={`view-panel app-page view-candidatures ${view === 'candidatures' ? 'active' : ''}`} style={{ display: view === 'candidatures' ? 'flex' : 'none' }}>
           <header className="page-header page-header-dashboard">
-            <div>
+            <div className="page-title-row">
               <h1 className="page-title">Mes candidatures</h1>
-              <p className="page-subtitle">Suis toutes tes candidatures ici. Glisse les cartes pour changer le statut.</p>
-            </div>
-            <div className="dashboard-header-actions">
-              <button type="button" className="button button-tertiary btn-add-manual" onClick={() => setAddManualModalOpen(true)}>
-                Ajouter une candidature (hors app)
-              </button>
-              <button type="button" className="button button-primary btn-new-candidature" onClick={() => setSetupModalOpen(true)}>
-                Nouvelle Candidature
-              </button>
+              <p className="page-subtitle" title="Suis toutes tes candidatures ici. Glisse les cartes pour changer le statut.">
+                Suis toutes tes candidatures ici. Glisse les cartes pour changer le statut.
+              </p>
+              <div className="dashboard-header-actions page-title-row-actions">
+                <button type="button" className="button button-tertiary button--sm btn-add-manual" onClick={() => setAddManualModalOpen(true)}>
+                  Ajouter une candidature (hors app)
+                </button>
+                <button type="button" className="button button-primary button--sm btn-new-candidature" onClick={() => setSetupModalOpen(true)}>
+                  Nouvelle Candidature
+                </button>
+              </div>
             </div>
           </header>
           {usage && usage.adaptations_used === 0 && (
@@ -3996,8 +4000,12 @@ export default function App() {
 
         <div id="viewProfil" className={`view-panel app-page view-profil ${view === 'profil' ? 'active' : ''}`} style={{ display: view === 'profil' ? 'flex' : 'none' }}>
           <header className="page-header">
-            <h1 className="page-title">Profil</h1>
-            <p className="page-subtitle">Ton CV de base. Modifications enregistrées automatiquement.</p>
+            <div className="page-title-row">
+              <h1 className="page-title">Profil</h1>
+              <p className="page-subtitle" title="Ton CV de base. Modifications enregistrées automatiquement.">
+                Ton CV de base. Modifications enregistrées automatiquement.
+              </p>
+            </div>
             {usage && usage.adaptations_used === 0 && (
               <div className="zero-adapt-banner zero-adapt-banner--compact" role="status">
                 <span>Pour adapter ton CV à une offre, va sur </span>
@@ -4013,8 +4021,12 @@ export default function App() {
 
         <div id="viewSettings" className={`view-panel app-page view-settings ${view === 'settings' ? 'active' : ''}`} style={{ display: view === 'settings' ? 'flex' : 'none' }} data-analytics-section="settings_page">
           <header className="page-header">
-            <h1 className="page-title">Paramètres</h1>
-            <p className="page-subtitle">Compte, export PDF, éditeur et confidentialité.</p>
+            <div className="page-title-row">
+              <h1 className="page-title">Paramètres</h1>
+              <p className="page-subtitle" title="Compte, export PDF, éditeur et confidentialité.">
+                Compte, export PDF, éditeur et confidentialité.
+              </p>
+            </div>
           </header>
           <div className="page-content">
             <SettingsView

--- a/frontend/src/styles/app/pages.css
+++ b/frontend/src/styles/app/pages.css
@@ -11,24 +11,32 @@
 
 .app-page .page-header {
   flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-space-sm);
   /* DESIGN-cohere + ds tokens : chrome compact (md/xl), pas 1.25rem aéré */
   padding: var(--ds-space-md) var(--ds-space-xl);
   border-bottom: 1px solid var(--color-hairline);
   background: var(--color-canvas);
 }
 
+/* Une ligne : titre | sous-titre (sacrifiable) | actions */
 .page-title-row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: var(--ds-space-sm);
+  flex-wrap: nowrap;
+  gap: var(--ds-space-md);
+  min-width: 0;
+  width: 100%;
+  container-type: inline-size;
+  container-name: page-title-row;
 }
 
 .page-title-row-left {
   display: flex;
   align-items: center;
   gap: var(--ds-space-sm);
+  flex-shrink: 0;
 }
 
 .page-title-row-actions {
@@ -36,7 +44,8 @@
   align-items: center;
   gap: var(--ds-space-sm);
   margin-left: auto;
-  flex-wrap: wrap;
+  flex-shrink: 0;
+  flex-wrap: nowrap;
   justify-content: flex-end;
 }
 
@@ -52,6 +61,8 @@
   font-weight: 500;
   color: var(--color-ink);
   letter-spacing: -0.02em;
+  flex-shrink: 0;
+  line-height: 1.2;
 }
 
 .page-tour-help {
@@ -84,24 +95,37 @@
 }
 
 .app-page .page-subtitle {
-  margin: var(--ds-space-xxs) 0 0;
+  margin: 0;
   font-size: 0.875rem;
   color: var(--color-body-muted);
+  flex: 1 1 auto;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.3;
+}
+
+/* Pas assez de place pour le sous-titre → on le retire (titre + actions restent) */
+@container page-title-row (max-width: 52rem) {
+  .page-subtitle {
+    display: none;
+  }
 }
 
 .page-header-dashboard {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
+  /* hérite de .page-header ; la ligne est .page-title-row */
+}
+
+.page-header-dashboard {
+  /* hérite de .page-header ; la ligne est .page-title-row */
 }
 
 .dashboard-header-actions {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--ds-space-sm);
   flex-shrink: 0;
 }
 

--- a/frontend/src/styles/app/pages.css
+++ b/frontend/src/styles/app/pages.css
@@ -11,7 +11,8 @@
 
 .app-page .page-header {
   flex-shrink: 0;
-  padding: 1.25rem 1.5rem;
+  /* DESIGN-cohere + ds tokens : chrome compact (md/xl), pas 1.25rem aéré */
+  padding: var(--ds-space-md) var(--ds-space-xl);
   border-bottom: 1px solid var(--color-hairline);
   background: var(--color-canvas);
 }
@@ -21,19 +22,19 @@
   align-items: center;
   justify-content: space-between;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: var(--ds-space-sm);
 }
 
 .page-title-row-left {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--ds-space-sm);
 }
 
 .page-title-row-actions {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--ds-space-sm);
   margin-left: auto;
   flex-wrap: wrap;
   justify-content: flex-end;
@@ -83,7 +84,7 @@
 }
 
 .app-page .page-subtitle {
-  margin: 0.2rem 0 0;
+  margin: var(--ds-space-xxs) 0 0;
   font-size: 0.875rem;
   color: var(--color-body-muted);
 }

--- a/frontend/src/styles/app/pages.css
+++ b/frontend/src/styles/app/pages.css
@@ -113,14 +113,6 @@
   }
 }
 
-.page-header-dashboard {
-  /* hérite de .page-header ; la ligne est .page-title-row */
-}
-
-.page-header-dashboard {
-  /* hérite de .page-header ; la ligne est .page-title-row */
-}
-
 .dashboard-header-actions {
   display: flex;
   flex-wrap: nowrap;

--- a/frontend/src/styles/app/responsive.css
+++ b/frontend/src/styles/app/responsive.css
@@ -45,12 +45,6 @@
     min-width: 0;
   }
 
-  .page-header-dashboard {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0.5rem;
-  }
-
   /* Page content */
   .app-page .page-content {
     padding: 0.75rem;
@@ -104,27 +98,29 @@
     flex-shrink: 0;
   }
 
-  .cv-chat-page .page-title-row {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0.5rem;
+  /* Mobile : sous-titre déjà masqué via @container ; actions sous le titre si besoin */
+  .page-title-row {
+    flex-wrap: wrap;
+    row-gap: var(--ds-space-sm);
   }
 
-  .cv-chat-page .page-title-row-actions {
+  .page-subtitle {
+    display: none;
+  }
+
+  .cv-chat-page .page-title-row-actions,
+  .dashboard-header-actions {
     width: 100%;
     margin-left: 0;
     justify-content: stretch;
+    flex-wrap: wrap;
   }
 
   .cv-chat-page .btn-new-adapt-session {
-    width: 100%;
+    flex: 1 1 auto;
     white-space: normal;
     text-align: center;
     justify-content: center;
-  }
-
-  .cv-chat-page .page-subtitle {
-    line-height: 1.5;
   }
 
   .cv-chat-error {

--- a/frontend/src/styles/app/responsive.css
+++ b/frontend/src/styles/app/responsive.css
@@ -15,12 +15,12 @@
 /* -- Mobile: full overhaul -- */
 @media (max-width: 767px) {
 
-  /* Page header */
+  /* Page header — aligné tokens (déjà compact en mobile) */
   .page-header,
   .app-page .page-header {
-    padding: 0.65rem 0.75rem;
+    padding: var(--ds-space-sm) var(--ds-space-md);
     flex-wrap: wrap;
-    gap: 0.4rem;
+    gap: var(--ds-space-xs);
   }
 
   .page-header h1,


### PR DESCRIPTION
## Summary
- Compact `.page-header` padding to design-system spacing tokens (`--ds-space-md` / `--ds-space-xl`) per DESIGN-cohere scale
- CV header actions use `button--sm` for a denser toolbar
- Mobile header padding aligned to the same tokens

## Test plan
- [ ] Open `/app/cv` — header visibly shorter; title + subtitle + actions still readable
- [ ] Check other `/app/*` headers still look coherent
- [ ] Mobile / narrow width: header remains compact

Fixes AXE-373
Closes #139

Made with [Cursor](https://cursor.com)