### PR TITLE
chore(ui): libellé Exporter en PDF

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3362,7 +3362,7 @@ export default function App() {
                       <span className="tpl-btn-bar-extra-icon" aria-hidden>
                         <HiArrowDownTray size={16} strokeWidth={2} />
                       </span>
-                      CV de base
+                      Exporter en PDF
                     </button>
                   )}
                 />

--- a/frontend/src/components/ProfileView.jsx
+++ b/frontend/src/components/ProfileView.jsx
@@ -1238,7 +1238,7 @@ export default function ProfileView({ onSaveSuccess, session, refreshKey, usage,
                 <span className="tpl-btn-bar-extra-icon" aria-hidden>
                   <HiArrowDownTray size={16} strokeWidth={2} />
                 </span>
-                CV de base
+                Exporter en PDF
               </button>
             )}
           />


### PR DESCRIPTION
## Summary
- Rename the « CV de base » action button to **Exporter en PDF** (Profil + `/app/cv`)

## Test plan
- [ ] Button label reads « Exporter en PDF » on CV and Profil bars
- [ ] Download still works


Made with [Cursor](https://cursor.com)