### PR TITLE
Improve: Settings — stack 1 col + rail actif (AXE-384)

### DIFF
--- a/frontend/src/components/SettingsView.jsx
+++ b/frontend/src/components/SettingsView.jsx
@@ -36,12 +36,12 @@ const SETTINGS_NAV = [
   { id: 'settings-privacy', label: 'Confidentialité' },
 ];
 
-function SettingsSection({ id, title, lead, children, wide = false }) {
+function SettingsSection({ id, title, lead, children }) {
   const sectionId = id.replace(/-title$/, '');
   return (
     <section
       id={sectionId}
-      className={`settings-section${wide ? ' settings-section--wide' : ''}`}
+      className="settings-section"
       aria-labelledby={id}
     >
       <h2 id={id} className="settings-section__title">{title}</h2>
@@ -117,10 +117,97 @@ export default function SettingsView({
 
   const pdfPatternInputRef = useRef(null);
   const messageTimerRef = useRef(null);
+  const stackRef = useRef(null);
+  const [activeSectionId, setActiveSectionId] = useState('settings-account');
+
+  const navItems = useMemo(
+    () => SETTINGS_NAV.filter((item) => !item.when || item.when(usage)),
+    [usage],
+  );
 
   const refreshLocalSummary = useCallback(() => {
     setLocalSummary(getLocalDataSummary());
   }, []);
+
+  useEffect(() => {
+    if (!navItems.length) return undefined;
+    if (!navItems.some((item) => item.id === activeSectionId)) {
+      setActiveSectionId(navItems[0].id);
+    }
+    return undefined;
+  }, [navItems, activeSectionId]);
+
+  useEffect(() => {
+    const stack = stackRef.current;
+    if (!stack || !navItems.length) return undefined;
+
+    const sections = navItems
+      .map((item) => document.getElementById(item.id))
+      .filter(Boolean);
+    if (!sections.length) return undefined;
+
+    const root = stack.closest('.app-page');
+    const ratios = new Map();
+
+    const pickActive = () => {
+      let bestId = navItems[0].id;
+      let bestRatio = -1;
+      for (const section of sections) {
+        const ratio = ratios.get(section.id) ?? 0;
+        if (ratio > bestRatio) {
+          bestRatio = ratio;
+          bestId = section.id;
+        }
+      }
+      if (bestRatio <= 0) {
+        // Fallback : première section dont le top est au-dessus du milieu du root
+        const rootTop = root ? root.getBoundingClientRect().top : 0;
+        const midpoint = rootTop + (root ? root.clientHeight * 0.28 : 120);
+        for (const section of sections) {
+          const top = section.getBoundingClientRect().top;
+          if (top <= midpoint) bestId = section.id;
+        }
+      }
+      setActiveSectionId((prev) => (prev === bestId ? prev : bestId));
+    };
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          ratios.set(entry.target.id, entry.isIntersecting ? entry.intersectionRatio : 0);
+        }
+        pickActive();
+      },
+      {
+        root: root || null,
+        rootMargin: '-12% 0px -62% 0px',
+        threshold: [0, 0.08, 0.2, 0.35, 0.5, 0.75, 1],
+      },
+    );
+
+    sections.forEach((section) => observer.observe(section));
+    pickActive();
+    return () => observer.disconnect();
+  }, [navItems]);
+
+  const scrollToSection = useCallback((sectionId) => {
+    const el = document.getElementById(sectionId);
+    if (!el) return;
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    setActiveSectionId(sectionId);
+    try {
+      window.history.replaceState(null, '', `#${sectionId}`);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  useEffect(() => {
+    const hash = (window.location.hash || '').replace(/^#/, '');
+    if (!hash || !navItems.some((item) => item.id === hash)) return undefined;
+    const t = window.setTimeout(() => scrollToSection(hash), 0);
+    return () => window.clearTimeout(t);
+  }, [navItems, scrollToSection]);
 
   useEffect(() => {
     if (!session) return;
@@ -230,16 +317,28 @@ export default function SettingsView({
       <div className="settings-shell">
         <aside className="settings-rail" aria-label="Sections des paramètres">
           <nav className="settings-rail-nav">
-            {SETTINGS_NAV.filter((item) => !item.when || item.when(usage)).map((item) => (
-              <a key={item.id} href={`#${item.id}`} className="settings-rail-link">
-                {item.label}
-              </a>
-            ))}
+            {navItems.map((item) => {
+              const isActive = activeSectionId === item.id;
+              return (
+                <a
+                  key={item.id}
+                  href={`#${item.id}`}
+                  className={`settings-rail-link${isActive ? ' is-active' : ''}`}
+                  aria-current={isActive ? 'true' : undefined}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    scrollToSection(item.id);
+                  }}
+                >
+                  {item.label}
+                </a>
+              );
+            })}
           </nav>
         </aside>
 
-        <div className="settings-mosaic">
-      <SettingsSection id="settings-account-title" title="Compte" lead="Identité de connexion et accès sécurisé." wide={!usage}>
+        <div className="settings-stack" ref={stackRef}>
+      <SettingsSection id="settings-account-title" title="Compte" lead="Identité de connexion et accès sécurisé.">
         <dl className="settings-meta">
           <dt>Email</dt>
           <dd>{accountEmail}</dd>
@@ -295,7 +394,6 @@ export default function SettingsView({
         id="settings-export-title"
         title="Export PDF"
         lead="Personnalise le nom de fichier et le dossier suggéré lors de l'enregistrement d'un CV adapté."
-        wide
       >
         <div className="settings-split">
           <div className="settings-split__col">
@@ -400,7 +498,6 @@ export default function SettingsView({
         id="settings-local-title"
         title="Données sur cet appareil"
         lead="Brouillons et caches locaux (non synchronisés entre appareils)."
-        wide
       >
         <div className="settings-list-grid">
           <div className="settings-list-grid__col">

--- a/frontend/src/components/SettingsView.jsx
+++ b/frontend/src/components/SettingsView.jsx
@@ -326,6 +326,13 @@ export default function SettingsView({
                   className={`settings-rail-link${isActive ? ' is-active' : ''}`}
                   aria-current={isActive ? 'true' : undefined}
                   onClick={(e) => {
+                    if (
+                      e.button !== 0
+                      || e.metaKey
+                      || e.ctrlKey
+                      || e.shiftKey
+                      || e.altKey
+                    ) return;
                     e.preventDefault();
                     scrollToSection(item.id);
                   }}

--- a/frontend/src/styles/app/settings.css
+++ b/frontend/src/styles/app/settings.css
@@ -1,23 +1,24 @@
 /**
- * Page Paramètres - Cohere 2026.
- * Rail latéral + grille mosaic 2 colonnes (hairline mesh, pas de cards).
+ * Page Paramètres — rail + stack 1 colonne (AXE-384).
+ * Tokens chrome : `--ds-*` (migration complète des boutons = AXE-385).
  */
 
 .view-settings {
-  background: var(--color-canvas);
+  background: var(--ds-color-bg-default);
 }
 
 .view-settings .page-header {
-  background: var(--color-canvas);
-  border-bottom: 1px solid var(--color-hairline);
+  background: var(--ds-color-bg-default);
+  border-bottom: 1px solid var(--ds-color-border-default);
+  /* Densité alignée pages app (déjà --ds-space-md/xl dans pages.css) */
 }
 
 .view-settings .page-content {
-  max-width: 72rem;
+  max-width: 56rem;
   width: 100%;
   margin: 0 auto;
-  padding: 0 clamp(1rem, 2.5vw, 1.5rem) 2.5rem;
-  background: var(--color-canvas);
+  padding: 0 clamp(1rem, 2.5vw, 1.5rem) var(--ds-space-2xl, 2.5rem);
+  background: var(--ds-color-bg-default);
 }
 
 .settings-page {
@@ -25,88 +26,100 @@
   flex-direction: column;
 }
 
-/* ── Shell : rail + mosaic ── */
+/* ── Shell : rail + stack (pas de carte englobante) ── */
 .settings-shell {
   display: grid;
-  grid-template-columns: 10.5rem minmax(0, 1fr);
+  grid-template-columns: 11rem minmax(0, 1fr);
   align-items: start;
-  border: 1px solid var(--color-hairline);
-  border-radius: var(--radius-sm);
-  overflow: hidden;
-  margin-top: 1.25rem;
+  gap: var(--ds-space-lg, 1rem) var(--ds-space-xl, 1.5rem);
+  margin-top: var(--ds-space-md, 0.75rem);
+  border: none;
+  border-radius: 0;
+  overflow: visible;
 }
 
 .settings-rail {
   position: sticky;
-  top: 0;
+  top: var(--ds-space-md, 0.75rem);
   align-self: start;
-  padding: 1rem 0;
-  background: var(--color-soft-stone);
-  border-right: 1px solid var(--color-hairline);
-  min-height: 100%;
+  padding: var(--ds-space-xs, 0.25rem) 0;
+  background: transparent;
+  border-right: none;
+  min-height: 0;
 }
 
 .settings-rail-nav {
   display: flex;
   flex-direction: column;
-  gap: 0.1rem;
+  gap: var(--ds-space-2xs, 0.15rem);
 }
 
 .settings-rail-link {
   display: block;
-  padding: 0.45rem 1rem;
-  font-size: 0.8125rem;
+  padding: 0.4rem 0.65rem;
+  font-size: var(--ds-font-size-label-sm, 0.75rem);
   font-weight: 400;
-  color: var(--color-body-muted);
+  line-height: 1.35;
+  color: var(--ds-color-text-muted);
   text-decoration: none;
   border-left: 2px solid transparent;
+  border-radius: 0 var(--ds-radius-sm, 0.25rem) var(--ds-radius-sm, 0.25rem) 0;
   transition: color 0.12s ease, border-color 0.12s ease, background 0.12s ease;
 }
 
 .settings-rail-link:hover {
-  color: var(--color-ink);
-  background: rgba(255, 255, 255, 0.55);
+  color: var(--ds-color-text-default);
+  background: var(--ds-color-bg-subtle);
+}
+
+.settings-rail-link.is-active,
+.settings-rail-link[aria-current='true'] {
+  color: var(--ds-color-text-default);
+  font-weight: 500;
+  border-left-color: var(--ds-color-action-primary-bg);
+  background: var(--ds-color-bg-subtle);
 }
 
 .settings-rail-link:focus-visible {
-  outline: 2px solid var(--color-focus-blue);
-  outline-offset: -2px;
+  outline: 2px solid var(--ds-color-border-focus);
+  outline-offset: 2px;
 }
 
-/* ── Mosaic : grille 2 col via gap hairline (pas de cards) ── */
-.settings-mosaic {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1px;
-  background: var(--color-hairline);
+/* ── Stack : sections empilées, séparateurs discrets ── */
+.settings-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
   min-width: 0;
+  border-top: 1px solid var(--ds-color-border-default);
 }
 
 .settings-section {
-  background: var(--color-canvas);
-  padding: 1.35rem 1.5rem;
+  background: transparent;
+  padding: var(--ds-space-lg, 1rem) 0;
   min-width: 0;
-  scroll-margin-top: 1rem;
+  scroll-margin-top: 1.25rem;
+  border-bottom: 1px solid var(--ds-color-border-default);
 }
 
-.settings-section--wide {
-  grid-column: 1 / -1;
+.settings-section:last-child {
+  border-bottom: none;
 }
 
 .settings-section__title {
-  margin: 0 0 0.4rem;
-  font-size: 1.0625rem;
-  font-weight: 400;
+  margin: 0 0 0.35rem;
+  font-size: var(--ds-font-size-heading-md, 1.0625rem);
+  font-weight: 500;
   letter-spacing: -0.02em;
-  color: var(--color-ink);
+  color: var(--ds-color-text-default);
   line-height: 1.25;
 }
 
 .settings-section__lead {
-  margin: 0 0 1rem;
-  font-size: 0.8125rem;
+  margin: 0 0 var(--ds-space-md, 0.75rem);
+  font-size: var(--ds-font-size-body-md, 0.875rem);
   line-height: 1.5;
-  color: var(--color-body-muted);
+  color: var(--ds-color-text-muted);
 }
 
 .settings-section__lead:last-child {
@@ -462,19 +475,21 @@
 @media (max-width: 900px) {
   .settings-shell {
     grid-template-columns: 1fr;
-    border-radius: 0;
-    border-left: none;
-    border-right: none;
-    margin-left: calc(-1 * clamp(1rem, 2.5vw, 1.5rem));
-    margin-right: calc(-1 * clamp(1rem, 2.5vw, 1.5rem));
-    width: calc(100% + 2 * clamp(1rem, 2.5vw, 1.5rem));
+    gap: var(--ds-space-sm, 0.5rem);
+    margin-top: var(--ds-space-sm, 0.5rem);
   }
 
   .settings-rail {
-    position: static;
+    position: sticky;
+    top: 0;
+    z-index: var(--ds-z-sticky, 200);
     border-right: none;
-    border-bottom: 1px solid var(--color-hairline);
-    padding: 0.65rem 0.75rem;
+    border-bottom: 1px solid var(--ds-color-border-default);
+    padding: var(--ds-space-sm, 0.5rem) 0;
+    margin: 0 calc(-1 * clamp(1rem, 2.5vw, 1.5rem));
+    padding-left: clamp(1rem, 2.5vw, 1.5rem);
+    padding-right: clamp(1rem, 2.5vw, 1.5rem);
+    background: var(--ds-color-bg-default);
     min-height: 0;
   }
 
@@ -482,7 +497,7 @@
     flex-direction: row;
     flex-wrap: nowrap;
     overflow-x: auto;
-    gap: 0.35rem;
+    gap: var(--ds-space-sm, 0.5rem);
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none;
   }
@@ -493,24 +508,27 @@
 
   .settings-rail-link {
     flex-shrink: 0;
-    padding: 0.35rem 0.75rem;
+    padding: 0.4rem 0.75rem;
     border-left: none;
-    border: 1px solid var(--color-hairline);
-    border-radius: var(--radius-xl);
-    background: var(--color-canvas);
-    font-size: 0.75rem;
+    border: 1px solid var(--ds-color-border-default);
+    border-radius: var(--ds-radius-action, 2rem);
+    background: var(--ds-color-bg-default);
+    font-size: var(--ds-font-size-label-sm, 0.75rem);
   }
 
   .settings-rail-link:hover {
-    background: var(--color-canvas-lavender);
+    background: var(--ds-color-bg-subtle);
   }
 
-  .settings-mosaic {
-    grid-template-columns: 1fr;
+  .settings-rail-link.is-active,
+  .settings-rail-link[aria-current='true'] {
+    border-color: var(--ds-color-action-primary-bg);
+    background: var(--ds-color-bg-subtle);
+    color: var(--ds-color-text-default);
   }
 
-  .settings-section--wide {
-    grid-column: auto;
+  .settings-stack {
+    border-top: none;
   }
 
   .settings-split {
@@ -521,7 +539,7 @@
     padding-left: 0;
     padding-top: 1.25rem;
     border-left: none;
-    border-top: 1px solid var(--color-hairline);
+    border-top: 1px solid var(--ds-color-border-default);
   }
 
   .settings-list-grid {
@@ -540,6 +558,13 @@
   }
 
   .settings-section {
-    padding: 1.15rem 1rem;
+    padding: var(--ds-space-md, 0.75rem) 0;
+  }
+
+  .settings-rail {
+    margin-left: -1rem;
+    margin-right: -1rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
   }
 }

--- a/frontend/src/styles/app/settings.css
+++ b/frontend/src/styles/app/settings.css
@@ -531,6 +531,11 @@
     border-top: none;
   }
 
+  /* Rail sticky horizontal : marge ≥ hauteur approx. des chips */
+  .settings-section {
+    scroll-margin-top: 4.5rem;
+  }
+
   .settings-split {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
## Summary
- Mosaïque 2 colonnes → **stack 1 colonne** avec séparateurs
- Shell allégé (plus de « carte » englobante)
- Rail avec **scrollspy** (`aria-current` / `.is-active`) + chips mobile
- Chrome layout en tokens `--ds-*`
- Fixes AXE-384 · Closes #159

## Test plan
- [ ] `/app/settings` : sections empilées, pas de grille 2 col
- [ ] Scroll : item rail actif suit la section visible
- [ ] Clic rail : scroll smooth + hash URL
- [ ] Mobile ≤900px : chips horizontales scrollables, état actif visible
- [ ] Toutes les sections / actions encore présentes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * La navigation des paramètres suit désormais automatiquement la section affichée.
  * Les liens d’ancrage prennent en charge la navigation fluide et la restauration depuis l’URL.
  * Les états actifs et l’accessibilité de la navigation ont été améliorés.
  * La page Paramètres adopte une présentation plus claire en sections empilées.
  * Sur mobile, la navigation devient horizontale et reste visible pendant le défilement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->