### PR TITLE
feat(candidatures): UX board empty, CTA menu, scroll, drag

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3865,16 +3865,18 @@ export default function App() {
                             <div className="app-card-top">
                               <CompanyLogo companyName={entreprise || app.entreprise} className="app-company-logo" size={32} />
                               <div className="app-card-text">
-                                <div className="app-title">{titre}</div>
+                                <div className="app-title-row">
+                                  <div className="app-title">{titre}</div>
+                                  {needsFollowUp && (
+                                    <span
+                                      className="app-follow-up-dot"
+                                      title="Sans nouvelle depuis 14 jours ou plus"
+                                      aria-label="À relancer"
+                                    />
+                                  )}
+                                </div>
                                 {entreprise ? <div className="app-meta">{entreprise}</div> : null}
                               </div>
-                              {needsFollowUp && (
-                                <span
-                                  className="app-follow-up-dot"
-                                  title="Sans nouvelle depuis 14 jours ou plus"
-                                  aria-label="À relancer"
-                                />
-                              )}
                             </div>
                             <div className="app-card-footer">
                               {hasDocs ? (

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -28,7 +28,7 @@ import Button from './components/ui/Button.jsx';
 import { CONTACT_EMAIL, STORAGE_EXPORT_DIR, STORAGE_EXPORT_ATS_BLOCK_SNOOZE, STORAGE_PRE_EXPORT_TEMPLATE_OPTIONS_DONE, STORAGE_PDF_EXPORT_FILENAME_PATTERN, STATUT_LABELS, KANBAN_COLUMNS, getExportFolderName } from './constants';
 import { buildAdaptedPdfFilename } from './lib/pdfExportFilename';
 import { getPdfSaveStartInDirectoryHandle } from './lib/pdfExportStartDirIdb';
-import { HiDocumentText, HiArrowDownTray, HiClipboardDocumentList, HiPencilSquare, HiChatBubbleLeftRight, HiCheck, HiSwatch, HiChevronDown, HiChevronUp } from 'react-icons/hi2';
+import { HiDocumentText, HiArrowDownTray, HiClipboardDocumentList, HiPencilSquare, HiChatBubbleLeftRight, HiCheck, HiSwatch, HiChevronDown, HiChevronUp, HiPlus } from 'react-icons/hi2';
 import { lazyWithChunkReload, clearChunkErrorReloadKey } from './lib/lazyChunkReload';
 import { APP_DEFAULT_ROUTE, getViewFromPathname, isKnownAppPathname } from './lib/appRoutes';
 import { syncRobotsMeta } from './lib/seoHead';
@@ -820,6 +820,8 @@ export default function App() {
   const [setupPoste, setSetupPoste] = useState('');
   const [setupFiche, setSetupFiche] = useState('');
   const [addManualModalOpen, setAddManualModalOpen] = useState(false);
+  const [candidaturesAddMenuOpen, setCandidaturesAddMenuOpen] = useState(false);
+  const candidaturesAddMenuRef = useRef(null);
   const [addManualPoste, setAddManualPoste] = useState('');
   const [addManualEntreprise, setAddManualEntreprise] = useState('');
   const [addManualStatut, setAddManualStatut] = useState('candidature_envoyee');
@@ -2882,6 +2884,24 @@ export default function App() {
     return () => clearTimeout(t);
   }, [applicationSearchQuery]);
 
+  useEffect(() => {
+    if (!candidaturesAddMenuOpen) return undefined;
+    const onPointerDown = (e) => {
+      if (candidaturesAddMenuRef.current && !candidaturesAddMenuRef.current.contains(e.target)) {
+        setCandidaturesAddMenuOpen(false);
+      }
+    };
+    const onKeyDown = (e) => {
+      if (e.key === 'Escape') setCandidaturesAddMenuOpen(false);
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [candidaturesAddMenuOpen]);
+
   const filteredApplications = useMemo(() => {
     const q = applicationSearchDebounced.toLowerCase();
     let list = applications;
@@ -3599,32 +3619,61 @@ export default function App() {
                 Suis toutes tes candidatures ici. Glisse les cartes pour changer le statut.
               </p>
               <div className="dashboard-header-actions page-title-row-actions">
-                <Button
-                  type="button"
-                  variant="tertiary"
-                  size="sm"
-                  className="btn-add-manual"
-                  onClick={() => setAddManualModalOpen(true)}
-                  data-attr="candidatures-header-cta-manual"
-                  data-track="cta"
-                  data-zone="header"
-                  data-level="secondary"
-                >
-                  Ajouter une candidature (hors app)
-                </Button>
-                <Button
-                  type="button"
-                  variant="primary"
-                  size="sm"
-                  className="btn-new-candidature"
-                  onClick={() => setSetupModalOpen(true)}
-                  data-attr="candidatures-header-cta-new"
-                  data-track="cta"
-                  data-zone="header"
-                  data-level="primary"
-                >
-                  Nouvelle Candidature
-                </Button>
+                <div className="candidatures-add-menu" ref={candidaturesAddMenuRef}>
+                  <Button
+                    type="button"
+                    variant="primary"
+                    size="sm"
+                    className="btn-new-candidature candidatures-add-menu-trigger"
+                    aria-expanded={candidaturesAddMenuOpen}
+                    aria-haspopup="menu"
+                    aria-controls="candidatures-add-menu"
+                    onClick={() => setCandidaturesAddMenuOpen((open) => !open)}
+                  >
+                    <HiPlus aria-hidden />
+                    Ajouter
+                    <HiChevronDown aria-hidden className={`candidatures-add-menu-chevron${candidaturesAddMenuOpen ? ' is-open' : ''}`} />
+                  </Button>
+                  {candidaturesAddMenuOpen && (
+                    <div
+                      id="candidatures-add-menu"
+                      className="candidatures-add-menu-panel"
+                      role="menu"
+                      aria-label="Ajouter une candidature"
+                    >
+                      <button
+                        type="button"
+                        role="menuitem"
+                        className="candidatures-add-menu-item"
+                        data-attr="candidatures-header-cta-new"
+                        data-track="cta"
+                        data-zone="header"
+                        data-level="primary"
+                        onClick={() => {
+                          setCandidaturesAddMenuOpen(false);
+                          setSetupModalOpen(true);
+                        }}
+                      >
+                        Nouvelle candidature
+                      </button>
+                      <button
+                        type="button"
+                        role="menuitem"
+                        className="candidatures-add-menu-item"
+                        data-attr="candidatures-header-cta-manual"
+                        data-track="cta"
+                        data-zone="header"
+                        data-level="secondary"
+                        onClick={() => {
+                          setCandidaturesAddMenuOpen(false);
+                          setAddManualModalOpen(true);
+                        }}
+                      >
+                        Hors app
+                      </button>
+                    </div>
+                  )}
+                </div>
               </div>
             </div>
           </header>
@@ -3848,6 +3897,11 @@ export default function App() {
                           </div>
                         );
                       })}
+                      {columnApps.length === 0 && (
+                        <div className="kanban-column-empty" aria-hidden="true">
+                          Glisse une carte ici
+                        </div>
+                      )}
                     </div>
                   </div>
                 );
@@ -4018,10 +4072,10 @@ export default function App() {
                   </label>
                 </div>
                 <div className="setup-modal-actions">
-                  <button type="submit" className="button button-primary" disabled={addManualSubmitting}>
+                  <Button type="submit" variant="primary" disabled={addManualSubmitting} loading={addManualSubmitting}>
                     {addManualSubmitting ? 'Ajout…' : 'Ajouter'}
-                  </button>
-                  <button type="button" className="button button-secondary" onClick={() => setAddManualModalOpen(false)}>Annuler</button>
+                  </Button>
+                  <Button type="button" variant="secondary" onClick={() => setAddManualModalOpen(false)}>Annuler</Button>
                 </div>
               </form>
             </div>

--- a/frontend/src/styles/app/candidatures.css
+++ b/frontend/src/styles/app/candidatures.css
@@ -287,7 +287,8 @@
 .view-candidatures .kanban-column-cards {
   flex: 1;
   overflow-y: auto;
-  padding: 0 0.5rem 0.25rem;
+  /* Marge haute : la carte du haut peut se soulever au hover sans clipper la bordure sous le header */
+  padding: 0.2rem 0.5rem 0.35rem;
   gap: 0.4rem;
   background: transparent;
 }
@@ -373,11 +374,14 @@
 
 /* Drag affordance */
 .view-candidatures .kanban-board .kanban-card {
+  position: relative;
+  z-index: 0;
   cursor: grab;
   transition: transform 0.12s ease, border-color 0.12s ease;
 }
 
 .view-candidatures .kanban-board .kanban-card:hover:not(.dragging) {
+  z-index: 2;
   transform: translateY(-1px);
   border-color: var(--ds-color-text-muted);
 }
@@ -388,6 +392,7 @@
 }
 
 .view-candidatures .kanban-board .kanban-card.dragging {
+  z-index: 3;
   opacity: 0.88;
   transform: scale(1.02);
   border-color: var(--ds-color-border-focus, var(--ds-color-text-link));

--- a/frontend/src/styles/app/candidatures.css
+++ b/frontend/src/styles/app/candidatures.css
@@ -4,14 +4,16 @@
  * Voir docs/DESIGN-cohere.md - product-card, research-table, button-primary.
  */
 
-/* ── Page : canvas blanc continu (pas de fond stone sur toute la page) ── */
+/* ── Page : canvas blanc, scroll unique sur le board (pas page + colonnes) ── */
+.view-candidatures.app-page,
 .view-candidatures {
   display: flex;
   flex-direction: column;
   flex: 1;
   min-height: 0;
   width: 100%;
-  background: var(--color-canvas);
+  background: var(--ds-color-bg-default);
+  overflow: hidden;
 }
 
 .view-candidatures .page-content.applications-full,
@@ -213,14 +215,14 @@
   white-space: nowrap;
 }
 
-/* ── Board : une seule surface stone (radius lg = 22px) ── */
+/* ── Board : une seule surface, densité un peu plus compacte ── */
 .candidatures-board {
   flex: 1;
   min-height: 0;
-  margin-top: 1.25rem;
-  background: var(--color-soft-stone);
-  border-radius: var(--radius-lg);
-  padding: 1rem 0.75rem;
+  margin-top: 0.85rem;
+  background: var(--ds-color-bg-subtle, var(--color-soft-stone));
+  border-radius: var(--ds-radius-lg, var(--radius-lg));
+  padding: 0.75rem 0.5rem;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -229,7 +231,7 @@
 .view-candidatures .kanban-board {
   display: flex;
   flex: 1;
-  min-height: 280px;
+  min-height: 0;
   gap: 0;
   overflow-x: auto;
   overflow-y: hidden;
@@ -286,19 +288,109 @@
   flex: 1;
   overflow-y: auto;
   padding: 0 0.5rem 0.25rem;
-  gap: 0.5rem;
+  gap: 0.4rem;
   background: transparent;
 }
 
-.view-candidatures .kanban-column-cards:empty::after {
-  content: '-';
-  display: block;
+.view-candidatures .kanban-column-empty {
+  flex: 1;
+  min-height: 4.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0.15rem 0;
+  padding: 0.75rem 0.5rem;
+  border: 1px dashed var(--ds-color-border-default);
+  border-radius: var(--ds-radius-sm, 0.375rem);
+  font-size: var(--ds-font-size-label-sm, 0.75rem);
+  font-weight: 400;
+  color: var(--ds-color-text-muted);
   text-align: center;
-  padding: 1.25rem 0;
-  font-size: 0.75rem;
-  color: var(--color-muted);
+  line-height: 1.35;
+  pointer-events: none;
+}
+
+.view-candidatures .kanban-column.drag-over .kanban-column-empty {
+  border-color: var(--ds-color-border-focus, var(--ds-color-text-link));
+  color: var(--ds-color-text-default);
+  background: var(--ds-color-bg-subtle, transparent);
+}
+
+/* Menu CTA unique header */
+.candidatures-add-menu {
+  position: relative;
+}
+
+.candidatures-add-menu-trigger.ds-button {
+  gap: 0.35rem;
+}
+
+.candidatures-add-menu-chevron {
+  width: 1rem;
+  height: 1rem;
+  transition: transform 0.15s ease;
+}
+
+.candidatures-add-menu-chevron.is-open {
+  transform: rotate(180deg);
+}
+
+.candidatures-add-menu-panel {
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  right: 0;
+  z-index: var(--ds-z-dropdown, 100);
+  min-width: 12.5rem;
+  padding: 0.35rem;
+  background: var(--ds-color-bg-default);
+  border: 1px solid var(--ds-color-border-default);
+  border-radius: var(--ds-radius-sm, 0.375rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.candidatures-add-menu-item {
+  display: block;
+  width: 100%;
+  margin: 0;
+  padding: 0.55rem 0.7rem;
   border: none;
-  border-radius: 0;
+  border-radius: var(--ds-radius-sm, 0.25rem);
+  background: transparent;
+  color: var(--ds-color-text-default);
+  font: inherit;
+  font-size: 0.875rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.candidatures-add-menu-item:hover,
+.candidatures-add-menu-item:focus-visible {
+  background: var(--ds-color-bg-subtle, #f5f5f5);
+  outline: none;
+}
+
+/* Drag affordance */
+.view-candidatures .kanban-board .kanban-card {
+  cursor: grab;
+  transition: transform 0.12s ease, border-color 0.12s ease;
+}
+
+.view-candidatures .kanban-board .kanban-card:hover:not(.dragging) {
+  transform: translateY(-1px);
+  border-color: var(--ds-color-text-muted);
+}
+
+.view-candidatures .kanban-board .kanban-card:active,
+.view-candidatures .kanban-board .kanban-card.dragging {
+  cursor: grabbing;
+}
+
+.view-candidatures .kanban-board .kanban-card.dragging {
+  opacity: 0.88;
+  transform: scale(1.02);
+  border-color: var(--ds-color-border-focus, var(--ds-color-text-link));
 }
 
 /* Cartes kanban — hiérarchie AXE-379 */
@@ -505,7 +597,7 @@
 }
 
 /* Header actions */
-.view-candidatures .dashboard-header-actions .btn-add-manual {
+.view-candidatures .dashboard-header-actions .btn-new-candidature {
   font-size: 0.875rem;
 }
 
@@ -574,7 +666,7 @@
     width: 100%;
     min-width: 0;
     border-right: none;
-    border-bottom: 1px solid var(--color-hairline);
+    border-bottom: 1px solid var(--ds-color-border-default);
     max-height: none;
   }
 
@@ -582,7 +674,13 @@
     border-bottom: none;
   }
 
+  /* Un seul scroll vertical (board) : pas de scroll interne par colonne */
   .view-candidatures .kanban-column-cards {
-    max-height: 240px;
+    max-height: none;
+    overflow-y: visible;
+  }
+
+  .view-candidatures .kanban-column-empty {
+    min-height: 3.25rem;
   }
 }

--- a/frontend/src/styles/app/candidatures.css
+++ b/frontend/src/styles/app/candidatures.css
@@ -367,7 +367,7 @@
 
 .candidatures-add-menu-item:hover,
 .candidatures-add-menu-item:focus-visible {
-  background: var(--ds-color-bg-subtle, #f5f5f5);
+  background: var(--ds-color-bg-subtle);
   outline: none;
 }
 

--- a/frontend/src/styles/app/candidatures.css
+++ b/frontend/src/styles/app/candidatures.css
@@ -448,12 +448,21 @@
   gap: 0.15rem;
 }
 
+.view-candidatures .kanban-board .app-title-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
 .view-candidatures .kanban-board .application-card .app-title {
   font-weight: 500;
   font-size: 0.8125rem;
   color: var(--ds-color-text-default);
   line-height: 1.35;
   word-break: break-word;
+  min-width: 0;
+  flex: 1;
 }
 
 .view-candidatures .kanban-board .application-card .app-meta {


### PR DESCRIPTION
## Summary
- Colonnes vides : zone pointillée « Glisse une carte ici »
- Un seul CTA header **Ajouter** (menu : Nouvelle candidature / Hors app) — `data-attr` C.9 inchangés
- Anti double-scroll (page figée ; scroll colonnes desktop / board mobile) + densité un peu plus compacte
- Drag : `grab` / légère élévation au survol

## Test plan
- [ ] Header : un seul primary « Ajouter » ; menu ouvre les 2 actions
- [ ] Colonne vide : dropzone pointillée (plus de « - »)
- [ ] Desktop : pas de scroll page + colonnes en même temps
- [ ] Survol / drag carte : curseur grab + léger lift

Fixes AXE-380
Closes #151


Made with [Cursor](https://cursor.com)