### PR TITLE
Feat: exposer le design Beta dans le picker de templates Stable

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3345,8 +3345,6 @@ export default function App() {
                   openOptionsFromSupport={location.state?.supportHighlight?.openTemplateOptions}
                   openOptionsNonce={exportPrepTemplateOptionsNonce}
                   onOptionsModalClosed={handleTemplateOptionsModalAfterClose}
-                  openModalToTab={null}
-                  onOpenFromUrlConsumed={() => navigate(location.pathname, { replace: true })}
                   optionsPreviewHtml={previewVariant === 'original' ? (originalPreviewHtml || previewHtmlFallback) : (modifiedPreviewHtml || previewHtmlFallback)}
                   optionsPreviewLoading={false}
                   profileLayout={profileLayout}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -36,6 +36,10 @@ import './styles/TemplatePicker.css';
 import './styles/GuidedTour.css';
 import { formatApplicationDateLabel } from './lib/applicationDates';
 import { applyA4PageFramesToDocument, syncCvPreviewIframeHeight } from './lib/cvPreviewA4Pages';
+import {
+  betaCanvasRenderFields,
+  withBetaCanvasTemplate,
+} from './lib/betaCanvasTemplate.js';
 
 const ProfileView = lazyWithChunkReload(() => import('./components/editor/ProfileViewSwitcher'));
 const SettingsView = lazyWithChunkReload(() => import('./components/SettingsView'));
@@ -836,6 +840,20 @@ export default function App() {
     try { return JSON.parse(localStorage.getItem('cv_template_options') || '{}'); } catch { return {}; }
   });
   const [templatesList, setTemplatesList] = useState([]);
+  /** Layout canvas Beta du profil (pour template virtuel `beta`). */
+  const [profileLayout, setProfileLayout] = useState(null);
+  const profileLayoutRef = useRef(null);
+  profileLayoutRef.current = profileLayout;
+
+  const postRenderHtml = useCallback((body) => apiPost('/api/render-html', {
+    ...body,
+    ...betaCanvasRenderFields(body?.template_id, profileLayoutRef.current),
+  }), []);
+
+  const postPdfBlob = useCallback((body) => apiPostBlob('/api/pdf', {
+    ...body,
+    ...betaCanvasRenderFields(body?.template_id, profileLayoutRef.current),
+  }), []);
 
   /**
    * Wrapper a appeler quand l utilisateur CHOISIT explicitement un nouveau
@@ -858,8 +876,9 @@ export default function App() {
    */
   const handleUserPickTemplate = useCallback((nextId, templates = templatesList) => {
     setTemplateId(nextId);
-    const nextTemplate = Array.isArray(templates)
-      ? templates.find((t) => t && t.id === nextId)
+    const list = withBetaCanvasTemplate(templates);
+    const nextTemplate = Array.isArray(list)
+      ? list.find((t) => t && t.id === nextId)
       : null;
     setTemplateOptions(nextTemplate ? resetTemplateOptionsToDefaults(nextTemplate) : {});
   }, [templatesList]);
@@ -1020,7 +1039,7 @@ export default function App() {
   }, [session, templateId, templateOptions]);
 
   const templateParams = { template_id: templateId, template_options: templateOptions };
-  const templateKey = templateId + '|' + JSON.stringify(templateOptions);
+  const templateKey = `${templateId}|${JSON.stringify(templateOptions)}|layout:${profileLayout ? '1' : '0'}`;
 
   // Garder HTML original/modifié pour l'iframe et CvEditablePreview
   const wantHighlight = !!(lastBaseCv && lastAdaptedCv);
@@ -1164,6 +1183,9 @@ export default function App() {
         setNeedsOnboarding(empty);
         if (data?.template_id !== undefined && (data.template_id || '').trim()) setTemplateId((data.template_id || '').trim() || 'minimal');
         if (data?.template_options !== undefined && typeof data.template_options === 'object') setTemplateOptions(data.template_options || {});
+        if (data && typeof data === 'object' && 'layout' in data) {
+          setProfileLayout(data.layout && typeof data.layout === 'object' ? data.layout : null);
+        }
       })
       .catch(() => {
         setProfileCvLoadError('Impossible de charger ton profil. Vérifie ta connexion puis réessaie.');
@@ -1392,7 +1414,7 @@ export default function App() {
       if (adaptChanged && suppressAdaptedPreviewRef.current && lastAdaptedCv) {
         suppressAdaptedPreviewRef.current = false;
         if (lastBaseCv) {
-          apiPost('/api/render-html', { cv: lastBaseCv, template_id: tid, template_options: opts })
+          postRenderHtml({ cv: lastBaseCv, template_id: tid, template_options: opts })
             .then((html) => setOriginalPreviewHtml(html))
             .catch(() => {
         /* ignore */
@@ -1401,7 +1423,7 @@ export default function App() {
         return;
       }
       if (lastAdaptedCv) {
-        apiPost('/api/render-html', {
+        postRenderHtml({
           cv: lastAdaptedCv,
           base_cv: lastBaseCv || undefined,
           highlight_changes: wantHighlight,
@@ -1419,7 +1441,7 @@ export default function App() {
         loadInitialPreview(tid, opts);
       }
       if (lastBaseCv) {
-        apiPost('/api/render-html', { cv: lastBaseCv, template_id: tid, template_options: opts })
+        postRenderHtml({ cv: lastBaseCv, template_id: tid, template_options: opts })
           .then((html) => setOriginalPreviewHtml(html))
           .catch(() => {
         /* ignore */
@@ -1443,7 +1465,7 @@ export default function App() {
     const run = async () => {
       try {
         if (lastAdaptedCv && lastBaseCv) {
-          const html = await apiPost('/api/render-html', {
+          const html = await postRenderHtml({
             cv: lastAdaptedCv,
             base_cv: lastBaseCv,
             highlight_changes: true,
@@ -1460,7 +1482,7 @@ export default function App() {
         }
         if (lastBaseCv && hasProfilMinContent(lastBaseCv)) {
           const adapted = buildTourDemoAdaptedFromBase(lastBaseCv);
-          const html = await apiPost('/api/render-html', {
+          const html = await postRenderHtml({
             cv: adapted,
             base_cv: lastBaseCv,
             highlight_changes: true,
@@ -1470,7 +1492,7 @@ export default function App() {
           if (!cancelled) setTourDemoPreviewHtml(html);
           return;
         }
-        const html = await apiPost('/api/render-html', {
+        const html = await postRenderHtml({
           cv: TOUR_STATIC_DEMO_ADAPTED_CV,
           base_cv: TOUR_STATIC_DEMO_BASE_CV,
           highlight_changes: true,
@@ -1507,7 +1529,7 @@ export default function App() {
         loadInitialPreview();
       }
       if (lastAdaptedCv) {
-        apiPost('/api/render-html', {
+        postRenderHtml({
           cv: lastAdaptedCv,
           base_cv: lastBaseCv || undefined,
           highlight_changes: !!(lastBaseCv && lastAdaptedCv),
@@ -1640,7 +1662,7 @@ export default function App() {
         const tid = templateIdForPreviewRef.current;
         const opts = templateOptionsForPreviewRef.current;
         if (adapted) {
-          apiPost('/api/render-html', {
+          postRenderHtml({
             cv: adapted,
             highlight_changes: false,
             selection_a4: lastSelectionA4 || undefined,
@@ -2010,7 +2032,7 @@ export default function App() {
       } catch {
         /* fallback: lastBaseCv */
       }
-      const html = lastStreamPreviewHtml || await apiPost('/api/render-html', {
+      const html = lastStreamPreviewHtml || await postRenderHtml({
         ...templateParams,
         cv: data.cv,
         base_cv: baseCv ?? lastBaseCv ?? undefined,
@@ -2192,7 +2214,7 @@ export default function App() {
           showError(persistErr.message || 'CV affiné en local - enregistrement serveur incomplet. Réessaie ou exporte le dossier.');
         }
       }
-      const html = await apiPost('/api/render-html', {
+      const html = await postRenderHtml({
         ...templateParams,
         cv: data.cv,
         base_cv: lastBaseCv || undefined,
@@ -2235,7 +2257,7 @@ export default function App() {
   const handleSaveCvEdits = (editedCv) => {
     if (!editedCv) return;
     setLastAdaptedCv(editedCv);
-    apiPost('/api/render-html', {
+    postRenderHtml({
       ...templateParams,
       cv: editedCv,
       base_cv: lastBaseCv || undefined,
@@ -2351,7 +2373,7 @@ export default function App() {
       try {
         startIn = await getPdfSaveStartInDirectoryHandle();
       } catch (_) { /* ignore */ }
-      const { blob } = await apiPostBlob('/api/pdf', {
+      const { blob } = await postPdfBlob({
         cv: lastAdaptedCv,
         titre: titre || undefined,
         entreprise: ent || undefined,
@@ -2399,7 +2421,7 @@ export default function App() {
     }
     try {
       const pdfTemplateOptions = { ...opts, show_mots_cles_ats: opts?.show_mots_cles_ats !== false };
-      const { blob, filename } = await apiPostBlob('/api/pdf', {
+      const { blob, filename } = await postPdfBlob({
         cv: base,
         template_id: templateId,
         template_options: pdfTemplateOptions,
@@ -2638,7 +2660,7 @@ export default function App() {
       return;
     }
     if (lastBaseCv) {
-      apiPost('/api/render-html', {
+      postRenderHtml({
         cv: lastBaseCv,
         template_id: templateId,
         template_options: templateOptions,
@@ -3327,6 +3349,10 @@ export default function App() {
                   onOpenFromUrlConsumed={() => navigate(location.pathname, { replace: true })}
                   optionsPreviewHtml={previewVariant === 'original' ? (originalPreviewHtml || previewHtmlFallback) : (modifiedPreviewHtml || previewHtmlFallback)}
                   optionsPreviewLoading={false}
+                  profileLayout={profileLayout}
+                  onBetaUnavailable={() => {
+                    showError('Crée d’abord un design dans Profil → active le mode Beta, puis reviens choisir « Beta » ici.');
+                  }}
                   extraBarLeft={(
                     <button
                       type="button"
@@ -3405,7 +3431,7 @@ export default function App() {
                     onChange={(updatedCv) => {
                       setLastAdaptedCv(updatedCv);
                       trackEvent('cv_manually_edited', { adaptation_id: lastAdaptationId });
-                      apiPost('/api/render-html', {
+                      postRenderHtml({
                         ...templateParams,
                         cv: updatedCv,
                         base_cv: lastBaseCv || undefined,
@@ -3958,7 +3984,7 @@ export default function App() {
                       /* ignore */
                     }
                     if (baseCv) setLastBaseCv(baseCv);
-                    const html = await apiPost('/api/render-html', {
+                    const html = await postRenderHtml({
                       ...templateParams,
                       cv: data.cv,
                       base_cv: baseCv ?? undefined,

--- a/frontend/src/components/ProfileView.jsx
+++ b/frontend/src/components/ProfileView.jsx
@@ -19,6 +19,7 @@ import ReauthModal from './ReauthModal';
 import DesignModeBridgeModal from './editor/DesignModeBridgeModal.jsx';
 import { applyA4PageFramesToDocument, syncCvPreviewIframeHeight } from '../lib/cvPreviewA4Pages';
 import { buildBetaToStableOffer } from '../lib/designModeBridge.js';
+import { betaCanvasRenderFields } from '../lib/betaCanvasTemplate.js';
 import { HiArrowDownTray } from 'react-icons/hi2';
 import '../styles/ProfileView.css';
 import '../styles/TemplatePicker.css';
@@ -365,6 +366,7 @@ export default function ProfileView({ onSaveSuccess, session, refreshKey, usage,
           cv,
           template_id: templateId,
           template_options: templateOptions,
+          ...betaCanvasRenderFields(templateId, cv?.layout),
         });
         if (cancelled) return;
         setProfilePreviewHtml(typeof html === 'string' ? html : '');
@@ -391,6 +393,7 @@ export default function ProfileView({ onSaveSuccess, session, refreshKey, usage,
         cv,
         template_id: templateId,
         template_options: pdfTemplateOptions,
+        ...betaCanvasRenderFields(templateId, cv?.layout),
       });
       await saveBlobWithPreferredMethod(blob, filename || 'CV-base.pdf', { preopenedWindow });
       trackEvent('base_cv_pdf_downloaded', { template_id: templateId, source: 'profile' });
@@ -1220,6 +1223,10 @@ export default function ProfileView({ onSaveSuccess, session, refreshKey, usage,
             onUpgradeClick={onUpgradeClick}
             optionsPreviewHtml={profilePreviewHtml}
             optionsPreviewLoading={profilePreviewLoading}
+            profileLayout={cv?.layout}
+            onBetaUnavailable={() => {
+              setError('Crée d’abord un design en activant le mode Beta (canvas), puis choisis « Beta » ici.');
+            }}
             extraBarLeft={(
               <button
                 type="button"

--- a/frontend/src/components/TemplateModal.jsx
+++ b/frontend/src/components/TemplateModal.jsx
@@ -1,7 +1,5 @@
-import { useState, useEffect, useRef } from 'react';
-import { HiStar, HiOutlineStar } from 'react-icons/hi2';
+import { useEffect, useRef } from 'react';
 import {
-  BETA_CANVAS_TEMPLATE_ID,
   hasUsableBetaCanvasLayout,
   isBetaCanvasTemplateId,
   withBetaCanvasTemplate,
@@ -17,8 +15,6 @@ const PREVIEW_THUMBNAILS = {
   bold:      { bg: '#1e293b', sidebar: '#f1f5f9', accent: '#dc2626', layout: 'right-sidebar' },
   beta:      { bg: '#17171c', sidebar: '#f4f1ea', accent: '#e85d4c', layout: 'beta-canvas' },
 };
-
-export const FAVORITES_STORAGE_KEY = 'cv_template_favorites';
 
 function MiniPreview({ templateId, isActive }) {
   const isCustom = templateId && String(templateId).startsWith('custom_');
@@ -83,15 +79,10 @@ function MiniPreview({ templateId, isActive }) {
   );
 }
 
-function TemplateCard({ template, isSelected, isFavorite, onSelect, onToggleFavorite, disabled, badge }) {
+function TemplateCard({ template, isSelected, onSelect, disabled, badge }) {
   const handleClick = () => {
     if (disabled) return;
     onSelect(template);
-  };
-  const handleStarClick = (e) => {
-    e.stopPropagation();
-    if (isBetaCanvasTemplateId(template.id)) return;
-    onToggleFavorite(template.id);
   };
 
   const handleCardKeyDown = (e) => {
@@ -119,19 +110,12 @@ function TemplateCard({ template, isSelected, isFavorite, onSelect, onToggleFavo
         {template.name}
         {badge ? <span className="tpl-modal-card-badge">{badge}</span> : null}
       </span>
-      {!isBetaCanvasTemplateId(template.id) && (
-        <button
-          type="button"
-          className="tpl-modal-card-fav"
-          onClick={handleStarClick}
-          title={isFavorite ? 'Retirer des favoris' : 'Ajouter aux favoris'}
-          aria-label={isFavorite ? 'Retirer des favoris' : 'Ajouter aux favoris'}
-        >
-          {isFavorite ? <HiStar size={16} /> : <HiOutlineStar size={16} />}
-        </button>
-      )}
     </div>
   );
+}
+
+function isCustomTemplate(t) {
+  return t?.tags?.includes('custom') || (t?.id && String(t.id).startsWith('custom_'));
 }
 
 export default function TemplateModal({
@@ -140,18 +124,10 @@ export default function TemplateModal({
   templates,
   templateId,
   onChangeTemplate,
-  favoriteIds,
-  onToggleFavorite,
-  initialTab,
   profileLayout = null,
   onBetaUnavailable = null,
 }) {
-  const [tab, setTab] = useState('library');
   const ref = useRef(null);
-
-  useEffect(() => {
-    if (open && initialTab) setTab(initialTab);
-  }, [open, initialTab]);
 
   useEffect(() => {
     if (!open) return;
@@ -173,7 +149,7 @@ export default function TemplateModal({
 
   if (!open) return null;
 
-  const catalog = withBetaCanvasTemplate(templates);
+  const catalog = withBetaCanvasTemplate(templates).filter((t) => !isCustomTemplate(t));
   const betaReady = hasUsableBetaCanvasLayout(profileLayout);
 
   const handleSelect = (t) => {
@@ -185,13 +161,6 @@ export default function TemplateModal({
     onClose();
   };
 
-  const isCustomTemplate = (t) => t.tags?.includes('custom') || (t.id && String(t.id).startsWith('custom_'));
-  const libraryTemplates = catalog.filter((t) => !isCustomTemplate(t));
-  const customTemplates = catalog.filter(isCustomTemplate);
-  const favoritesList = libraryTemplates.filter(
-    (t) => favoriteIds.includes(t.id) && !isBetaCanvasTemplateId(t.id),
-  );
-
   return (
     <div className="tpl-modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="tpl-modal-title">
       <div className="tpl-modal" ref={ref}>
@@ -201,100 +170,37 @@ export default function TemplateModal({
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
           </button>
         </div>
-        <div className="tpl-modal-tabs">
-          <button
-            type="button"
-            className={`tpl-modal-tab${tab === 'library' ? ' tpl-modal-tab--active' : ''}`}
-            onClick={() => setTab('library')}
-          >
-            Bibliothèque de templates
-          </button>
-          <button
-            type="button"
-            className={`tpl-modal-tab${tab === 'mine' ? ' tpl-modal-tab--active' : ''}`}
-            onClick={() => setTab('mine')}
-          >
-            Mes templates
-          </button>
-        </div>
         <div className="tpl-modal-body">
-          {tab === 'library' && (
-            <div className="tpl-modal-library">
-              <div className="tpl-modal-grid">
-                {libraryTemplates.map((t) => {
-                  const isBeta = isBetaCanvasTemplateId(t.id);
-                  const disabled = isBeta && !betaReady;
-                  return (
-                    <TemplateCard
-                      key={t.id}
-                      template={{
-                        ...t,
-                        disabledReason: disabled
-                          ? 'Crée d’abord un design dans Profil → mode Beta.'
-                          : t.description,
-                      }}
-                      isSelected={templateId === t.id}
-                      isFavorite={favoriteIds.includes(t.id)}
-                      onSelect={handleSelect}
-                      onToggleFavorite={onToggleFavorite}
-                      disabled={disabled}
-                      badge={isBeta ? 'Canvas' : null}
-                    />
-                  );
-                })}
-              </div>
-              {libraryTemplates.length === 0 && (
-                <p className="tpl-modal-mine-empty">
-                  Les templates intégrés (Classic, Modern, Minimal, etc.) devraient s&apos;afficher ici. Rechargez la page si la liste est vide.
-                </p>
-              )}
+          <div className="tpl-modal-library">
+            <div className="tpl-modal-grid">
+              {catalog.map((t) => {
+                const isBeta = isBetaCanvasTemplateId(t.id);
+                const disabled = isBeta && !betaReady;
+                return (
+                  <TemplateCard
+                    key={t.id}
+                    template={{
+                      ...t,
+                      disabledReason: disabled
+                        ? 'Crée d’abord un design dans Profil → mode Beta.'
+                        : t.description,
+                    }}
+                    isSelected={templateId === t.id}
+                    onSelect={handleSelect}
+                    disabled={disabled}
+                    badge={isBeta ? 'Canvas' : null}
+                  />
+                );
+              })}
             </div>
-          )}
-          {tab === 'mine' && (
-            <div className="tpl-modal-mine">
-              {customTemplates.length > 0 && (
-                <div className="tpl-modal-mine-section">
-                  <h3 className="tpl-modal-mine-section-title">Mes templates personnalisés</h3>
-                  <div className="tpl-modal-grid">
-                    {customTemplates.map((t) => (
-                      <TemplateCard
-                        key={t.id}
-                        template={t}
-                        isSelected={templateId === t.id}
-                        isFavorite={favoriteIds.includes(t.id)}
-                        onSelect={handleSelect}
-                        onToggleFavorite={onToggleFavorite}
-                      />
-                    ))}
-                  </div>
-                </div>
-              )}
-              <div className="tpl-modal-mine-section">
-                <h3 className="tpl-modal-mine-section-title">Favoris (bibliothèque)</h3>
-                <div className="tpl-modal-grid">
-                  {favoritesList.map((t) => (
-                    <TemplateCard
-                      key={t.id}
-                      template={t}
-                      isSelected={templateId === t.id}
-                      isFavorite={true}
-                      onSelect={handleSelect}
-                      onToggleFavorite={onToggleFavorite}
-                    />
-                  ))}
-                </div>
-                {favoritesList.length === 0 && (
-                  <p className="tpl-modal-mine-empty">
-                    Aucun favori. Ajoute des favoris depuis la bibliothèque (étoile).
-                  </p>
-                )}
-              </div>
-            </div>
-          )}
+            {catalog.length === 0 && (
+              <p className="tpl-modal-empty">
+                Les templates intégrés (Classic, Modern, Minimal, etc.) devraient s&apos;afficher ici. Rechargez la page si la liste est vide.
+              </p>
+            )}
+          </div>
         </div>
       </div>
     </div>
   );
 }
-
-export { BETA_CANVAS_TEMPLATE_ID };

--- a/frontend/src/components/TemplateModal.jsx
+++ b/frontend/src/components/TemplateModal.jsx
@@ -1,5 +1,11 @@
 import { useState, useEffect, useRef } from 'react';
 import { HiStar, HiOutlineStar } from 'react-icons/hi2';
+import {
+  BETA_CANVAS_TEMPLATE_ID,
+  hasUsableBetaCanvasLayout,
+  isBetaCanvasTemplateId,
+  withBetaCanvasTemplate,
+} from '../lib/betaCanvasTemplate.js';
 
 const PREVIEW_THUMBNAILS = {
   classic:   { bg: '#1e2a3a', sidebar: '#f4f4f2', accent: '#1e2a3a', layout: 'right-sidebar' },
@@ -9,6 +15,7 @@ const PREVIEW_THUMBNAILS = {
   elegant:   { bg: '#ffffff', sidebar: null,      accent: '#4a5568', layout: 'single-centered' },
   creative:  { bg: '#6366f1', sidebar: '#6366f1', accent: '#f59e0b', layout: 'left-sidebar' },
   bold:      { bg: '#1e293b', sidebar: '#f1f5f9', accent: '#dc2626', layout: 'right-sidebar' },
+  beta:      { bg: '#17171c', sidebar: '#f4f1ea', accent: '#e85d4c', layout: 'beta-canvas' },
 };
 
 export const FAVORITES_STORAGE_KEY = 'cv_template_favorites';
@@ -61,20 +68,34 @@ function MiniPreview({ templateId, isActive }) {
           </div>
         </div>
       )}
+      {t.layout === 'beta-canvas' && (
+        <div className="tpl-mini-inner" style={{ background: t.sidebar || '#f4f1ea' }}>
+          <div className="tpl-mini-hdr" style={{ background: t.bg, height: 8 }} />
+          <div style={{ padding: '3px 4px', display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2 }}>
+            <div className="tpl-mini-ln" style={{ background: t.accent, width: '100%', height: 6, borderRadius: 1 }} />
+            <div className="tpl-mini-ln" style={{ width: '100%', height: 6 }} />
+            <div className="tpl-mini-ln" style={{ width: '100%', height: 4 }} />
+            <div className="tpl-mini-ln" style={{ width: '70%', height: 4 }} />
+          </div>
+        </div>
+      )}
     </div>
   );
 }
 
-function TemplateCard({ template, isSelected, isFavorite, onSelect, onToggleFavorite }) {
+function TemplateCard({ template, isSelected, isFavorite, onSelect, onToggleFavorite, disabled, badge }) {
   const handleClick = () => {
+    if (disabled) return;
     onSelect(template);
   };
   const handleStarClick = (e) => {
     e.stopPropagation();
+    if (isBetaCanvasTemplateId(template.id)) return;
     onToggleFavorite(template.id);
   };
 
   const handleCardKeyDown = (e) => {
+    if (disabled) return;
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       handleClick();
@@ -84,25 +105,31 @@ function TemplateCard({ template, isSelected, isFavorite, onSelect, onToggleFavo
   return (
     <div
       role="button"
-      tabIndex={0}
-      className={`tpl-modal-card${isSelected ? ' tpl-modal-card--active' : ''}`}
+      tabIndex={disabled ? -1 : 0}
+      aria-disabled={disabled || undefined}
+      className={`tpl-modal-card${isSelected ? ' tpl-modal-card--active' : ''}${disabled ? ' tpl-modal-card--disabled' : ''}`}
       onClick={handleClick}
       onKeyDown={handleCardKeyDown}
-      title={template.description}
+      title={disabled ? (template.disabledReason || template.description) : template.description}
     >
       <div className="tpl-modal-card-preview">
         <MiniPreview templateId={template.id} isActive={isSelected} />
       </div>
-      <span className="tpl-modal-card-name">{template.name}</span>
-      <button
-        type="button"
-        className="tpl-modal-card-fav"
-        onClick={handleStarClick}
-        title={isFavorite ? 'Retirer des favoris' : 'Ajouter aux favoris'}
-        aria-label={isFavorite ? 'Retirer des favoris' : 'Ajouter aux favoris'}
-      >
-        {isFavorite ? <HiStar size={16} /> : <HiOutlineStar size={16} />}
-      </button>
+      <span className="tpl-modal-card-name">
+        {template.name}
+        {badge ? <span className="tpl-modal-card-badge">{badge}</span> : null}
+      </span>
+      {!isBetaCanvasTemplateId(template.id) && (
+        <button
+          type="button"
+          className="tpl-modal-card-fav"
+          onClick={handleStarClick}
+          title={isFavorite ? 'Retirer des favoris' : 'Ajouter aux favoris'}
+          aria-label={isFavorite ? 'Retirer des favoris' : 'Ajouter aux favoris'}
+        >
+          {isFavorite ? <HiStar size={16} /> : <HiOutlineStar size={16} />}
+        </button>
+      )}
     </div>
   );
 }
@@ -116,6 +143,8 @@ export default function TemplateModal({
   favoriteIds,
   onToggleFavorite,
   initialTab,
+  profileLayout = null,
+  onBetaUnavailable = null,
 }) {
   const [tab, setTab] = useState('library');
   const ref = useRef(null);
@@ -144,15 +173,24 @@ export default function TemplateModal({
 
   if (!open) return null;
 
+  const catalog = withBetaCanvasTemplate(templates);
+  const betaReady = hasUsableBetaCanvasLayout(profileLayout);
+
   const handleSelect = (t) => {
+    if (isBetaCanvasTemplateId(t.id) && !betaReady) {
+      if (typeof onBetaUnavailable === 'function') onBetaUnavailable();
+      return;
+    }
     onChangeTemplate(t.id);
     onClose();
   };
 
   const isCustomTemplate = (t) => t.tags?.includes('custom') || (t.id && String(t.id).startsWith('custom_'));
-  const libraryTemplates = templates.filter((t) => !isCustomTemplate(t));
-  const customTemplates = templates.filter(isCustomTemplate);
-  const favoritesList = libraryTemplates.filter((t) => favoriteIds.includes(t.id));
+  const libraryTemplates = catalog.filter((t) => !isCustomTemplate(t));
+  const customTemplates = catalog.filter(isCustomTemplate);
+  const favoritesList = libraryTemplates.filter(
+    (t) => favoriteIds.includes(t.id) && !isBetaCanvasTemplateId(t.id),
+  );
 
   return (
     <div className="tpl-modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="tpl-modal-title">
@@ -183,20 +221,31 @@ export default function TemplateModal({
           {tab === 'library' && (
             <div className="tpl-modal-library">
               <div className="tpl-modal-grid">
-                {libraryTemplates.map((t) => (
-                  <TemplateCard
-                    key={t.id}
-                    template={t}
-                    isSelected={templateId === t.id}
-                    isFavorite={favoriteIds.includes(t.id)}
-                    onSelect={handleSelect}
-                    onToggleFavorite={onToggleFavorite}
-                  />
-                ))}
+                {libraryTemplates.map((t) => {
+                  const isBeta = isBetaCanvasTemplateId(t.id);
+                  const disabled = isBeta && !betaReady;
+                  return (
+                    <TemplateCard
+                      key={t.id}
+                      template={{
+                        ...t,
+                        disabledReason: disabled
+                          ? 'Crée d’abord un design dans Profil → mode Beta.'
+                          : t.description,
+                      }}
+                      isSelected={templateId === t.id}
+                      isFavorite={favoriteIds.includes(t.id)}
+                      onSelect={handleSelect}
+                      onToggleFavorite={onToggleFavorite}
+                      disabled={disabled}
+                      badge={isBeta ? 'Canvas' : null}
+                    />
+                  );
+                })}
               </div>
               {libraryTemplates.length === 0 && (
                 <p className="tpl-modal-mine-empty">
-                  Les templates intégrés (Classic, Modern, Minimal, etc.) devraient s'afficher ici. Rechargez la page si la liste est vide.
+                  Les templates intégrés (Classic, Modern, Minimal, etc.) devraient s&apos;afficher ici. Rechargez la page si la liste est vide.
                 </p>
               )}
             </div>
@@ -247,3 +296,5 @@ export default function TemplateModal({
     </div>
   );
 }
+
+export { BETA_CANVAS_TEMPLATE_ID };

--- a/frontend/src/components/TemplatePicker.jsx
+++ b/frontend/src/components/TemplatePicker.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { apiGet } from '../api';
 import { applyA4PageFramesToDocument, syncCvPreviewIframeHeight } from '../lib/cvPreviewA4Pages';
-import TemplateModal, { FAVORITES_STORAGE_KEY } from './TemplateModal';
+import TemplateModal from './TemplateModal';
 import {
   isBetaCanvasTemplateId,
   withBetaCanvasTemplate,
@@ -536,24 +536,6 @@ function TemplateOptionsModal({
   );
 }
 
-function loadFavorites() {
-  try {
-    const raw = localStorage.getItem(FAVORITES_STORAGE_KEY);
-    const arr = raw ? JSON.parse(raw) : [];
-    return Array.isArray(arr) ? arr : [];
-  } catch {
-    return [];
-  }
-}
-
-function saveFavorites(ids) {
-  try {
-    localStorage.setItem(FAVORITES_STORAGE_KEY, JSON.stringify(ids));
-  } catch {
-    /* ignore quota / private mode */
-  }
-}
-
 export default function TemplatePicker({
   templates: templatesProp,
   templateId,
@@ -563,8 +545,6 @@ export default function TemplatePicker({
   openOptionsFromSupport,
   openOptionsNonce = 0,
   onOptionsModalClosed,
-  openModalToTab,
-  onOpenFromUrlConsumed,
   optionsPreviewHtml = '',
   optionsPreviewLoading = false,
   extraBarLeft = null,
@@ -574,8 +554,6 @@ export default function TemplatePicker({
   const [templatesLocal, setTemplatesLocal] = useState([]);
   const [optionsModalOpen, setOptionsModalOpen] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
-  const [initialTab, setInitialTab] = useState(null);
-  const [favoriteIds, setFavoriteIds] = useState(loadFavorites);
   const useProp = templatesProp !== undefined;
   const templatesRaw = useProp && Array.isArray(templatesProp) ? templatesProp : templatesLocal;
   const templates = withBetaCanvasTemplate(templatesRaw);
@@ -605,23 +583,6 @@ export default function TemplatePicker({
       setOptionsModalOpen(true);
     }
   }, [openOptionsNonce]);
-
-  const openedFromUrlRef = useRef(false);
-  useEffect(() => {
-    if (openModalToTab !== 'mine' || openedFromUrlRef.current || modalOpen) return;
-    openedFromUrlRef.current = true;
-    setInitialTab('mine');
-    setModalOpen(true);
-    onOpenFromUrlConsumed?.();
-  }, [openModalToTab, modalOpen, onOpenFromUrlConsumed]);
-
-  const toggleFavorite = useCallback((id) => {
-    setFavoriteIds((prev) => {
-      const next = prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id];
-      saveFavorites(next);
-      return next;
-    });
-  }, []);
 
   const handleOptionsModalClose = useCallback(() => {
     setOptionsModalOpen(false);
@@ -679,13 +640,10 @@ export default function TemplatePicker({
       </div>
       <TemplateModal
         open={modalOpen}
-        onClose={() => { setModalOpen(false); setInitialTab(null); }}
+        onClose={() => setModalOpen(false)}
         templates={templates}
         templateId={templateId}
         onChangeTemplate={onChangeTemplate}
-        favoriteIds={favoriteIds}
-        onToggleFavorite={toggleFavorite}
-        initialTab={initialTab}
         profileLayout={profileLayout}
         onBetaUnavailable={onBetaUnavailable}
       />

--- a/frontend/src/components/TemplatePicker.jsx
+++ b/frontend/src/components/TemplatePicker.jsx
@@ -3,6 +3,10 @@ import { createPortal } from 'react-dom';
 import { apiGet } from '../api';
 import { applyA4PageFramesToDocument, syncCvPreviewIframeHeight } from '../lib/cvPreviewA4Pages';
 import TemplateModal, { FAVORITES_STORAGE_KEY } from './TemplateModal';
+import {
+  isBetaCanvasTemplateId,
+  withBetaCanvasTemplate,
+} from '../lib/betaCanvasTemplate.js';
 
 const TYPO_DEFAULTS = {
   font_size_name: 15,
@@ -382,6 +386,7 @@ function TemplateOptionsModal({
   onChangeOptions,
   previewHtml,
   previewLoading,
+  betaMode = false,
 }) {
   const previewIframeRef = useRef(null);
   const previewScrollRef = useRef(null);
@@ -460,14 +465,24 @@ function TemplateOptionsModal({
       >
         <header className="tpl-options-modal-header">
           <h2 id="tpl-options-modal-title" className="tpl-options-modal-title">Personnaliser le CV</h2>
-          <p className="tpl-options-modal-sub">Les changements s’appliquent tout de suite à l’aperçu ; rien à valider.</p>
+          <p className="tpl-options-modal-sub">
+            {betaMode
+              ? 'Le design Beta se règle dans l’éditeur canvas (Profil → mode Beta).'
+              : 'Les changements s’appliquent tout de suite à l’aperçu ; rien à valider.'}
+          </p>
           <button type="button" className="tpl-options-modal-close" onClick={onClose} aria-label="Fermer">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
           </button>
         </header>
         <div className="tpl-options-modal-body">
           <aside className="tpl-options-modal-settings">
-            <OptionsPanel templateId={templateId} options={options} templateOptions={templateOptions} onChangeOptions={onChangeOptions} />
+            {betaMode ? (
+              <p className="tpl-options-beta-hint">
+                Couleurs, blocs et typo du canvas Beta se modifient dans Profil avec le mode Beta activé.
+              </p>
+            ) : (
+              <OptionsPanel templateId={templateId} options={options} templateOptions={templateOptions} onChangeOptions={onChangeOptions} />
+            )}
           </aside>
           <div className="tpl-options-modal-preview">
             <div className="tpl-options-modal-preview-bar">
@@ -553,6 +568,8 @@ export default function TemplatePicker({
   optionsPreviewHtml = '',
   optionsPreviewLoading = false,
   extraBarLeft = null,
+  profileLayout = null,
+  onBetaUnavailable = null,
 }) {
   const [templatesLocal, setTemplatesLocal] = useState([]);
   const [optionsModalOpen, setOptionsModalOpen] = useState(false);
@@ -560,11 +577,13 @@ export default function TemplatePicker({
   const [initialTab, setInitialTab] = useState(null);
   const [favoriteIds, setFavoriteIds] = useState(loadFavorites);
   const useProp = templatesProp !== undefined;
-  const templates = useProp && Array.isArray(templatesProp) ? templatesProp : templatesLocal;
-  const loading = useProp ? templates.length === 0 : templatesLocal.length === 0;
+  const templatesRaw = useProp && Array.isArray(templatesProp) ? templatesProp : templatesLocal;
+  const templates = withBetaCanvasTemplate(templatesRaw);
+  const loading = useProp ? templatesRaw.length === 0 : templatesLocal.length === 0;
   const currentMeta = templates.find(t => t.id === templateId) || templates[0] || {};
   const rawLayoutOptions = currentMeta.options || [];
   const isCustomTemplate = (templateId || '').startsWith('custom_');
+  const isBetaTemplate = isBetaCanvasTemplateId(templateId);
   const options = (isCustomTemplate && rawLayoutOptions.length === 0) ? LAYOUT_OPTIONS_FALLBACK : rawLayoutOptions;
 
   useEffect(() => {
@@ -638,7 +657,9 @@ export default function TemplatePicker({
           type="button"
           className={`tpl-gear${optionsModalOpen ? ' tpl-gear--open' : ''}`}
           onClick={() => setOptionsModalOpen(true)}
-          title="Personnaliser le template (couleurs, typo)"
+          title={isBetaTemplate
+            ? 'Le design Beta se personnalise dans l’éditeur Beta'
+            : 'Personnaliser le template (couleurs, typo)'}
         >
           <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>
@@ -653,6 +674,7 @@ export default function TemplatePicker({
           onChangeOptions={onChangeOptions}
           previewHtml={optionsPreviewHtml}
           previewLoading={optionsPreviewLoading}
+          betaMode={isBetaTemplate}
         />
       </div>
       <TemplateModal
@@ -664,6 +686,8 @@ export default function TemplatePicker({
         favoriteIds={favoriteIds}
         onToggleFavorite={toggleFavorite}
         initialTab={initialTab}
+        profileLayout={profileLayout}
+        onBetaUnavailable={onBetaUnavailable}
       />
     </div>
   );

--- a/frontend/src/lib/betaCanvasTemplate.js
+++ b/frontend/src/lib/betaCanvasTemplate.js
@@ -1,0 +1,58 @@
+/**
+ * Template virtuel « Beta » = design canvas libre du profil (AXE-374).
+ * Pas un dossier templates/ — le rendu passe par `layout` (layout_renderer).
+ */
+
+import { isEmptyLayoutV3 } from './cvLayoutModelV3.js';
+
+export const BETA_CANVAS_TEMPLATE_ID = 'beta';
+
+export const BETA_CANVAS_TEMPLATE = {
+  id: BETA_CANVAS_TEMPLATE_ID,
+  name: 'Beta',
+  description:
+    'Ton design de l’éditeur Beta (canvas libre). Modifie-le sur Profil en mode Beta.',
+  tags: ['beta', 'canvas', 'free-canvas'],
+  options: [],
+};
+
+/**
+ * @param {unknown} templateId
+ * @returns {boolean}
+ */
+export function isBetaCanvasTemplateId(templateId) {
+  return String(templateId || '').trim() === BETA_CANVAS_TEMPLATE_ID;
+}
+
+/**
+ * @param {unknown} layout
+ * @returns {boolean}
+ */
+export function hasUsableBetaCanvasLayout(layout) {
+  return Boolean(layout) && !isEmptyLayoutV3(layout);
+}
+
+/**
+ * Injecte la carte Beta en tête de liste (idempotent).
+ * @param {unknown[]} templates
+ * @returns {object[]}
+ */
+export function withBetaCanvasTemplate(templates) {
+  const list = Array.isArray(templates) ? templates.filter(Boolean) : [];
+  if (list.some((t) => isBetaCanvasTemplateId(t?.id))) {
+    return list;
+  }
+  return [BETA_CANVAS_TEMPLATE, ...list];
+}
+
+/**
+ * Champs à fusionner dans render-html / pdf quand Beta est actif.
+ * @param {string|null|undefined} templateId
+ * @param {object|null|undefined} layout
+ * @returns {{ layout?: object }}
+ */
+export function betaCanvasRenderFields(templateId, layout) {
+  if (!isBetaCanvasTemplateId(templateId)) return {};
+  if (!hasUsableBetaCanvasLayout(layout)) return {};
+  return { layout };
+}

--- a/frontend/src/styles/TemplatePicker.css
+++ b/frontend/src/styles/TemplatePicker.css
@@ -683,9 +683,37 @@
   background: color-mix(in srgb, var(--accent) 10%, transparent);
 }
 
-.tpl-modal-card--locked {
-  opacity: 0.75;
+.tpl-modal-card--disabled {
+  opacity: 0.55;
   cursor: not-allowed;
+}
+
+.tpl-modal-card--disabled:hover {
+  border-color: var(--color-hairline);
+  background: transparent;
+}
+
+.tpl-modal-card-name {
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.2;
+  word-break: break-word;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.tpl-modal-card-badge {
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ds-color-text-muted, var(--color-muted));
+  border: 1px solid var(--color-hairline);
+  border-radius: var(--ds-radius-xs, 4px);
+  padding: 0.1rem 0.35rem;
 }
 
 .tpl-modal-card-preview {
@@ -695,23 +723,19 @@
   justify-content: center;
 }
 
-.tpl-modal-card-lock {
-  position: absolute;
-  right: 0;
-  top: 50%;
-  transform: translateY(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--muted, #64748b);
+.tpl-modal-card--locked {
+  opacity: 0.75;
+  cursor: not-allowed;
 }
 
-.tpl-modal-card-name {
-  font-size: 11px;
-  font-weight: 500;
-  line-height: 1.2;
-  word-break: break-word;
+.tpl-options-beta-hint {
+  margin: 0;
+  padding: var(--ds-space-md, 0.75rem);
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  color: var(--color-body-muted, var(--muted));
 }
+
 
 .tpl-modal-card-fav {
   position: absolute;

--- a/frontend/src/styles/TemplatePicker.css
+++ b/frontend/src/styles/TemplatePicker.css
@@ -614,36 +614,6 @@
   color: var(--text-primary);
 }
 
-.tpl-modal-tabs {
-  display: flex;
-  gap: 0;
-  padding: 0 16px;
-  border-bottom: 1px solid var(--border);
-  flex-shrink: 0;
-}
-
-.tpl-modal-tab {
-  padding: 10px 14px;
-  border: none;
-  border-bottom: 2px solid transparent;
-  margin-bottom: -1px;
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
-}
-
-.tpl-modal-tab:hover {
-  color: var(--text-primary);
-}
-
-.tpl-modal-tab--active {
-  color: var(--accent);
-  border-bottom-color: var(--accent);
-}
-
 .tpl-modal-body {
   padding: 16px;
   overflow-y: auto;
@@ -736,60 +706,7 @@
   color: var(--color-body-muted, var(--muted));
 }
 
-
-.tpl-modal-card-fav {
-  position: absolute;
-  top: 6px;
-  right: 6px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 26px;
-  height: 26px;
-  border: none;
-  border-radius: 50%;
-  background: var(--bg);
-  color: var(--text-muted, #94a3b8);
-  cursor: pointer;
-  transition: color 0.15s, background 0.15s;
-}
-
-.tpl-modal-card-fav:hover {
-  color: var(--accent);
-  background: var(--bg-secondary);
-}
-
-.tpl-modal-card-fav svg {
-  flex-shrink: 0;
-}
-
-.tpl-modal-card:has(.tpl-modal-card-fav) .tpl-modal-card-preview {
-  padding-right: 22px;
-}
-
-/* Mes templates: liste + carte custom désactivée */
-.tpl-modal-mine {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.tpl-modal-mine-section {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.tpl-modal-mine-section-title {
-  margin: 0;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-.tpl-modal-mine-empty {
+.tpl-modal-empty {
   margin: 0;
   font-size: 13px;
   color: var(--text-secondary);

--- a/frontend/tests/unit/betaCanvasTemplate.test.js
+++ b/frontend/tests/unit/betaCanvasTemplate.test.js
@@ -1,0 +1,46 @@
+/**
+ * Tests unitaires — template virtuel Beta (AXE-374).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  BETA_CANVAS_TEMPLATE,
+  BETA_CANVAS_TEMPLATE_ID,
+  betaCanvasRenderFields,
+  hasUsableBetaCanvasLayout,
+  isBetaCanvasTemplateId,
+  withBetaCanvasTemplate,
+} from '../../src/lib/betaCanvasTemplate.js';
+
+test('isBetaCanvasTemplateId', () => {
+  assert.equal(isBetaCanvasTemplateId('beta'), true);
+  assert.equal(isBetaCanvasTemplateId(' minimal '), false);
+  assert.equal(isBetaCanvasTemplateId(null), false);
+});
+
+test('withBetaCanvasTemplate injecte en tête sans doublon', () => {
+  const once = withBetaCanvasTemplate([{ id: 'minimal', name: 'Minimal' }]);
+  assert.equal(once[0].id, BETA_CANVAS_TEMPLATE_ID);
+  assert.equal(once.length, 2);
+  const twice = withBetaCanvasTemplate(once);
+  assert.equal(twice.length, 2);
+  assert.equal(twice[0].name, BETA_CANVAS_TEMPLATE.name);
+});
+
+test('hasUsableBetaCanvasLayout', () => {
+  assert.equal(hasUsableBetaCanvasLayout(null), false);
+  assert.equal(hasUsableBetaCanvasLayout({ pages: [{ blocks: [] }] }), false);
+  assert.equal(
+    hasUsableBetaCanvasLayout({ pages: [{ blocks: [{ id: 'a', type: 'text', x: 0, y: 0, w: 10, h: 10 }] }] }),
+    true,
+  );
+});
+
+test('betaCanvasRenderFields', () => {
+  const layout = { pages: [{ blocks: [{ id: 'a', type: 'text', x: 0, y: 0, w: 10, h: 10 }] }] };
+  assert.deepEqual(betaCanvasRenderFields('minimal', layout), {});
+  assert.deepEqual(betaCanvasRenderFields('beta', null), {});
+  assert.deepEqual(betaCanvasRenderFields('beta', layout), { layout });
+});


### PR DESCRIPTION
## Summary
- Add a virtual **Beta** card in the Stable template library (`TemplateModal`)
- Selecting it uses the profile free-canvas `layout` for preview and PDF
- If no Beta layout yet, the card is disabled with guidance
- Remove **Mes templates** tab (favorites + customs UI) — single library grid only

## Test plan
- [ ] Open « Choisir un template » — no « Mes templates » tab / no star icons
- [ ] Beta card still present; other templates unchanged
- [ ] Preview/PDF with Beta layout still works

Fixes AXE-374
Fixes AXE-375
Closes #141
Closes #143