### PR TITLE
Feat: Mes candidatures — liste groupée mobile (AXE-381)

### DIFF
--- a/docs/taggage-analytics.md
+++ b/docs/taggage-analytics.md
@@ -573,6 +573,7 @@ Un ID posé en prod ne se renomme jamais. Tracker app = `/api/events/track` + fu
 | `candidatures-banner-cta-adapt` | cta | secondary | Banner zéro adaptation | Aller à Adapter un CV (`/app/cv`) |
 | `candidatures-search-empty-cta-clear` | cta | secondary | Empty recherche | Effacer la recherche |
 | `candidatures-controls-input-search` | input | tertiary | Barre de filtres | Champ recherche. **Ne jamais** envoyer la valeur dans un event. |
+| `candidatures-list-input-statut` | input | tertiary | Liste mobile (≤768px) | Select changement de statut. **Ne jamais** envoyer la valeur dans un event. |
 
 `data-section` (hors compte) :
 
@@ -580,6 +581,7 @@ Un ID posé en prod ne se renomme jamais. Tracker app = `/api/events/track` + fu
 |---|---|
 | `candidatures` | Board kanban `/app/postule` |
 | `candidatures-stats` | Bandeau métriques |
+| `candidatures-list-mobile` | Liste groupée mobile (AXE-381) |
 
 V2 candidatures (ne pas poser maintenant) : ouverture carte, archive, drag colonne, métriques cliquables.
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -23,6 +23,7 @@ import { fetchAuthSessionWithTimeout } from './lib/supabaseAuthSession';
 import AuthForm from './components/AuthForm';
 import AppTopbar from './components/AppTopbar';
 import CompanyLogo from './components/CompanyLogo';
+import CandidatureBoardCard from './components/CandidatureBoardCard';
 import { NotFoundPage } from './components/ErrorPages';
 import Button from './components/ui/Button.jsx';
 import { CONTACT_EMAIL, STORAGE_EXPORT_DIR, STORAGE_EXPORT_ATS_BLOCK_SNOOZE, STORAGE_PRE_EXPORT_TEMPLATE_OPTIONS_DONE, STORAGE_PDF_EXPORT_FILENAME_PATTERN, STATUT_LABELS, KANBAN_COLUMNS, getExportFolderName } from './constants';
@@ -36,7 +37,7 @@ import './App.css';
 import './styles/TemplatePicker.css';
 import './styles/GuidedTour.css';
 import { formatApplicationDateLabel, formatApplicationRelativeLabel } from './lib/applicationDates';
-import { computeApplicationMetrics, getApplicationCardAccent, isApplicationToFollowUp } from './lib/applicationStats.js';
+import { computeApplicationMetrics, isApplicationToFollowUp } from './lib/applicationStats.js';
 import { applyA4PageFramesToDocument, syncCvPreviewIframeHeight } from './lib/cvPreviewA4Pages';
 import {
   betaCanvasRenderFields,
@@ -3780,136 +3781,98 @@ export default function App() {
                 </div>
               </div>
               <div className="candidatures-board">
-                <div className="kanban-board">
-              {KANBAN_COLUMNS.map((col) => {
-                const columnApps = filteredApplications.filter((app) => {
-                  if (app.archived) return false;
-                  const s = app.statut in STATUT_LABELS ? app.statut : 'candidature_envoyee';
-                  return s === col.id;
-                });
-                return (
-                  <div
-                    key={col.id}
-                    className={`kanban-column kanban-column--${col.id} ${kanbanDragOverColumn === col.id ? 'drag-over' : ''}`}
-                    onDragOver={(e) => { e.preventDefault(); e.dataTransfer.dropEffect = 'move'; setKanbanDragOverColumn(col.id); }}
-                    onDragLeave={() => setKanbanDragOverColumn(null)}
-                    onDrop={(e) => {
-                      e.preventDefault();
-                      setKanbanDragOverColumn(null);
-                      const appId = e.dataTransfer.getData('application/id');
-                      const app = applications.find((a) => a.id === appId);
-                      if (app) handleKanbanDrop(col.id, app);
-                    }}
-                  >
-                    <div className="kanban-column-header">
-                      <span className="kanban-column-title">{col.label}</span>
-                      <span className="kanban-column-count">{columnApps.length}</span>
-                    </div>
-                    <div className="kanban-column-cards">
-                      {columnApps.map((app) => {
-                        const titre = app.poste || app.poste_offre || 'Sans intitulé';
-                        const entreprise = (app.entreprise || '').trim();
-                        const isDragging = kanbanDraggedId === app.id;
-                        const statutKey = app.statut in STATUT_LABELS ? app.statut : 'candidature_envoyee';
-                        const needsFollowUp = isApplicationToFollowUp(app);
-                        const accent = getApplicationCardAccent(app);
-                        const hasDocs = Boolean(
-                          app.pdf_lettre_url || app.pdf_cv_url || app.pdf_fiche_url
-                          || app.pdf_cv_stored || app.pdf_fiche_stored || app.pdf_lettre_stored,
-                        );
-                        const dateAbs = formatApplicationDateLabel(app.date);
-                        const dateRel = formatApplicationRelativeLabel(app.date);
-                        return (
-                          <div
-                            key={app.id}
-                            className={[
-                              'application-card',
-                              'kanban-card',
-                              app.archived ? 'archived' : '',
-                              isDragging ? 'dragging' : '',
-                              justAddedAppId === app.id ? 'just-added' : '',
-                              accent ? `application-card--accent-${accent}` : '',
-                            ].filter(Boolean).join(' ')}
-                            draggable={!app.archived}
-                            onDragStart={(e) => {
-                              setKanbanDraggedId(app.id);
-                              e.dataTransfer.setData('application/id', app.id);
-                              e.dataTransfer.effectAllowed = 'move';
-                            }}
-                            onDragEnd={() => setKanbanDraggedId(null)}
-                          >
-                            <div className="app-card-actions-icons">
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="sm"
-                                iconOnly
-                                className="app-card-action"
-                                onClick={() => openApplicationDetail(app.id)}
-                                title="Voir"
-                                aria-label="Voir"
-                              >
-                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
-                              </Button>
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="sm"
-                                iconOnly
-                                className="app-card-action app-card-action--archive"
-                                onClick={() => handleArchive(app.id, true)}
-                                title="Archiver"
-                                aria-label="Archiver"
-                              >
-                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
-                              </Button>
-                            </div>
-                            <div className="app-card-top">
-                              <CompanyLogo companyName={entreprise || app.entreprise} className="app-company-logo" size={32} />
-                              <div className="app-card-text">
-                                <div className="app-title-row">
-                                  <div className="app-title">{titre}</div>
-                                  {needsFollowUp && (
-                                    <span
-                                      className="app-follow-up-dot"
-                                      title="Sans nouvelle depuis 14 jours ou plus"
-                                      aria-label="À relancer"
-                                    />
-                                  )}
-                                </div>
-                                {entreprise ? <div className="app-meta">{entreprise}</div> : null}
-                              </div>
-                            </div>
-                            <div className="app-card-footer">
-                              {hasDocs ? (
-                                <div className="app-docs-badge" title="Documents PDF joints">
-                                  <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M16 13H8"/><path d="M16 17H8"/></svg>
-                                  <span>PDF</span>
-                                </div>
-                              ) : (
-                                <span className="app-card-footer-spacer" aria-hidden />
-                              )}
-                              <time
-                                className="app-date"
-                                dateTime={(app.date || '').trim().slice(0, 10) || undefined}
-                                title={dateAbs || undefined}
-                              >
-                                {dateRel}
-                              </time>
-                            </div>
-                            <span className="app-card-statut-sr">{STATUT_LABELS[statutKey]}</span>
-                          </div>
-                        );
-                      })}
-                      {columnApps.length === 0 && (
-                        <div className="kanban-column-empty" aria-hidden="true">
-                          Glisse une carte ici
+                <div className="kanban-board" data-section="candidatures-board-desktop" aria-label="Tableau kanban des candidatures">
+                  {KANBAN_COLUMNS.map((col) => {
+                    const columnApps = filteredApplications.filter((app) => {
+                      if (app.archived) return false;
+                      const s = app.statut in STATUT_LABELS ? app.statut : 'candidature_envoyee';
+                      return s === col.id;
+                    });
+                    return (
+                      <div
+                        key={col.id}
+                        className={`kanban-column kanban-column--${col.id} ${kanbanDragOverColumn === col.id ? 'drag-over' : ''}`}
+                        onDragOver={(e) => { e.preventDefault(); e.dataTransfer.dropEffect = 'move'; setKanbanDragOverColumn(col.id); }}
+                        onDragLeave={() => setKanbanDragOverColumn(null)}
+                        onDrop={(e) => {
+                          e.preventDefault();
+                          setKanbanDragOverColumn(null);
+                          const appId = e.dataTransfer.getData('application/id');
+                          const app = applications.find((a) => a.id === appId);
+                          if (app) handleKanbanDrop(col.id, app);
+                        }}
+                      >
+                        <div className="kanban-column-header">
+                          <span className="kanban-column-title">{col.label}</span>
+                          <span className="kanban-column-count">{columnApps.length}</span>
                         </div>
-                      )}
-                    </div>
-                  </div>
-                );
-              })}
+                        <div className="kanban-column-cards">
+                          {columnApps.map((app) => (
+                            <CandidatureBoardCard
+                              key={app.id}
+                              app={app}
+                              variant="kanban"
+                              isDragging={kanbanDraggedId === app.id}
+                              justAdded={justAddedAppId === app.id}
+                              onView={() => openApplicationDetail(app.id)}
+                              onArchive={() => handleArchive(app.id, true)}
+                              onDragStart={(e) => {
+                                setKanbanDraggedId(app.id);
+                                e.dataTransfer.setData('application/id', app.id);
+                                e.dataTransfer.effectAllowed = 'move';
+                              }}
+                              onDragEnd={() => setKanbanDraggedId(null)}
+                            />
+                          ))}
+                          {columnApps.length === 0 && (
+                            <div className="kanban-column-empty" aria-hidden="true">
+                              Glisse une carte ici
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+                <div
+                  className="candidatures-list-mobile"
+                  data-section="candidatures-list-mobile"
+                  data-analytics-section="candidatures_list_mobile"
+                  aria-label="Liste des candidatures par statut"
+                >
+                  {KANBAN_COLUMNS.map((col) => {
+                    const sectionApps = filteredApplications.filter((app) => {
+                      if (app.archived) return false;
+                      const s = app.statut in STATUT_LABELS ? app.statut : 'candidature_envoyee';
+                      return s === col.id;
+                    });
+                    if (sectionApps.length === 0) return null;
+                    return (
+                      <section
+                        key={col.id}
+                        className={`candidatures-list-section candidatures-list-section--${col.id}`}
+                        aria-labelledby={`candidatures-list-${col.id}`}
+                      >
+                        <h3 className="candidatures-list-section-title" id={`candidatures-list-${col.id}`}>
+                          <span>{col.label}</span>
+                          <span className="candidatures-list-section-count">{sectionApps.length}</span>
+                        </h3>
+                        <div className="candidatures-list-section-cards">
+                          {sectionApps.map((app) => (
+                            <CandidatureBoardCard
+                              key={app.id}
+                              app={app}
+                              variant="list"
+                              justAdded={justAddedAppId === app.id}
+                              onView={() => openApplicationDetail(app.id)}
+                              onArchive={() => handleArchive(app.id, true)}
+                              onStatutChange={(statut) => handleKanbanDrop(statut, app)}
+                            />
+                          ))}
+                        </div>
+                      </section>
+                    );
+                  })}
                 </div>
               </div>
             {applications.filter((a) => !a.archived).length === 0 && !showArchived && (

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -31,7 +31,7 @@ import { buildAdaptedPdfFilename } from './lib/pdfExportFilename';
 import { getPdfSaveStartInDirectoryHandle } from './lib/pdfExportStartDirIdb';
 import { HiDocumentText, HiArrowDownTray, HiClipboardDocumentList, HiPencilSquare, HiChatBubbleLeftRight, HiCheck, HiSwatch, HiChevronDown, HiChevronUp, HiPlus } from 'react-icons/hi2';
 import { lazyWithChunkReload, clearChunkErrorReloadKey } from './lib/lazyChunkReload';
-import { APP_DEFAULT_ROUTE, getViewFromPathname, isKnownAppPathname } from './lib/appRoutes';
+import { APP_DEFAULT_ROUTE, APP_ROUTES, getViewFromPathname, isKnownAppPathname } from './lib/appRoutes';
 import { syncRobotsMeta } from './lib/seoHead';
 import './App.css';
 import './styles/TemplatePicker.css';
@@ -2729,8 +2729,8 @@ export default function App() {
     try {
       await apiPatch(`/api/applications/${encodeURIComponent(id)}`, { statut, ...extra });
       loadApplications();
-    } catch {
-      /* ignore */
+    } catch (e) {
+      showError(e?.message || 'Impossible de mettre à jour le statut.');
     }
   };
 
@@ -2829,7 +2829,7 @@ export default function App() {
     if (supabase) await supabase.auth.signOut();
   };
 
-  /** En production : bloque l’espace /app sur petit écran (l’app vaut mieux sur PC). Désactiver avec VITE_ALLOW_MOBILE_APP=true */
+  /** Prod : bloque /app sur petit écran (sauf Mes candidatures — liste mobile AXE-381). Opt-out : VITE_ALLOW_MOBILE_APP=true */
   const MOBILE_APP_GATE_MAX_PX = 768;
   const mobileAppGateActive =
     import.meta.env.PROD &&
@@ -2848,7 +2848,11 @@ export default function App() {
     return () => mq.removeEventListener('change', sync);
   }, []);
 
-  const showMobileAppGate = mobileAppGateActive && mobileViewportTooNarrow && pathname.startsWith('/app');
+  const showMobileAppGate =
+    mobileAppGateActive &&
+    mobileViewportTooNarrow &&
+    pathname.startsWith('/app') &&
+    !pathname.startsWith(APP_ROUTES.postule);
 
   useEffect(() => {
     if (!showMobileAppGate) return;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -732,6 +732,8 @@ export default function App() {
   const [applicationSearchDebounced, setApplicationSearchDebounced] = useState('');
   /** Filtre métrique : `relancer` | null */
   const [candidaturesMetricFilter, setCandidaturesMetricFilter] = useState(null);
+  /** Erreur locale Mes candidatures (ne touche pas `error`/`rapport` de la vue CV) */
+  const [candidaturesError, setCandidaturesError] = useState('');
   /* sidebar removed - now using topbar layout */
   const [session, setSession] = useState(null);
   const [authLoading, setAuthLoading] = useState(!!supabase);
@@ -2728,9 +2730,10 @@ export default function App() {
   const handleStatutChange = async (id, statut, extra = {}) => {
     try {
       await apiPatch(`/api/applications/${encodeURIComponent(id)}`, { statut, ...extra });
+      setCandidaturesError('');
       loadApplications();
     } catch (e) {
-      showError(e?.message || 'Impossible de mettre à jour le statut.');
+      setCandidaturesError(e?.message || 'Impossible de mettre à jour le statut.');
     }
   };
 
@@ -2767,8 +2770,9 @@ export default function App() {
       setStatutModalType(null);
       setStatutModalAppId(null);
       setStatutModalApp(null);
+      setCandidaturesError('');
     } catch (e) {
-      setError(e.message || 'Erreur enregistrement');
+      setCandidaturesError(e.message || 'Erreur enregistrement');
     } finally {
       setStatutModalSubmitting(false);
     }
@@ -2788,8 +2792,9 @@ export default function App() {
       setStatutModalType(null);
       setStatutModalAppId(null);
       setStatutModalApp(null);
+      setCandidaturesError('');
     } catch (e) {
-      setError(e.message || 'Erreur enregistrement');
+      setCandidaturesError(e.message || 'Erreur enregistrement');
     } finally {
       setStatutModalSubmitting(false);
     }
@@ -3703,6 +3708,25 @@ export default function App() {
           )}
           <div className="page-content applications-full candidatures-page" data-section="candidatures" data-analytics-section="candidatures_board">
             <div className="candidatures-page-inner">
+              {candidaturesError && (
+                <div
+                  className="candidatures-error"
+                  role="alert"
+                  aria-live="assertive"
+                >
+                  <span className="candidatures-error-msg">{candidaturesError}</span>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="candidatures-error-dismiss"
+                    onClick={() => setCandidaturesError('')}
+                    aria-label="Fermer l’erreur"
+                  >
+                    Fermer
+                  </Button>
+                </div>
+              )}
               <div className="candidatures-toolbar" data-section="candidatures-toolbar">
                 <div
                   className="candidatures-metrics candidatures-metrics--compact"

--- a/frontend/src/components/CandidatureBoardCard.jsx
+++ b/frontend/src/components/CandidatureBoardCard.jsx
@@ -1,0 +1,131 @@
+import CompanyLogo from './CompanyLogo';
+import Button from './ui/Button.jsx';
+import { KANBAN_COLUMNS, STATUT_LABELS } from '../constants';
+import { formatApplicationDateLabel, formatApplicationRelativeLabel } from '../lib/applicationDates';
+import { getApplicationCardAccent, isApplicationToFollowUp } from '../lib/applicationStats.js';
+
+/**
+ * Carte candidature — kanban (drag) ou liste mobile (select statut).
+ * @param {'kanban' | 'list'} [props.variant]
+ */
+export default function CandidatureBoardCard({
+  app,
+  variant = 'kanban',
+  isDragging = false,
+  justAdded = false,
+  onDragStart,
+  onDragEnd,
+  onView,
+  onArchive,
+  onStatutChange,
+}) {
+  const titre = app.poste || app.poste_offre || 'Sans intitulé';
+  const entreprise = (app.entreprise || '').trim();
+  const statutKey = app.statut in STATUT_LABELS ? app.statut : 'candidature_envoyee';
+  const needsFollowUp = isApplicationToFollowUp(app);
+  const accent = getApplicationCardAccent(app);
+  const hasDocs = Boolean(
+    app.pdf_lettre_url || app.pdf_cv_url || app.pdf_fiche_url
+    || app.pdf_cv_stored || app.pdf_fiche_stored || app.pdf_lettre_stored,
+  );
+  const dateAbs = formatApplicationDateLabel(app.date);
+  const dateRel = formatApplicationRelativeLabel(app.date);
+  const isList = variant === 'list';
+
+  return (
+    <div
+      className={[
+        'application-card',
+        isList ? 'candidatures-list-card' : 'kanban-card',
+        app.archived ? 'archived' : '',
+        isDragging ? 'dragging' : '',
+        justAdded ? 'just-added' : '',
+        accent ? `application-card--accent-${accent}` : '',
+      ].filter(Boolean).join(' ')}
+      draggable={!isList && !app.archived}
+      onDragStart={!isList ? onDragStart : undefined}
+      onDragEnd={!isList ? onDragEnd : undefined}
+    >
+      <div className="app-card-actions-icons">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          iconOnly
+          className="app-card-action"
+          onClick={onView}
+          title="Voir"
+          aria-label="Voir"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          iconOnly
+          className="app-card-action app-card-action--archive"
+          onClick={onArchive}
+          title="Archiver"
+          aria-label="Archiver"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+        </Button>
+      </div>
+      <div className="app-card-top">
+        <CompanyLogo companyName={entreprise || app.entreprise} className="app-company-logo" size={32} />
+        <div className="app-card-text">
+          <div className="app-title-row">
+            <div className="app-title">{titre}</div>
+            {needsFollowUp && (
+              <span
+                className="app-follow-up-dot"
+                title="Sans nouvelle depuis 14 jours ou plus"
+                aria-label="À relancer"
+              />
+            )}
+          </div>
+          {entreprise ? <div className="app-meta">{entreprise}</div> : null}
+        </div>
+      </div>
+      <div className="app-card-footer">
+        {hasDocs ? (
+          <div className="app-docs-badge" title="Documents PDF joints">
+            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M16 13H8"/><path d="M16 17H8"/></svg>
+            <span>PDF</span>
+          </div>
+        ) : (
+          <span className="app-card-footer-spacer" aria-hidden />
+        )}
+        <time
+          className="app-date"
+          dateTime={(app.date || '').trim().slice(0, 10) || undefined}
+          title={dateAbs || undefined}
+        >
+          {dateRel}
+        </time>
+      </div>
+      {isList ? (
+        <label className="candidatures-list-statut">
+          <span className="candidatures-list-statut-label">Statut</span>
+          <select
+            className="ds-input candidatures-list-statut-select"
+            value={statutKey}
+            aria-label={`Statut — ${titre}`}
+            data-attr="candidatures-list-input-statut"
+            data-track="input"
+            data-zone="list"
+            data-level="tertiary"
+            onChange={(e) => onStatutChange?.(e.target.value)}
+          >
+            {KANBAN_COLUMNS.map((col) => (
+              <option key={col.id} value={col.id}>{col.label}</option>
+            ))}
+          </select>
+        </label>
+      ) : (
+        <span className="app-card-statut-sr">{STATUT_LABELS[statutKey]}</span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/styles/app/candidatures.css
+++ b/frontend/src/styles/app/candidatures.css
@@ -246,6 +246,11 @@
   overflow: hidden;
 }
 
+/* Liste mobile : masquée desktop (AXE-381) */
+.candidatures-list-mobile {
+  display: none;
+}
+
 .view-candidatures .kanban-board {
   display: flex;
   flex: 1;
@@ -685,37 +690,174 @@
 
   .candidatures-board {
     margin: 0;
-    padding: 0.35rem 0 0;
+    padding: 0;
     border-radius: 0;
-  }
-
-  .view-candidatures .kanban-board {
-    flex-direction: column;
-    overflow-x: hidden;
     overflow-y: auto;
-    min-height: auto;
+    overflow-x: hidden;
   }
 
-  .view-candidatures .kanban-column {
-    flex: none;
-    width: 100%;
-    min-width: 0;
-    border-right: none;
+  /* Desktop kanban masqué ; liste groupée (AXE-381) */
+  .view-candidatures .kanban-board {
+    display: none;
+  }
+
+  .candidatures-list-mobile {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    gap: 0;
+    padding: 0 0.75rem 1rem;
+  }
+
+  .candidatures-list-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.75rem 0 0.25rem;
     border-bottom: 1px solid var(--ds-color-border-default);
-    max-height: none;
   }
 
-  .view-candidatures .kanban-column:last-child {
+  .candidatures-list-section:last-child {
     border-bottom: none;
   }
 
-  /* Un seul scroll vertical (board) : pas de scroll interne par colonne */
-  .view-candidatures .kanban-column-cards {
-    max-height: none;
-    overflow-y: visible;
+  .candidatures-list-section-title {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0.15rem 0;
+    font-size: var(--ds-font-size-label-md, 0.8125rem);
+    font-weight: 500;
+    color: var(--ds-color-text-default);
+    line-height: 1.3;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--ds-color-bg-subtle, var(--color-soft-stone));
   }
 
-  .view-candidatures .kanban-column-empty {
-    min-height: 3.25rem;
+  .candidatures-list-section-count {
+    font-variant-numeric: tabular-nums;
+    font-weight: 400;
+    color: var(--ds-color-text-muted);
+    font-size: var(--ds-font-size-label-sm, 0.75rem);
+  }
+
+  .candidatures-list-section-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .view-candidatures .candidatures-list-card.application-card {
+    position: relative;
+    margin: 0;
+    padding: 0.75rem 0.65rem 0.65rem;
+    background: var(--ds-color-bg-default);
+    border: 1px solid var(--ds-color-border-default);
+    border-radius: var(--ds-radius-sm, 0.375rem);
+    cursor: default;
+  }
+
+  .view-candidatures .candidatures-list-card .app-card-actions-icons {
+    position: absolute;
+    top: 0.35rem;
+    right: 0.25rem;
+  }
+
+  .view-candidatures .candidatures-list-card .app-card-top {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.65rem;
+    padding-right: 4.25rem;
+  }
+
+  .view-candidatures .candidatures-list-card .app-card-text {
+    min-width: 0;
+    flex: 1;
+  }
+
+  .view-candidatures .candidatures-list-card .app-title-row {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  .view-candidatures .candidatures-list-card .application-card .app-title,
+  .view-candidatures .candidatures-list-card .app-title {
+    font-size: var(--ds-font-size-body-md, 0.9375rem);
+    font-weight: 500;
+    color: var(--ds-color-text-default);
+    line-height: 1.25;
+  }
+
+  .view-candidatures .candidatures-list-card .app-meta {
+    font-size: var(--ds-font-size-label-sm, 0.75rem);
+    color: var(--ds-color-text-muted);
+  }
+
+  .view-candidatures .candidatures-list-card .app-card-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 0.45rem;
+  }
+
+  .view-candidatures .candidatures-list-card .app-date {
+    font-size: var(--ds-font-size-label-sm, 0.75rem);
+    color: var(--ds-color-text-muted);
+  }
+
+  .view-candidatures .candidatures-list-card .app-follow-up-dot {
+    width: 0.5rem;
+    height: 0.5rem;
+    flex-shrink: 0;
+    border-radius: 50%;
+    background: var(--ds-color-feedback-warning);
+  }
+
+  .view-candidatures .candidatures-list-card .app-company-logo,
+  .view-candidatures .candidatures-list-card .company-logo-fallback {
+    width: 32px;
+    height: 32px;
+    border-radius: var(--ds-radius-sm, 0.375rem);
+  }
+
+  .candidatures-list-statut {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin-top: 0.55rem;
+  }
+
+  .candidatures-list-statut-label {
+    font-size: var(--ds-font-size-label-sm, 0.75rem);
+    color: var(--ds-color-text-muted);
+  }
+
+  .candidatures-list-statut-select.ds-input {
+    width: 100%;
+    min-height: var(--ds-size-touch-min, 2.75rem);
+    font-size: var(--ds-font-size-body-md, 0.9375rem);
+  }
+
+  .view-candidatures .candidatures-list-card.application-card--accent-offre {
+    box-shadow: inset 3px 0 0 var(--ds-color-feedback-success);
+  }
+
+  .view-candidatures .candidatures-list-card.application-card--accent-refus {
+    box-shadow: inset 3px 0 0 var(--ds-color-text-danger);
+  }
+
+  .view-candidatures .candidatures-list-card.application-card--accent-relancer {
+    box-shadow: inset 3px 0 0 var(--ds-color-feedback-warning);
+  }
+
+  .view-candidatures .candidatures-list-card .app-card-action.ds-button {
+    min-width: var(--ds-size-touch-min, 2.75rem);
+    min-height: var(--ds-size-touch-min, 2.75rem);
   }
 }

--- a/frontend/src/styles/app/candidatures.css
+++ b/frontend/src/styles/app/candidatures.css
@@ -36,6 +36,30 @@
   padding: 0;
 }
 
+.candidatures-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ds-space-sm, 0.5rem);
+  flex-shrink: 0;
+  margin: 0;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--ds-color-border-default);
+  background: var(--ds-color-bg-subtle);
+  color: var(--ds-color-text-danger);
+  font-size: var(--ds-font-size-body-md, 0.9375rem);
+  line-height: 1.35;
+}
+
+.candidatures-error-msg {
+  min-width: 0;
+  flex: 1;
+}
+
+.candidatures-error-dismiss.ds-button {
+  flex-shrink: 0;
+}
+
 /* ── Toolbar unifiée : métriques + contrôles (AXE-382) ── */
 .candidatures-toolbar {
   display: flex;

--- a/frontend/src/styles/app/candidatures.css
+++ b/frontend/src/styles/app/candidatures.css
@@ -238,7 +238,7 @@
   flex: 1;
   min-height: 0;
   margin: 0;
-  background: var(--ds-color-bg-subtle, var(--color-soft-stone));
+  background: var(--ds-color-bg-subtle);
   border-radius: 0;
   padding: 0.5rem 0 0;
   display: flex;
@@ -615,7 +615,7 @@
 }
 
 .view-candidatures .kanban-archived-list .application-card:hover {
-  background: var(--color-soft-stone);
+  background: var(--ds-color-bg-subtle);
   border-radius: var(--radius-xs);
 }
 
@@ -736,7 +736,7 @@
     position: sticky;
     top: 0;
     z-index: 1;
-    background: var(--ds-color-bg-subtle, var(--color-soft-stone));
+    background: var(--ds-color-bg-subtle);
   }
 
   .candidatures-list-section-count {


### PR DESCRIPTION
## Summary
- Sous ~768px : liste groupée par statut (sections sticky) à la place du kanban empilé
- Changement de statut via select (mêmes modales refus / entretien que le drag)
- Carte partagée `CandidatureBoardCard` ; desktop kanban inchangé
- Fixes AXE-381 · Closes #155

## Test plan
- [ ] Desktop (>768) : kanban + drag inchangés
- [ ] Mobile (≤768 ou DevTools) : sections par statut, pas de colonnes horizontales
- [ ] Select statut → change la section (refus / entretien ouvrent les modales)
- [ ] Voir / Archiver / recherche / filtre « À relancer » OK
- [ ] Touches ≥ 44px sur select et icônes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - Ajout d’une vue mobile des candidatures regroupées par statut, avec en-têtes persistants et compteurs.
  - Ajout de cartes tactiles avec consultation, archivage et changement de statut.
  - Conservation des informations clés : logo, documents PDF, dates et rappels de suivi.
  - Le tableau Kanban reste disponible sur ordinateur.
  - Affichage des erreurs lors de la mise à jour du statut.

- **Documentation**
  - Ajout des identifiants de suivi analytique pour le sélecteur de statut et la liste mobile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->