### PR TITLE
Fix: badge PDF fidélité — survol + détail bandeau (AXE-383)

### DIFF
--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -324,6 +324,17 @@ function CvEditorBeta({
     () => summarizeNonFaithfulBlocks(pdfFidelityIssues),
     [pdfFidelityIssues],
   );
+  const pdfFidelityReasons = useMemo(() => {
+    const reasons = [];
+    const seen = new Set();
+    for (const item of pdfFidelityIssues) {
+      const reason = String(item?.reason || '').trim();
+      if (!reason || seen.has(reason)) continue;
+      seen.add(reason);
+      reasons.push(reason);
+    }
+    return reasons;
+  }, [pdfFidelityIssues]);
 
   const clearCanvasSelection = useCallback(() => {
     setSelectedBlockIds([]);
@@ -2112,9 +2123,19 @@ function CvEditorBeta({
       )}
       {pdfFidelityIssues.length > 0 && !loading && layout && (
         <div className="cv-editor-beta-pdf-fidelity" role="status">
-          Certains blocs ne seront pas exportés à l&apos;identique dans le PDF
-          {pdfFidelitySummary ? ` (${pdfFidelitySummary})` : ''}.
-          Survole le badge « PDF » sur le canvas pour le détail.
+          <p className="cv-editor-beta-pdf-fidelity-lead">
+            Certains blocs ne seront pas exportés à l&apos;identique dans le PDF
+            {pdfFidelitySummary ? ` (${pdfFidelitySummary})` : ''}.
+            {' '}
+            Un badge « PDF » sur le canvas rappelle le bloc concerné (survole-le pour le détail).
+          </p>
+          {pdfFidelityReasons.length > 0 && (
+            <ul className="cv-editor-beta-pdf-fidelity-list">
+              {pdfFidelityReasons.map((reason) => (
+                <li key={reason}>{reason}</li>
+              ))}
+            </ul>
+          )}
         </div>
       )}
 

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -223,7 +223,9 @@ function CvEditorBeta({
   const [pdfExportError, setPdfExportError] = useState('');
   const [exportMenuOpen, setExportMenuOpen] = useState(false);
   const [docxNoticeOpen, setDocxNoticeOpen] = useState(false);
+  const [pdfFidelityInfoOpen, setPdfFidelityInfoOpen] = useState(false);
   const exportMenuRef = useRef(null);
+  const pdfFidelityInfoRef = useRef(null);
   const [atsOptimizeMessage, setAtsOptimizeMessage] = useState('');
   const [atsOptimizePreview, setAtsOptimizePreview] = useState(null);
   const [atsOptimizePreviewLoading, setAtsOptimizePreviewLoading] = useState(false);
@@ -1812,6 +1814,30 @@ function CvEditorBeta({
     };
   }, [exportMenuOpen]);
 
+  useEffect(() => {
+    if (!pdfFidelityInfoOpen) return undefined;
+    const onPointerDown = (event) => {
+      const root = pdfFidelityInfoRef.current;
+      if (root && !root.contains(event.target)) setPdfFidelityInfoOpen(false);
+    };
+    const onKeyDown = (event) => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      event.stopPropagation();
+      setPdfFidelityInfoOpen(false);
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown, true);
+    };
+  }, [pdfFidelityInfoOpen]);
+
+  useEffect(() => {
+    if (pdfFidelityIssues.length === 0) setPdfFidelityInfoOpen(false);
+  }, [pdfFidelityIssues.length]);
+
   const handleSaveLayoutProposal = useCallback((name) => {
     if (!layout) return;
     saveLayoutProposal(name, layout);
@@ -2079,10 +2105,59 @@ function CvEditorBeta({
             </button>
           </div>
           <div className="cv-editor-beta-export-wrap" ref={exportMenuRef}>
+            {pdfFidelityIssues.length > 0 && !loading && layout && (
+              <div className="cv-editor-beta-pdf-fidelity-wrap" ref={pdfFidelityInfoRef}>
+                <button
+                  type="button"
+                  className="cv-editor-beta-pdf-fidelity-btn"
+                  onClick={() => {
+                    setExportMenuOpen(false);
+                    setPdfFidelityInfoOpen((open) => !open);
+                  }}
+                  aria-expanded={pdfFidelityInfoOpen}
+                  aria-haspopup="dialog"
+                  aria-controls="cv-editor-beta-pdf-fidelity-popover"
+                  title="Certains blocs seront simplifiés à l’export PDF"
+                >
+                  PDF info
+                  {pdfFidelitySummary ? (
+                    <span className="cv-editor-beta-pdf-fidelity-btn__count" aria-hidden>
+                      {pdfFidelityIssues.length}
+                    </span>
+                  ) : null}
+                </button>
+                {pdfFidelityInfoOpen && (
+                  <div
+                    id="cv-editor-beta-pdf-fidelity-popover"
+                    className="cv-editor-beta-pdf-fidelity-popover"
+                    role="dialog"
+                    aria-label="Fidélité export PDF"
+                  >
+                    <p className="cv-editor-beta-pdf-fidelity-popover__lead">
+                      Certains blocs ne seront pas exportés à l&apos;identique
+                      {pdfFidelitySummary ? ` (${pdfFidelitySummary})` : ''}.
+                    </p>
+                    {pdfFidelityReasons.length > 0 && (
+                      <ul className="cv-editor-beta-pdf-fidelity-popover__list">
+                        {pdfFidelityReasons.map((reason) => (
+                          <li key={reason}>{reason}</li>
+                        ))}
+                      </ul>
+                    )}
+                    <p className="cv-editor-beta-pdf-fidelity-popover__hint">
+                      Un badge « PDF » sur le canvas marque chaque bloc concerné (survole-le pour le même détail).
+                    </p>
+                  </div>
+                )}
+              </div>
+            )}
             <button
               type="button"
               className="cv-editor-beta-history-btn"
-              onClick={() => setExportMenuOpen((open) => !open)}
+              onClick={() => {
+                setPdfFidelityInfoOpen(false);
+                setExportMenuOpen((open) => !open);
+              }}
               disabled={loading || !layout || pdfExporting}
               aria-expanded={exportMenuOpen}
               aria-haspopup="menu"
@@ -2119,23 +2194,6 @@ function CvEditorBeta({
       {pdfExportError && (
         <div className="cv-editor-beta-error" role="alert">
           {pdfExportError}
-        </div>
-      )}
-      {pdfFidelityIssues.length > 0 && !loading && layout && (
-        <div className="cv-editor-beta-pdf-fidelity" role="status">
-          <p className="cv-editor-beta-pdf-fidelity-lead">
-            Certains blocs ne seront pas exportés à l&apos;identique dans le PDF
-            {pdfFidelitySummary ? ` (${pdfFidelitySummary})` : ''}.
-            {' '}
-            Un badge « PDF » sur le canvas rappelle le bloc concerné (survole-le pour le détail).
-          </p>
-          {pdfFidelityReasons.length > 0 && (
-            <ul className="cv-editor-beta-pdf-fidelity-list">
-              {pdfFidelityReasons.map((reason) => (
-                <li key={reason}>{reason}</li>
-              ))}
-            </ul>
-          )}
         </div>
       )}
 

--- a/frontend/src/components/editor/FreeCanvasBlock.jsx
+++ b/frontend/src/components/editor/FreeCanvasBlock.jsx
@@ -1000,6 +1000,7 @@ export default function FreeCanvasBlock({
           className={`free-canvas-block__pdf-fidelity-badge free-canvas-block__pdf-fidelity-badge--${pdfFidelity.level}`}
           title={pdfFidelity.reason || 'Export PDF partiel pour ce bloc'}
           aria-label={pdfFidelity.reason || 'Export PDF partiel pour ce bloc'}
+          onPointerDown={(e) => e.stopPropagation()}
         >
           PDF
         </span>

--- a/frontend/src/styles/CvEditorBeta.css
+++ b/frontend/src/styles/CvEditorBeta.css
@@ -516,6 +516,19 @@
   line-height: 1.4;
 }
 
+.cv-editor-beta-pdf-fidelity-lead {
+  margin: 0;
+}
+
+.cv-editor-beta-pdf-fidelity-list {
+  margin: 0.35rem 0 0;
+  padding-left: 1.15rem;
+}
+
+.cv-editor-beta-pdf-fidelity-list li {
+  margin: 0.15rem 0;
+}
+
 .cv-editor-beta-canvas {
   position: relative;
   flex: 1;

--- a/frontend/src/styles/CvEditorBeta.css
+++ b/frontend/src/styles/CvEditorBeta.css
@@ -167,6 +167,95 @@
 .cv-editor-beta-export-wrap {
   position: relative;
   display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.cv-editor-beta-pdf-fidelity-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.cv-editor-beta-pdf-fidelity-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  height: 32px;
+  padding: 0 0.65rem;
+  border: 1px solid var(--color-hairline);
+  border-radius: 999px;
+  background: var(--color-pale-blue, #f1f5ff);
+  color: var(--color-action-blue, #1863dc);
+  font-size: 0.75rem;
+  font-weight: 500;
+  font-family: var(--editor-font-family);
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.cv-editor-beta-pdf-fidelity-btn:hover {
+  border-color: var(--color-action-blue, #1863dc);
+}
+
+.cv-editor-beta-pdf-fidelity-btn:focus-visible {
+  outline: 2px solid var(--color-focus-blue);
+  outline-offset: 2px;
+}
+
+.cv-editor-beta-pdf-fidelity-btn__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.15rem;
+  height: 1.15rem;
+  padding: 0 0.25rem;
+  border-radius: 999px;
+  background: var(--color-action-blue, #1863dc);
+  color: #fff;
+  font-size: 0.68rem;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.cv-editor-beta-pdf-fidelity-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 35;
+  width: min(22rem, calc(100vw - 2rem));
+  padding: 0.75rem 0.85rem;
+  background: var(--color-canvas);
+  border: 1px solid var(--color-hairline);
+  border-radius: 12px;
+  color: var(--color-ink);
+  box-shadow: none;
+}
+
+.cv-editor-beta-pdf-fidelity-popover__lead {
+  margin: 0;
+  font-size: 0.84rem;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.cv-editor-beta-pdf-fidelity-popover__list {
+  margin: 0.45rem 0 0;
+  padding-left: 1.1rem;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  color: var(--color-body-muted);
+}
+
+.cv-editor-beta-pdf-fidelity-popover__list li {
+  margin: 0.2rem 0;
+}
+
+.cv-editor-beta-pdf-fidelity-popover__hint {
+  margin: 0.55rem 0 0;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: var(--color-body-muted);
 }
 
 .cv-editor-beta-export-menu {
@@ -505,28 +594,6 @@
   font-family: inherit;
   padding: 0;
   flex-shrink: 0;
-}
-
-.cv-editor-beta-pdf-fidelity {
-  background: var(--color-soft-stone);
-  color: var(--color-body-muted);
-  border-bottom: 1px solid var(--color-hairline);
-  padding: 0.5rem 1rem;
-  font-size: 0.82rem;
-  line-height: 1.4;
-}
-
-.cv-editor-beta-pdf-fidelity-lead {
-  margin: 0;
-}
-
-.cv-editor-beta-pdf-fidelity-list {
-  margin: 0.35rem 0 0;
-  padding-left: 1.15rem;
-}
-
-.cv-editor-beta-pdf-fidelity-list li {
-  margin: 0.15rem 0;
 }
 
 .cv-editor-beta-canvas {

--- a/frontend/src/styles/FreeCanvas.css
+++ b/frontend/src/styles/FreeCanvas.css
@@ -409,7 +409,9 @@
   letter-spacing: 0.04em;
   line-height: 1.3;
   text-transform: uppercase;
-  pointer-events: none;
+  /* Doit rester cliquable / survollable pour le title natif (détail fidélité PDF) */
+  pointer-events: auto;
+  cursor: help;
 }
 
 .free-canvas-block__pdf-fidelity-badge--unsupported {


### PR DESCRIPTION
## Summary
- Active le survol du badge « PDF » (`pointer-events: auto`)
- Liste les raisons de fidélité dans le bandeau (plus seulement au tooltip)
- Fixes AXE-383 · Closes #157

## Test plan
- [ ] Éditeur Beta avec un bloc partial (ex. resume + title_style) : bandeau avec la raison visible
- [ ] Survol du badge PDF sur le canvas : tooltip navigateur avec le détail
- [ ] Drag du bloc : le badge ne démarre pas un drag (stopPropagation)


Made with [Cursor](https://cursor.com)