### PR TITLE
feat(candidatures): métriques actionnables compactes

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -852,6 +852,8 @@ def _application_row(aid: str, data: dict, updated_at: str | None = None) -> dic
         "statut": data.get("statut", "candidature_envoyee"),
         "archived": data.get("archived", False),
         "date": date_str,
+        "date_envoi": (data.get("date_envoi") or "").strip(),
+        "date_reponse": (data.get("date_reponse") or "").strip(),
         "created_at": created,
         "refus_raison": data.get("refus_raison", ""),
         "refus_raison_type": data.get("refus_raison_type", ""),
@@ -1281,6 +1283,10 @@ def update_adaptation(adaptation_id: str, updates: dict, user_id: str | None = N
         # Ne fixer date_envoi que lors du premier passage en "candidature_envoyee" (pas quand on y revient après un autre statut)
         if updates["statut"] == "candidature_envoyee" and statut_prev != "candidature_envoyee":
             current["date_envoi"] = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M")
+        # Première réponse employeur (métrique délai moyen AXE-378)
+        _response_statuts = frozenset({"reponse_recue", "interview", "offre", "refus"})
+        if updates["statut"] in _response_statuts and not current.get("date_reponse"):
+            current["date_reponse"] = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M")
     if "archived" in updates:
         current["archived"] = bool(updates["archived"])
     if "poste" in updates:

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -36,6 +36,7 @@ import './App.css';
 import './styles/TemplatePicker.css';
 import './styles/GuidedTour.css';
 import { formatApplicationDateLabel } from './lib/applicationDates';
+import { computeApplicationMetrics, isApplicationToFollowUp } from './lib/applicationStats.js';
 import { applyA4PageFramesToDocument, syncCvPreviewIframeHeight } from './lib/cvPreviewA4Pages';
 import {
   betaCanvasRenderFields,
@@ -728,6 +729,8 @@ export default function App() {
   const [showArchived, setShowArchived] = useState(false);
   const [applicationSearchQuery, setApplicationSearchQuery] = useState('');
   const [applicationSearchDebounced, setApplicationSearchDebounced] = useState('');
+  /** Filtre métrique : `relancer` | null */
+  const [candidaturesMetricFilter, setCandidaturesMetricFilter] = useState(null);
   /* sidebar removed - now using topbar layout */
   const [session, setSession] = useState(null);
   const [authLoading, setAuthLoading] = useState(!!supabase);
@@ -2881,15 +2884,21 @@ export default function App() {
 
   const filteredApplications = useMemo(() => {
     const q = applicationSearchDebounced.toLowerCase();
-    if (!q) return applications;
-    return applications.filter((app) => {
-      const poste = ((app.poste || app.poste_offre || '') + ' ').toLowerCase();
-      const entreprise = ((app.entreprise || '') + ' ').toLowerCase();
-      const source = ((app.source_offre || '') + ' ').toLowerCase();
-      const date = ((app.date || '') + ' ').toLowerCase();
-      return poste.includes(q) || entreprise.includes(q) || source.includes(q) || date.includes(q);
-    });
-  }, [applications, applicationSearchDebounced]);
+    let list = applications;
+    if (q) {
+      list = list.filter((app) => {
+        const poste = ((app.poste || app.poste_offre || '') + ' ').toLowerCase();
+        const entreprise = ((app.entreprise || '') + ' ').toLowerCase();
+        const source = ((app.source_offre || '') + ' ').toLowerCase();
+        const date = ((app.date || '') + ' ').toLowerCase();
+        return poste.includes(q) || entreprise.includes(q) || source.includes(q) || date.includes(q);
+      });
+    }
+    if (candidaturesMetricFilter === 'relancer') {
+      list = list.filter((app) => isApplicationToFollowUp(app));
+    }
+    return list;
+  }, [applications, applicationSearchDebounced, candidaturesMetricFilter]);
 
   const filteredNonArchivedCount = useMemo(
     () => filteredApplications.filter((a) => !a.archived).length,
@@ -2900,31 +2909,7 @@ export default function App() {
     [filteredApplications],
   );
 
-  const applicationStats = (() => {
-    const now = new Date();
-    const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
-    const yesterday = new Date(now);
-    yesterday.setDate(yesterday.getDate() - 1);
-    const yesterdayStr = `${yesterday.getFullYear()}-${String(yesterday.getMonth() + 1).padStart(2, '0')}-${String(yesterday.getDate()).padStart(2, '0')}`;
-    const thisMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
-    const lastMonthDate = new Date(now.getFullYear(), now.getMonth() - 1, 1);
-    const lastMonth = `${lastMonthDate.getFullYear()}-${String(lastMonthDate.getMonth() + 1).padStart(2, '0')}`;
-    let countToday = 0, countYesterday = 0, countMonth = 0, countLastMonth = 0, total = 0;
-    // Total / périodes = toutes les candidatures non archivées (tous statuts du board).
-    applications.forEach((app) => {
-      if (app.archived) return;
-      total++;
-      const d = (app.date || '').trim().split(/\s+/)[0];
-      if (!d || !/^\d{4}-\d{2}-\d{2}$/.test(d)) return;
-      if (d === today) countToday++;
-      if (d === yesterdayStr) countYesterday++;
-      if (d.startsWith(thisMonth)) countMonth++;
-      if (d.startsWith(lastMonth)) countLastMonth++;
-    });
-    const todayPct = countYesterday > 0 ? Math.round(((countToday - countYesterday) / countYesterday) * 100) : (countToday > 0 ? 100 : 0);
-    const monthPct = countLastMonth > 0 ? Math.round(((countMonth - countLastMonth) / countLastMonth) * 100) : (countMonth > 0 ? 100 : 0);
-    return { countToday, countMonth, total, todayPct, monthPct };
-  })();
+  const applicationStats = useMemo(() => computeApplicationMetrics(applications), [applications]);
 
   /* Mode full Supabase : sans config Supabase, on n'affiche que l'écran de configuration */
   if (!supabase) {
@@ -3664,34 +3649,60 @@ export default function App() {
           )}
           <div className="page-content applications-full candidatures-page" data-section="candidatures" data-analytics-section="candidatures_board">
             <div className="candidatures-page-inner">
-              <dl className="candidatures-metrics" data-section="candidatures-stats" data-analytics-section="candidatures_stats">
-                <div className="candidatures-metric">
-                  <dt className="candidatures-metric-label">Aujourd&apos;hui</dt>
-                  <dd className="candidatures-metric-body">
-                    <span className="candidatures-metric-value">{applicationStats.countToday}</span>
-                    {applicationStats.countToday > 0 && (
-                      <span className="candidatures-metric-delta candidatures-metric-delta--up">↑ +{applicationStats.todayPct}%</span>
-                    )}
-                  </dd>
+              <div
+                className="candidatures-metrics candidatures-metrics--compact"
+                data-section="candidatures-stats"
+                data-analytics-section="candidatures_stats"
+                role="group"
+                aria-label="Indicateurs candidatures"
+              >
+                <Button
+                  type="button"
+                  variant={candidaturesMetricFilter === 'relancer' ? 'secondary' : 'ghost'}
+                  size="sm"
+                  className={`candidatures-metric-chip${applicationStats.toFollowUp > 0 ? ' candidatures-metric-chip--alert' : ''}`}
+                  aria-pressed={candidaturesMetricFilter === 'relancer'}
+                  title="À postuler ou envoyée depuis 14 jours ou plus — clic pour filtrer"
+                  onClick={() => setCandidaturesMetricFilter((f) => (f === 'relancer' ? null : 'relancer'))}
+                >
+                  <span className="candidatures-metric-chip-label">À relancer</span>
+                  <span className="candidatures-metric-chip-value">{applicationStats.toFollowUp}</span>
+                </Button>
+                <div
+                  className="candidatures-metric-chip candidatures-metric-chip--static"
+                  title="Part des candidatures envoyées ayant reçu une réponse (réponse, entretien, offre ou refus)"
+                >
+                  <span className="candidatures-metric-chip-label">Taux de réponse</span>
+                  <span className="candidatures-metric-chip-value">
+                    {applicationStats.responseRatePct == null ? '—' : `${applicationStats.responseRatePct}%`}
+                  </span>
                 </div>
-                <div className="candidatures-metric">
-                  <dt className="candidatures-metric-label">Ce mois</dt>
-                  <dd className="candidatures-metric-body">
-                    <span className="candidatures-metric-value">{applicationStats.countMonth}</span>
-                    {applicationStats.countMonth > 0 && (
-                      <span className={`candidatures-metric-delta ${applicationStats.monthPct >= 0 ? 'candidatures-metric-delta--up' : 'candidatures-metric-delta--down'}`}>
-                        {applicationStats.monthPct >= 0 ? '↑' : '↓'} {applicationStats.monthPct >= 0 ? '+' : ''}{applicationStats.monthPct}%
-                      </span>
-                    )}
-                  </dd>
+                <div
+                  className="candidatures-metric-chip candidatures-metric-chip--static"
+                  title="Moyenne des jours entre envoi et première réponse employeur (nécessite date_reponse)"
+                >
+                  <span className="candidatures-metric-chip-label">Délai moyen</span>
+                  <span className="candidatures-metric-chip-value">
+                    {applicationStats.avgResponseDays == null
+                      ? '—'
+                      : `${applicationStats.avgResponseDays} j`}
+                  </span>
                 </div>
-                <div className="candidatures-metric">
-                  <dt className="candidatures-metric-label">Total</dt>
-                  <dd className="candidatures-metric-body">
-                    <span className="candidatures-metric-value">{applicationStats.total}</span>
-                  </dd>
-                </div>
-              </dl>
+                <span className="candidatures-metric-total" title="Candidatures non archivées">
+                  {applicationStats.total} candidature{applicationStats.total !== 1 ? 's' : ''}
+                </span>
+                {candidaturesMetricFilter === 'relancer' && (
+                  <Button
+                    type="button"
+                    variant="link"
+                    size="sm"
+                    className="candidatures-metric-clear"
+                    onClick={() => setCandidaturesMetricFilter(null)}
+                  >
+                    Afficher tout
+                  </Button>
+                )}
+              </div>
               <div className="candidatures-controls">
                 <label className="applications-toggle">
                   <input type="checkbox" checked={showArchived} onChange={(e) => setShowArchived(e.target.checked)} />

--- a/frontend/src/lib/applicationStats.js
+++ b/frontend/src/lib/applicationStats.js
@@ -1,0 +1,94 @@
+/**
+ * Métriques actionnables du board Mes candidatures (AXE-378).
+ *
+ * Définitions (candidatures non archivées) :
+ * - total : toutes
+ * - à relancer : statut `a_postuler` | `candidature_envoyee` et date d’envoi
+ *   (ou `date` liste) ≥ {@link RELANCE_DAYS} jours
+ * - taux de réponse : (réponse reçue | entretien | offre | refus)
+ *   / (toutes sauf `a_postuler`), en % arrondi
+ * - délai moyen : moyenne des (date_reponse − date_envoi) en jours entiers,
+ *   uniquement si les deux dates sont présentes (sinon null)
+ */
+
+import { STATUT_LABELS } from '../constants.js';
+
+export const RELANCE_DAYS = 14;
+
+const WAITING_STATUTS = new Set(['a_postuler', 'candidature_envoyee']);
+const RESPONDED_STATUTS = new Set(['reponse_recue', 'interview', 'offre', 'refus']);
+
+/**
+ * @param {string | null | undefined} dateStr
+ * @returns {Date | null}
+ */
+export function parseApplicationDate(dateStr) {
+  if (!dateStr || typeof dateStr !== 'string') return null;
+  const trimmed = dateStr.trim();
+  const m = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})(?:[T\s](\d{2}):(\d{2}))?/);
+  if (!m) return null;
+  const y = parseInt(m[1], 10);
+  const mo = parseInt(m[2], 10) - 1;
+  const d = parseInt(m[3], 10);
+  if (m[4] != null && m[5] != null) {
+    return new Date(Date.UTC(y, mo, d, parseInt(m[4], 10), parseInt(m[5], 10)));
+  }
+  return new Date(y, mo, d);
+}
+
+function resolveStatut(app) {
+  const s = app?.statut;
+  return s && s in STATUT_LABELS ? s : 'candidature_envoyee';
+}
+
+/**
+ * @param {object} app
+ * @param {{ now?: Date, relanceDays?: number }} [opts]
+ */
+export function isApplicationToFollowUp(app, { now = new Date(), relanceDays = RELANCE_DAYS } = {}) {
+  if (!app || app.archived) return false;
+  if (!WAITING_STATUTS.has(resolveStatut(app))) return false;
+  const ref = parseApplicationDate(app.date_envoi || app.date);
+  if (!ref) return false;
+  const ms = now.getTime() - ref.getTime();
+  return ms >= relanceDays * 24 * 60 * 60 * 1000;
+}
+
+/**
+ * @param {object[]} applications
+ * @param {{ now?: Date, relanceDays?: number }} [opts]
+ */
+export function computeApplicationMetrics(applications, { now = new Date(), relanceDays = RELANCE_DAYS } = {}) {
+  const list = Array.isArray(applications) ? applications : [];
+  const active = list.filter((a) => a && !a.archived);
+
+  let toFollowUp = 0;
+  let sent = 0;
+  let responded = 0;
+  const delays = [];
+
+  for (const app of active) {
+    const statut = resolveStatut(app);
+    if (isApplicationToFollowUp(app, { now, relanceDays })) toFollowUp += 1;
+
+    if (statut === 'a_postuler') continue;
+    sent += 1;
+    if (!RESPONDED_STATUTS.has(statut)) continue;
+    responded += 1;
+
+    const envoi = parseApplicationDate(app.date_envoi || app.date);
+    const reponse = parseApplicationDate(app.date_reponse);
+    if (envoi && reponse && reponse.getTime() >= envoi.getTime()) {
+      delays.push((reponse.getTime() - envoi.getTime()) / (24 * 60 * 60 * 1000));
+    }
+  }
+
+  return {
+    total: active.length,
+    toFollowUp,
+    responseRatePct: sent > 0 ? Math.round((responded / sent) * 100) : null,
+    avgResponseDays: delays.length > 0 ? Math.round(delays.reduce((a, b) => a + b, 0) / delays.length) : null,
+    sent,
+    responded,
+  };
+}

--- a/frontend/src/styles/app/candidatures.css
+++ b/frontend/src/styles/app/candidatures.css
@@ -33,21 +33,75 @@
   padding: 0 1.5rem 1.5rem;
 }
 
-/* ── Métriques : ligne ouverte, séparateurs hairline (pas de cards) ── */
+/* ── Métriques compactes actionnables (AXE-378) ── */
 .candidatures-metrics {
   display: flex;
   margin: 0;
   padding: 1.25rem 0;
-  border-bottom: 1px solid var(--color-hairline);
+  border-bottom: 1px solid var(--ds-color-border-default);
 }
 
+.candidatures-metrics--compact {
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--ds-space-sm, 0.5rem) var(--ds-space-md, 0.75rem);
+  padding: 0.5rem 0;
+  min-height: 2.5rem;
+}
+
+.candidatures-metric-chip {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  margin: 0;
+  min-height: var(--ds-size-button-sm, 2rem);
+}
+
+.candidatures-metric-chip--static {
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--ds-radius-sm, 0.25rem);
+  color: var(--ds-color-text-default);
+}
+
+.candidatures-metric-chip-label {
+  font-size: var(--ds-font-size-label-sm, 0.75rem);
+  font-weight: 400;
+  letter-spacing: 0.02em;
+  color: var(--ds-color-text-muted);
+  line-height: 1.2;
+}
+
+.candidatures-metric-chip-value {
+  font-size: var(--ds-font-size-body-md, 0.9375rem);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  color: var(--ds-color-text-default);
+  line-height: 1.2;
+}
+
+.candidatures-metric-chip--alert .candidatures-metric-chip-value {
+  color: var(--ds-color-text-danger);
+}
+
+.candidatures-metric-total {
+  margin-left: auto;
+  font-size: var(--ds-font-size-label-sm, 0.75rem);
+  color: var(--ds-color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.candidatures-metric-clear {
+  flex-shrink: 0;
+}
+
+/* Legacy 3-colonnes (si réutilisé ailleurs) */
 .candidatures-metric {
   flex: 1;
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
   padding: 0 1.5rem;
-  border-right: 1px solid var(--color-hairline);
+  border-right: 1px solid var(--ds-color-border-default);
   min-width: 0;
 }
 
@@ -66,7 +120,7 @@
   font-weight: 400;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--color-muted);
+  color: var(--ds-color-text-muted);
   line-height: 1.4;
 }
 
@@ -82,7 +136,7 @@
   font-size: 1.5rem;
   font-weight: 400;
   letter-spacing: -0.02em;
-  color: var(--color-ink);
+  color: var(--ds-color-text-default);
   line-height: 1.1;
 }
 
@@ -92,11 +146,11 @@
 }
 
 .candidatures-metric-delta--up {
-  color: var(--color-deep-green);
+  color: var(--ds-color-feedback-success);
 }
 
 .candidatures-metric-delta--down {
-  color: var(--color-error);
+  color: var(--ds-color-text-danger);
 }
 
 /* ── Contrôles : bande hairline, pas de carte englobante ── */
@@ -363,9 +417,15 @@
   }
 
   .candidatures-metrics {
-    flex-direction: column;
-    gap: 0;
-    padding: 1rem 0;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.35rem 0.5rem;
+    padding: 0.5rem 0;
+  }
+
+  .candidatures-metrics--compact .candidatures-metric-total {
+    margin-left: 0;
+    width: 100%;
   }
 
   .candidatures-metric {
@@ -374,7 +434,7 @@
     justify-content: space-between;
     padding: 0.65rem 0;
     border-right: none;
-    border-bottom: 1px solid var(--color-hairline);
+    border-bottom: 1px solid var(--ds-color-border-default);
   }
 
   .candidatures-metric:last-child {

--- a/frontend/tests/unit/applicationStats.test.js
+++ b/frontend/tests/unit/applicationStats.test.js
@@ -1,0 +1,100 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  RELANCE_DAYS,
+  parseApplicationDate,
+  isApplicationToFollowUp,
+  computeApplicationMetrics,
+} from '../../src/lib/applicationStats.js';
+
+test('parseApplicationDate accepte jour seul et datetime UTC', () => {
+  const day = parseApplicationDate('2026-01-10');
+  assert.ok(day instanceof Date);
+  assert.equal(day.getFullYear(), 2026);
+  assert.equal(day.getMonth(), 0);
+  assert.equal(day.getDate(), 10);
+
+  const withTime = parseApplicationDate('2026-01-10 14:30');
+  assert.ok(withTime instanceof Date);
+  assert.equal(withTime.toISOString().slice(0, 16), '2026-01-10T14:30');
+});
+
+test('parseApplicationDate refuse les valeurs invalides', () => {
+  assert.equal(parseApplicationDate(''), null);
+  assert.equal(parseApplicationDate(null), null);
+  assert.equal(parseApplicationDate('hier'), null);
+});
+
+test('isApplicationToFollowUp : 14j+ en attente', () => {
+  const now = new Date('2026-08-21T12:00:00Z');
+  assert.equal(
+    isApplicationToFollowUp(
+      { statut: 'candidature_envoyee', date: '2026-08-01', archived: false },
+      { now },
+    ),
+    true,
+  );
+  assert.equal(
+    isApplicationToFollowUp(
+      { statut: 'candidature_envoyee', date: '2026-08-20', archived: false },
+      { now },
+    ),
+    false,
+  );
+  assert.equal(
+    isApplicationToFollowUp(
+      { statut: 'interview', date: '2026-07-01', archived: false },
+      { now },
+    ),
+    false,
+  );
+  assert.equal(
+    isApplicationToFollowUp(
+      { statut: 'candidature_envoyee', date: '2026-07-01', archived: true },
+      { now },
+    ),
+    false,
+  );
+});
+
+test('computeApplicationMetrics : total, relance, taux, délai', () => {
+  const now = new Date('2026-08-21T12:00:00Z');
+  const metrics = computeApplicationMetrics(
+    [
+      { statut: 'candidature_envoyee', date: '2026-08-01', archived: false },
+      { statut: 'a_postuler', date: '2026-07-01', archived: false },
+      {
+        statut: 'reponse_recue',
+        date_envoi: '2026-08-01',
+        date_reponse: '2026-08-11',
+        archived: false,
+      },
+      {
+        statut: 'refus',
+        date_envoi: '2026-08-01',
+        date_reponse: '2026-08-05',
+        archived: false,
+      },
+      { statut: 'offre', date: '2026-08-10', archived: true },
+    ],
+    { now },
+  );
+
+  assert.equal(metrics.total, 4);
+  assert.equal(metrics.toFollowUp, 2);
+  assert.equal(metrics.sent, 3);
+  assert.equal(metrics.responded, 2);
+  assert.equal(metrics.responseRatePct, 67);
+  assert.equal(metrics.avgResponseDays, 7);
+  assert.equal(RELANCE_DAYS, 14);
+});
+
+test('computeApplicationMetrics : sans envoi → taux et délai null', () => {
+  const metrics = computeApplicationMetrics([
+    { statut: 'a_postuler', date: '2026-08-01', archived: false },
+  ]);
+  assert.equal(metrics.total, 1);
+  assert.equal(metrics.responseRatePct, null);
+  assert.equal(metrics.avgResponseDays, null);
+});


### PR DESCRIPTION
## Summary
- Remplace le bandeau Aujourd’hui / Mois / Total par une ligne compacte : **À relancer** (filtre 14j+), **taux de réponse**, **délai moyen**, total discret.
- Pose `date_reponse` au premier passage en statut réponse (backend) ; expose `date_envoi` / `date_reponse` dans la liste API.
- Calculs unitaires dans `applicationStats.js` + tokens `--ds-*` / `<Button>`.

## Test plan
- [ ] `/app/postule` : bandeau ~une ligne, board plus haut dans le viewport
- [ ] Clic « À relancer » filtre le board ; « Afficher tout » remet tout
- [ ] Déplacer une carte vers Réponse / Entretien / Offre / Refusé → prochain reload, délai moyen peut se remplir
- [ ] `npm run test:unit` : `applicationStats.test.js` vert

Fixes AXE-378
Closes #147


Made with [Cursor](https://cursor.com)