### PR TITLE
feat(candidatures): redesign cartes kanban

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -35,8 +35,8 @@ import { syncRobotsMeta } from './lib/seoHead';
 import './App.css';
 import './styles/TemplatePicker.css';
 import './styles/GuidedTour.css';
-import { formatApplicationDateLabel } from './lib/applicationDates';
-import { computeApplicationMetrics, isApplicationToFollowUp } from './lib/applicationStats.js';
+import { formatApplicationDateLabel, formatApplicationRelativeLabel } from './lib/applicationDates';
+import { computeApplicationMetrics, getApplicationCardAccent, isApplicationToFollowUp } from './lib/applicationStats.js';
 import { applyA4PageFramesToDocument, syncCvPreviewIframeHeight } from './lib/cvPreviewA4Pages';
 import {
   betaCanvasRenderFields,
@@ -3757,12 +3757,28 @@ export default function App() {
                     <div className="kanban-column-cards">
                       {columnApps.map((app) => {
                         const titre = app.poste || app.poste_offre || 'Sans intitulé';
-                        const sousTitre = [app.entreprise].filter(Boolean).join(' · ');
+                        const entreprise = (app.entreprise || '').trim();
                         const isDragging = kanbanDraggedId === app.id;
+                        const statutKey = app.statut in STATUT_LABELS ? app.statut : 'candidature_envoyee';
+                        const needsFollowUp = isApplicationToFollowUp(app);
+                        const accent = getApplicationCardAccent(app);
+                        const hasDocs = Boolean(
+                          app.pdf_lettre_url || app.pdf_cv_url || app.pdf_fiche_url
+                          || app.pdf_cv_stored || app.pdf_fiche_stored || app.pdf_lettre_stored,
+                        );
+                        const dateAbs = formatApplicationDateLabel(app.date);
+                        const dateRel = formatApplicationRelativeLabel(app.date);
                         return (
                           <div
                             key={app.id}
-                            className={`application-card kanban-card ${app.archived ? 'archived' : ''} ${isDragging ? 'dragging' : ''} ${justAddedAppId === app.id ? 'just-added' : ''}`}
+                            className={[
+                              'application-card',
+                              'kanban-card',
+                              app.archived ? 'archived' : '',
+                              isDragging ? 'dragging' : '',
+                              justAddedAppId === app.id ? 'just-added' : '',
+                              accent ? `application-card--accent-${accent}` : '',
+                            ].filter(Boolean).join(' ')}
                             draggable={!app.archived}
                             onDragStart={(e) => {
                               setKanbanDraggedId(app.id);
@@ -3772,28 +3788,63 @@ export default function App() {
                             onDragEnd={() => setKanbanDraggedId(null)}
                           >
                             <div className="app-card-actions-icons">
-                              <button type="button" className="btn btn-icon btn-icon-view" onClick={() => openApplicationDetail(app.id)} title="Voir" aria-label="Voir">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
-                              </button>
-                              <button type="button" className="btn btn-icon btn-icon-archive" onClick={() => handleArchive(app.id, true)} title="Archiver" aria-label="Archiver">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
-                              </button>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                iconOnly
+                                className="app-card-action"
+                                onClick={() => openApplicationDetail(app.id)}
+                                title="Voir"
+                                aria-label="Voir"
+                              >
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                              </Button>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                iconOnly
+                                className="app-card-action app-card-action--archive"
+                                onClick={() => handleArchive(app.id, true)}
+                                title="Archiver"
+                                aria-label="Archiver"
+                              >
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+                              </Button>
                             </div>
-                            <div className={`app-status-dot app-status-dot--${(app.statut in STATUT_LABELS ? app.statut : 'candidature_envoyee')}`} title={STATUT_LABELS[app.statut in STATUT_LABELS ? app.statut : 'candidature_envoyee']} aria-hidden />
                             <div className="app-card-top">
-                              <CompanyLogo companyName={app.entreprise} className="app-company-logo" size={36} />
-                              <div className="app-poste-date">
+                              <CompanyLogo companyName={entreprise || app.entreprise} className="app-company-logo" size={32} />
+                              <div className="app-card-text">
                                 <div className="app-title">{titre}</div>
-                                <div className="app-date">{formatApplicationDateLabel(app.date)}</div>
+                                {entreprise ? <div className="app-meta">{entreprise}</div> : null}
                               </div>
+                              {needsFollowUp && (
+                                <span
+                                  className="app-follow-up-dot"
+                                  title="Sans nouvelle depuis 14 jours ou plus"
+                                  aria-label="À relancer"
+                                />
+                              )}
                             </div>
-                            {sousTitre && <div className="app-meta">{sousTitre}</div>}
-                            {(app.pdf_lettre_url || app.pdf_cv_url || app.pdf_fiche_url || app.pdf_cv_stored || app.pdf_fiche_stored || app.pdf_lettre_stored) && (
-                              <div className="app-docs-badge" title="Documents PDF joints">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M16 13H8"/><path d="M16 17H8"/></svg>
-                                <span>PDF</span>
-                              </div>
-                            )}
+                            <div className="app-card-footer">
+                              {hasDocs ? (
+                                <div className="app-docs-badge" title="Documents PDF joints">
+                                  <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M16 13H8"/><path d="M16 17H8"/></svg>
+                                  <span>PDF</span>
+                                </div>
+                              ) : (
+                                <span className="app-card-footer-spacer" aria-hidden />
+                              )}
+                              <time
+                                className="app-date"
+                                dateTime={(app.date || '').trim().slice(0, 10) || undefined}
+                                title={dateAbs || undefined}
+                              >
+                                {dateRel}
+                              </time>
+                            </div>
+                            <span className="app-card-statut-sr">{STATUT_LABELS[statutKey]}</span>
                           </div>
                         );
                       })}
@@ -3846,22 +3897,26 @@ export default function App() {
                 <div className="applications-list kanban-archived-list">
                   {filteredArchived.map((app) => {
                     const titre = app.poste || app.poste_offre || 'Sans intitulé';
+                    const entreprise = (app.entreprise || '').trim();
                     const statutVal = app.statut in STATUT_LABELS ? app.statut : 'candidature_envoyee';
+                    const dateAbs = formatApplicationDateLabel(app.date);
+                    const dateRel = formatApplicationRelativeLabel(app.date);
                     return (
                       <div key={app.id} className="application-card archived">
                         <div className="app-card-top">
-                          <CompanyLogo companyName={app.entreprise} className="app-company-logo" size={36} />
-                          <div className="app-poste-date">
+                          <CompanyLogo companyName={entreprise || app.entreprise} className="app-company-logo" size={32} />
+                          <div className="app-card-text">
                             <div className="app-title">{titre}</div>
-                            <div className="app-date">{formatApplicationDateLabel(app.date)}</div>
+                            {entreprise ? <div className="app-meta">{entreprise}</div> : null}
                           </div>
+                          <time className="app-date" title={dateAbs || undefined}>{dateRel}</time>
                         </div>
                         <div className="app-actions">
-                          <button type="button" className="btn btn-view" onClick={() => openApplicationDetail(app.id)}>Voir</button>
+                          <Button type="button" variant="secondary" size="sm" onClick={() => openApplicationDetail(app.id)}>Voir</Button>
                           <select className="app-statut" value={statutVal} onChange={(e) => handleStatutChange(app.id, e.target.value)}>
                             {Object.entries(STATUT_LABELS).map(([k, v]) => <option key={k} value={k}>{v}</option>)}
                           </select>
-                          <button type="button" className="btn btn-archive" onClick={() => handleArchive(app.id, false)}>Désarchiver</button>
+                          <Button type="button" variant="tertiary" size="sm" onClick={() => handleArchive(app.id, false)}>Désarchiver</Button>
                         </div>
                       </div>
                     );

--- a/frontend/src/components/CompanyLogo.jsx
+++ b/frontend/src/components/CompanyLogo.jsx
@@ -14,11 +14,23 @@ function getCompanyLogoUrl(companyName) {
 export default function CompanyLogo({ companyName, className, size = 40 }) {
   const [failed, setFailed] = useState(false);
   const url = getCompanyLogoUrl(companyName);
-  const initial = (companyName || '?').trim().charAt(0).toUpperCase();
+  const trimmed = (companyName || '').trim();
+  const monogram = trimmed
+    ? trimmed
+        .split(/\s+/)
+        .slice(0, 2)
+        .map((w) => w.charAt(0))
+        .join('')
+        .toUpperCase()
+    : '?';
   if (failed || !url) {
     return (
-      <div className={`company-logo-fallback ${className || ''}`} style={{ width: size, height: size, fontSize: Math.round(size * 0.5) }}>
-        {initial}
+      <div
+        className={`company-logo-fallback ${className || ''}`}
+        style={{ width: size, height: size, fontSize: Math.round(size * 0.4) }}
+        aria-hidden
+      >
+        {monogram}
       </div>
     );
   }

--- a/frontend/src/lib/applicationDates.js
+++ b/frontend/src/lib/applicationDates.js
@@ -2,6 +2,29 @@
  * Affichage dates candidatures : heure stockée en UTC (YYYY-MM-DD HH:mm) → fuseau local ;
  * date seule (legacy) sans heure à minuit.
  */
+
+/**
+ * @param {string | null | undefined} dateStr
+ * @returns {Date | null}
+ */
+export function parseApplicationDate(dateStr) {
+  if (!dateStr || typeof dateStr !== 'string') return null;
+  const trimmed = dateStr.trim();
+  const m = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})(?:[T\s](\d{2}):(\d{2}))?/);
+  if (!m) return null;
+  const y = parseInt(m[1], 10);
+  const mo = parseInt(m[2], 10) - 1;
+  const d = parseInt(m[3], 10);
+  if (m[4] != null && m[5] != null) {
+    return new Date(Date.UTC(y, mo, d, parseInt(m[4], 10), parseInt(m[5], 10)));
+  }
+  return new Date(y, mo, d);
+}
+
+/**
+ * Affichage absolu (liste / tooltip) : UTC → fuseau local si heure présente.
+ * @param {string | null | undefined} dateStr
+ */
 export function formatApplicationDateLabel(dateStr) {
   if (!dateStr || typeof dateStr !== 'string') return dateStr || '';
   const trimmed = dateStr.trim();
@@ -17,4 +40,27 @@ export function formatApplicationDateLabel(dateStr) {
     return new Date(ms).toLocaleString('fr-FR', { dateStyle: 'short', timeStyle: 'short' });
   }
   return new Date(y, mo - 1, d).toLocaleDateString('fr-FR', { dateStyle: 'medium' });
+}
+
+/**
+ * Date relative pour cartes kanban (« il y a 12 j »).
+ * @param {string | null | undefined} dateStr
+ * @param {{ now?: Date }} [opts]
+ */
+export function formatApplicationRelativeLabel(dateStr, { now = new Date() } = {}) {
+  const d = parseApplicationDate(dateStr);
+  if (!d) return formatApplicationDateLabel(dateStr) || '';
+  const diffMs = now.getTime() - d.getTime();
+  if (Number.isNaN(diffMs) || diffMs < 0) return formatApplicationDateLabel(dateStr);
+  const mins = Math.floor(diffMs / 60000);
+  if (mins < 1) return "à l'instant";
+  if (mins < 60) return `il y a ${mins} min`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `il y a ${hours} h`;
+  const days = Math.floor(hours / 24);
+  if (days < 60) return `il y a ${days} j`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `il y a ${months} mois`;
+  const years = Math.floor(days / 365);
+  return `il y a ${years} an${years > 1 ? 's' : ''}`;
 }

--- a/frontend/src/lib/applicationStats.js
+++ b/frontend/src/lib/applicationStats.js
@@ -12,29 +12,14 @@
  */
 
 import { STATUT_LABELS } from '../constants.js';
+import { parseApplicationDate } from './applicationDates.js';
+
+export { parseApplicationDate } from './applicationDates.js';
 
 export const RELANCE_DAYS = 14;
 
 const WAITING_STATUTS = new Set(['a_postuler', 'candidature_envoyee']);
 const RESPONDED_STATUTS = new Set(['reponse_recue', 'interview', 'offre', 'refus']);
-
-/**
- * @param {string | null | undefined} dateStr
- * @returns {Date | null}
- */
-export function parseApplicationDate(dateStr) {
-  if (!dateStr || typeof dateStr !== 'string') return null;
-  const trimmed = dateStr.trim();
-  const m = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})(?:[T\s](\d{2}):(\d{2}))?/);
-  if (!m) return null;
-  const y = parseInt(m[1], 10);
-  const mo = parseInt(m[2], 10) - 1;
-  const d = parseInt(m[3], 10);
-  if (m[4] != null && m[5] != null) {
-    return new Date(Date.UTC(y, mo, d, parseInt(m[4], 10), parseInt(m[5], 10)));
-  }
-  return new Date(y, mo, d);
-}
 
 function resolveStatut(app) {
   const s = app?.statut;
@@ -52,6 +37,21 @@ export function isApplicationToFollowUp(app, { now = new Date(), relanceDays = R
   if (!ref) return false;
   const ms = now.getTime() - ref.getTime();
   return ms >= relanceDays * 24 * 60 * 60 * 1000;
+}
+
+/**
+ * Accent bordure gauche carte : offre | refus | relancer | null.
+ * @param {object} app
+ * @param {{ now?: Date }} [opts]
+ * @returns {'offre' | 'refus' | 'relancer' | null}
+ */
+export function getApplicationCardAccent(app, { now = new Date() } = {}) {
+  if (!app || app.archived) return null;
+  const statut = resolveStatut(app);
+  if (statut === 'offre') return 'offre';
+  if (statut === 'refus') return 'refus';
+  if (isApplicationToFollowUp(app, { now })) return 'relancer';
+  return null;
 }
 
 /**

--- a/frontend/src/styles/app/candidatures.css
+++ b/frontend/src/styles/app/candidatures.css
@@ -301,18 +301,34 @@
   border-radius: 0;
 }
 
-/* Cartes : product-card - canvas blanc sur fond stone */
+/* Cartes kanban — hiérarchie AXE-379 */
 .view-candidatures .kanban-board .application-card {
-  background: var(--color-canvas);
-  border: 1px solid var(--color-card-border);
-  border-radius: var(--radius-sm);
-  padding: 0.7rem 0.75rem;
+  background: var(--ds-color-bg-default);
+  border: 1px solid var(--ds-color-border-default);
+  border-radius: var(--ds-radius-sm, 0.375rem);
+  box-shadow: inset 3px 0 0 transparent;
+  padding: 0.65rem 0.7rem 0.55rem;
   font-size: 0.8125rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
 }
 
 .view-candidatures .kanban-board .application-card:hover {
-  border-color: var(--color-hairline);
-  background: var(--color-canvas);
+  border-color: var(--ds-color-border-default);
+  background: var(--ds-color-bg-default);
+}
+
+.view-candidatures .kanban-board .application-card--accent-offre {
+  box-shadow: inset 3px 0 0 var(--ds-color-feedback-success);
+}
+
+.view-candidatures .kanban-board .application-card--accent-refus {
+  box-shadow: inset 3px 0 0 var(--ds-color-text-danger);
+}
+
+.view-candidatures .kanban-board .application-card--accent-relancer {
+  box-shadow: inset 3px 0 0 var(--ds-color-feedback-warning);
 }
 
 .view-candidatures .kanban-board .app-status-dot {
@@ -320,36 +336,118 @@
 }
 
 .view-candidatures .kanban-board .app-card-top {
-  padding-right: 3rem;
-  margin-bottom: 0.15rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding-right: 3.25rem;
+  margin-bottom: 0;
+}
+
+.view-candidatures .kanban-board .app-card-text {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
 }
 
 .view-candidatures .kanban-board .application-card .app-title {
   font-weight: 500;
   font-size: 0.8125rem;
-  color: var(--color-ink);
+  color: var(--ds-color-text-default);
   line-height: 1.35;
-}
-
-.view-candidatures .kanban-board .application-card .app-date {
-  color: var(--color-muted);
-  font-weight: 400;
-  font-size: 0.6875rem;
+  word-break: break-word;
 }
 
 .view-candidatures .kanban-board .application-card .app-meta {
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: var(--ds-color-text-muted);
+  line-height: 1.3;
+}
+
+.view-candidatures .kanban-board .app-follow-up-dot {
+  flex-shrink: 0;
+  width: 8px;
+  height: 8px;
+  margin-top: 0.35rem;
+  border-radius: 50%;
+  background: var(--ds-color-feedback-warning);
+}
+
+.view-candidatures .kanban-board .app-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  min-height: 1rem;
+}
+
+.view-candidatures .kanban-board .app-card-footer-spacer {
+  flex: 1;
+}
+
+.view-candidatures .kanban-board .application-card .app-date {
+  margin-left: auto;
   font-size: 0.6875rem;
-  color: var(--color-body-muted);
+  font-weight: 400;
+  color: var(--ds-color-text-muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.view-candidatures .kanban-board .application-card .app-docs-badge {
+  margin-top: 0;
+  color: var(--ds-color-text-muted);
 }
 
 .view-candidatures .kanban-board .app-company-logo,
 .view-candidatures .kanban-board .company-logo-fallback {
-  border-radius: var(--radius-xs);
+  width: 32px;
+  height: 32px;
+  border-radius: var(--ds-radius-sm, 0.375rem);
+  border: 1px solid var(--ds-color-border-default);
+  background: var(--ds-color-bg-default);
+  object-fit: contain;
 }
 
 .view-candidatures .kanban-board .company-logo-fallback {
-  background: var(--color-primary);
+  color: var(--ds-color-text-default);
   font-weight: 500;
+  font-size: 0.8125rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.view-candidatures .kanban-board .app-card-actions-icons {
+  top: 0.35rem;
+  right: 0.35rem;
+  gap: 0.15rem;
+}
+
+.view-candidatures .kanban-board .app-card-action.ds-button {
+  width: 1.75rem;
+  height: 1.75rem;
+  min-height: 1.75rem;
+  padding: 0;
+  color: var(--ds-color-text-muted);
+}
+
+.view-candidatures .kanban-board .app-card-action--archive.ds-button:hover {
+  color: var(--ds-color-text-danger);
+}
+
+.app-card-statut-sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 /* Archivées : liste sous le board, style research-table */

--- a/frontend/tests/unit/applicationDates.test.js
+++ b/frontend/tests/unit/applicationDates.test.js
@@ -1,0 +1,35 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseApplicationDate,
+  formatApplicationDateLabel,
+  formatApplicationRelativeLabel,
+} from '../../src/lib/applicationDates.js';
+
+test('parseApplicationDate accepte jour seul et datetime UTC', () => {
+  const day = parseApplicationDate('2026-01-10');
+  assert.ok(day instanceof Date);
+  assert.equal(day.getFullYear(), 2026);
+  assert.equal(day.getMonth(), 0);
+  assert.equal(day.getDate(), 10);
+
+  const withTime = parseApplicationDate('2026-01-10 14:30');
+  assert.ok(withTime instanceof Date);
+  assert.equal(withTime.toISOString().slice(0, 16), '2026-01-10T14:30');
+});
+
+test('formatApplicationRelativeLabel : jours / heures', () => {
+  const now = new Date('2026-08-21T12:00:00Z');
+  assert.equal(formatApplicationRelativeLabel('2026-08-09 12:00', { now }), 'il y a 12 j');
+  assert.equal(
+    formatApplicationRelativeLabel('2026-08-21 10:00', { now }),
+    'il y a 2 h',
+  );
+  assert.equal(formatApplicationRelativeLabel('', { now }), '');
+});
+
+test('formatApplicationDateLabel reste utilisable en tooltip', () => {
+  const label = formatApplicationDateLabel('2026-08-09');
+  assert.ok(typeof label === 'string' && label.length > 0);
+});

--- a/frontend/tests/unit/applicationStats.test.js
+++ b/frontend/tests/unit/applicationStats.test.js
@@ -6,24 +6,25 @@ import {
   parseApplicationDate,
   isApplicationToFollowUp,
   computeApplicationMetrics,
+  getApplicationCardAccent,
 } from '../../src/lib/applicationStats.js';
 
-test('parseApplicationDate accepte jour seul et datetime UTC', () => {
-  const day = parseApplicationDate('2026-01-10');
-  assert.ok(day instanceof Date);
-  assert.equal(day.getFullYear(), 2026);
-  assert.equal(day.getMonth(), 0);
-  assert.equal(day.getDate(), 10);
-
-  const withTime = parseApplicationDate('2026-01-10 14:30');
-  assert.ok(withTime instanceof Date);
-  assert.equal(withTime.toISOString().slice(0, 16), '2026-01-10T14:30');
+test('parseApplicationDate est réexporté depuis applicationStats', () => {
+  assert.ok(parseApplicationDate('2026-01-10') instanceof Date);
 });
 
-test('parseApplicationDate refuse les valeurs invalides', () => {
-  assert.equal(parseApplicationDate(''), null);
-  assert.equal(parseApplicationDate(null), null);
-  assert.equal(parseApplicationDate('hier'), null);
+test('getApplicationCardAccent : offre / refus / relancer', () => {
+  const now = new Date('2026-08-21T12:00:00Z');
+  assert.equal(getApplicationCardAccent({ statut: 'offre', date: '2026-08-20' }, { now }), 'offre');
+  assert.equal(getApplicationCardAccent({ statut: 'refus', date: '2026-08-20' }, { now }), 'refus');
+  assert.equal(
+    getApplicationCardAccent({ statut: 'candidature_envoyee', date: '2026-08-01' }, { now }),
+    'relancer',
+  );
+  assert.equal(
+    getApplicationCardAccent({ statut: 'candidature_envoyee', date: '2026-08-20' }, { now }),
+    null,
+  );
 });
 
 test('isApplicationToFollowUp : 14j+ en attente', () => {


### PR DESCRIPTION
## Summary
- Hiérarchie carte : poste (500) → entreprise muted → date relative bas-droite (« il y a 12 j »)
- Point orange si 14j+ sans nouvelle ; accent inset gauche offre / refus / à relancer
- Logo 32px carré + monogramme (pas emoji) ; actions Voir/Archiver en `<Button iconOnly>`

## Test plan
- [ ] Cartes : entreprise sous le poste, date relative en bas à droite (tooltip = date absolue)
- [ ] Colonne Offre / Refusé : barre colorée à gauche
- [ ] Candidature envoyée vieille de 14j+ : point + accent « relancer »
- [ ] Fallback logo = initiales, fond blanc, bordure 1px
- [ ] `npm run test:unit` : applicationDates + applicationStats

Fixes AXE-379
Closes #149


Made with [Cursor](https://cursor.com)