### PR TITLE
Improve: Settings — nettoyer IA raccourcis / CV / export (AXE-386)

### DIFF
--- a/frontend/src/components/SettingsView.jsx
+++ b/frontend/src/components/SettingsView.jsx
@@ -396,43 +396,49 @@ export default function SettingsView({
         title="Export PDF"
         lead="Nom de fichier et dossier suggéré à l’enregistrement d’un CV adapté."
       >
-        <label className="settings-field">
-          Modèle du nom de fichier
-          <input
-            ref={pdfPatternInputRef}
-            className="ds-input"
-            type="text"
-            value={pdfPattern}
-            onChange={(e) => setPdfPattern(e.target.value)}
-            spellCheck={false}
-          />
-        </label>
-        <div className="settings-chips" aria-label="Variables">
-          {PDF_VARIABLES.map((token) => (
-            <button key={token} type="button" className="settings-chip" onClick={() => insertPdfVariable(token)}>
-              {token}
-            </button>
-          ))}
+        <div className="settings-export-layout">
+          <div className="settings-export-layout__col">
+            <label className="settings-field">
+              Modèle du nom de fichier
+              <input
+                ref={pdfPatternInputRef}
+                className="ds-input"
+                type="text"
+                value={pdfPattern}
+                onChange={(e) => setPdfPattern(e.target.value)}
+                spellCheck={false}
+              />
+            </label>
+            <div className="settings-chips" aria-label="Variables">
+              {PDF_VARIABLES.map((token) => (
+                <button key={token} type="button" className="settings-chip" onClick={() => insertPdfVariable(token)}>
+                  {token}
+                </button>
+              ))}
+            </div>
+            <p className="settings-preview">
+              Aperçu
+              <code>{profileLoading ? '…' : pdfExportFilenameExample}</code>
+            </p>
+          </div>
+          <div className="settings-export-layout__col">
+            <label className="settings-field">
+              Dossier d&apos;export (suggestion)
+              <input
+                className="ds-input"
+                type="text"
+                value={exportDossier}
+                onChange={(e) => setExportDossier(e.target.value)}
+                placeholder="Ex. Entreprise - Poste"
+                spellCheck={false}
+              />
+            </label>
+            <p className="settings-field-hint">
+              Mémorisé sur cet appareil.
+              {exportDirLabel ? <> Dernier dossier navigateur&nbsp;: <strong>{exportDirLabel}</strong></> : null}
+            </p>
+          </div>
         </div>
-        <p className="settings-preview">
-          Aperçu
-          <code>{profileLoading ? '…' : pdfExportFilenameExample}</code>
-        </p>
-        <label className="settings-field">
-          Dossier d&apos;export (suggestion)
-          <input
-            className="ds-input"
-            type="text"
-            value={exportDossier}
-            onChange={(e) => setExportDossier(e.target.value)}
-            placeholder="Ex. Entreprise - Poste"
-            spellCheck={false}
-          />
-        </label>
-        <p className="settings-field-hint">
-          Mémorisé sur cet appareil.
-          {exportDirLabel ? <> Dernier dossier navigateur&nbsp;: <strong>{exportDirLabel}</strong></> : null}
-        </p>
         <div className="settings-actions">
           <Button type="button" variant="primary" size="sm" onClick={saveExportPrefs}>
             Enregistrer

--- a/frontend/src/components/SettingsView.jsx
+++ b/frontend/src/components/SettingsView.jsx
@@ -28,12 +28,8 @@ const PDF_VARIABLES = ['{prenom}', '{nom}', '{poste}', '{entreprise}'];
 
 const SETTINGS_NAV = [
   { id: 'settings-account', label: 'Compte' },
-  { id: 'settings-plan', label: 'Abonnement', when: (usage) => Boolean(usage) },
   { id: 'settings-export', label: 'Export PDF' },
-  { id: 'settings-cv', label: 'CV & modèle' },
   { id: 'settings-editor', label: 'Éditeur' },
-  { id: 'settings-local', label: 'Données locales' },
-  { id: 'settings-nav', label: 'Raccourcis' },
   { id: 'settings-privacy', label: 'Confidentialité' },
 ];
 
@@ -67,7 +63,7 @@ function SettingsListRow({ label, detail, onClear, disabled, actionLabel = 'Effa
 }
 
 /**
- * Page Paramètres : compte, abonnement, export, éditeur, données locales.
+ * Page Paramètres : compte, export PDF, éditeur, confidentialité.
  */
 export default function SettingsView({
   session,
@@ -258,27 +254,19 @@ export default function SettingsView({
     [pdfPattern, profileBasics.prenom, profileBasics.nom, profileBasics.titre_professionnel],
   );
 
-  const savePdfPattern = useCallback(() => {
-    const trimmed = pdfPattern.trim() || DEFAULT_PDF_EXPORT_FILENAME_PATTERN;
+  const saveExportPrefs = useCallback(() => {
+    const trimmedPattern = pdfPattern.trim() || DEFAULT_PDF_EXPORT_FILENAME_PATTERN;
     try {
-      localStorage.setItem(STORAGE_PDF_EXPORT_FILENAME_PATTERN, trimmed);
-      setPdfPattern(trimmed);
-      showSuccess('Modèle de nom PDF enregistré.');
-    } catch {
-      setError('Impossible d’enregistrer le modèle localement.');
-    }
-  }, [pdfPattern]);
-
-  const saveExportDossier = useCallback(() => {
-    try {
-      const trimmed = exportDossier.trim();
-      if (trimmed) localStorage.setItem(STORAGE_EXPORT_DIR, trimmed);
+      localStorage.setItem(STORAGE_PDF_EXPORT_FILENAME_PATTERN, trimmedPattern);
+      setPdfPattern(trimmedPattern);
+      const trimmedDir = exportDossier.trim();
+      if (trimmedDir) localStorage.setItem(STORAGE_EXPORT_DIR, trimmedDir);
       else localStorage.removeItem(STORAGE_EXPORT_DIR);
-      showSuccess('Préférence de dossier enregistrée.');
+      showSuccess('Préférences d’export enregistrées.');
     } catch {
-      setError('Impossible d’enregistrer le dossier.');
+      setError('Impossible d’enregistrer les préférences d’export.');
     }
-  }, [exportDossier]);
+  }, [pdfPattern, exportDossier]);
 
   const insertPdfVariable = useCallback((token) => {
     const input = pdfPatternInputRef.current;
@@ -346,10 +334,29 @@ export default function SettingsView({
         </aside>
 
         <div className="settings-stack" ref={stackRef}>
-      <SettingsSection id="settings-account-title" title="Compte" lead="Identité de connexion et accès sécurisé.">
+      <SettingsSection id="settings-account-title" title="Compte" lead="Identité, abonnement et accès au profil CV.">
         <dl className="settings-meta">
           <dt>Email</dt>
           <dd>{accountEmail}</dd>
+          {usage && (
+            <>
+              <dt>Plan</dt>
+              <dd>
+                <span className={`settings-plan-badge ${isPro ? 'settings-plan-badge--pro' : ''}`}>
+                  {isPro ? 'Pro' : 'Gratuit'}
+                </span>
+              </dd>
+              {usage.adaptations_used != null && (
+                <>
+                  <dt>Adaptations</dt>
+                  <dd>
+                    {usage.adaptations_used}
+                    {usage.adaptations_limit ? ` / ${usage.adaptations_limit}` : ''}
+                  </dd>
+                </>
+              )}
+            </>
+          )}
         </dl>
         <div className="settings-actions">
           <Button
@@ -365,141 +372,103 @@ export default function SettingsView({
           >
             Mot de passe
           </Button>
+          {usage && !isPro && typeof onUpgradeClick === 'function' && (
+            <Button type="button" variant="primary" size="sm" onClick={onUpgradeClick}>
+              Passer Pro
+            </Button>
+          )}
+          {usage && isPro && usage.stripe_subscription && typeof onBillingPortalClick === 'function' && (
+            <Button type="button" variant="secondary" size="sm" onClick={onBillingPortalClick}>
+              Gérer l&apos;abonnement
+            </Button>
+          )}
         </div>
+        <p className="settings-inline-meta">
+          <Link to="/app/profil" className="settings-text-link">Ouvrir le profil CV</Link>
+          {templateName && templateName !== '-' && (
+            <span className="settings-inline-meta__muted">Modèle&nbsp;: {templateName}</span>
+          )}
+        </p>
       </SettingsSection>
-
-      {usage && (
-        <SettingsSection id="settings-plan-title" title="Abonnement">
-          <dl className="settings-meta">
-            <dt>Plan</dt>
-            <dd>
-              <span className={`settings-plan-badge ${isPro ? 'settings-plan-badge--pro' : ''}`}>
-                {isPro ? 'Pro' : 'Gratuit'}
-              </span>
-            </dd>
-            {usage.adaptations_used != null && (
-              <>
-                <dt>Adaptations</dt>
-                <dd>{usage.adaptations_used}{usage.adaptations_limit ? ` / ${usage.adaptations_limit}` : ''}</dd>
-              </>
-            )}
-          </dl>
-          <div className="settings-actions">
-            {!isPro && typeof onUpgradeClick === 'function' && (
-              <Button type="button" variant="primary" size="sm" onClick={onUpgradeClick}>
-                Passer Pro
-              </Button>
-            )}
-            {isPro && usage.stripe_subscription && typeof onBillingPortalClick === 'function' && (
-              <Button type="button" variant="secondary" size="sm" onClick={onBillingPortalClick}>
-                Gérer l&apos;abonnement
-              </Button>
-            )}
-          </div>
-        </SettingsSection>
-      )}
 
       <SettingsSection
         id="settings-export-title"
         title="Export PDF"
-        lead="Personnalise le nom de fichier et le dossier suggéré lors de l'enregistrement d'un CV adapté."
+        lead="Nom de fichier et dossier suggéré à l’enregistrement d’un CV adapté."
       >
-        <div className="settings-split">
-          <div className="settings-split__col">
-            <label className="settings-field">
-              Modèle du nom de fichier
-              <input
-                ref={pdfPatternInputRef}
-                className="ds-input"
-                type="text"
-                value={pdfPattern}
-                onChange={(e) => setPdfPattern(e.target.value)}
-                spellCheck={false}
-              />
-            </label>
-            <div className="settings-chips" aria-label="Variables">
-              {PDF_VARIABLES.map((token) => (
-                <button key={token} type="button" className="settings-chip" onClick={() => insertPdfVariable(token)}>
-                  {token}
-                </button>
-              ))}
-            </div>
-            <p className="settings-preview">
-              Aperçu
-              <code>{profileLoading ? '…' : pdfExportFilenameExample}</code>
-            </p>
-            <div className="settings-actions">
-              <Button type="button" variant="primary" size="sm" onClick={savePdfPattern}>
-                Enregistrer
-              </Button>
-              <Button
-                type="button"
-                variant="tertiary"
-                size="sm"
-                onClick={() => setPdfPattern(DEFAULT_PDF_EXPORT_FILENAME_PATTERN)}
-              >
-                Réinitialiser
-              </Button>
-            </div>
-          </div>
-          <div className="settings-split__col">
-            <label className="settings-field">
-              Dossier d&apos;export (suggestion)
-              <input
-                className="ds-input"
-                type="text"
-                value={exportDossier}
-                onChange={(e) => setExportDossier(e.target.value)}
-                placeholder="Ex. Entreprise - Poste"
-                spellCheck={false}
-              />
-            </label>
-            <p className="settings-field-hint">
-              Utilisé comme base pour organiser tes exports (mémorisé sur cet appareil).
-            </p>
-            {exportDirLabel && (
-              <p className="settings-field-hint">
-                Dernier dossier navigateur&nbsp;: <strong>{exportDirLabel}</strong>
-              </p>
-            )}
-            <div className="settings-actions">
-              <Button type="button" variant="secondary" size="sm" onClick={saveExportDossier}>
-                Enregistrer le dossier
-              </Button>
-            </div>
-            <hr className="settings-divider" />
-            <Button
-              type="button"
-              variant="tertiary"
-              size="sm"
-              onClick={() => {
-                try {
-                  localStorage.removeItem(STORAGE_PRE_EXPORT_TEMPLATE_OPTIONS_DONE);
-                  showSuccess('Le panneau de personnalisation réapparaîtra avant le prochain export.');
-                } catch {
-                  setError('Impossible de réinitialiser cette préférence.');
-                }
-              }}
-            >
-              Réafficher la personnalisation avant export
-            </Button>
-          </div>
+        <label className="settings-field">
+          Modèle du nom de fichier
+          <input
+            ref={pdfPatternInputRef}
+            className="ds-input"
+            type="text"
+            value={pdfPattern}
+            onChange={(e) => setPdfPattern(e.target.value)}
+            spellCheck={false}
+          />
+        </label>
+        <div className="settings-chips" aria-label="Variables">
+          {PDF_VARIABLES.map((token) => (
+            <button key={token} type="button" className="settings-chip" onClick={() => insertPdfVariable(token)}>
+              {token}
+            </button>
+          ))}
         </div>
-      </SettingsSection>
-
-      <SettingsSection id="settings-cv-title" title="CV & modèle" lead="Couleurs, polices et sections se gèrent dans le profil CV.">
-        <dl className="settings-meta">
-          <dt>Modèle actif</dt>
-          <dd>{templateName}</dd>
-        </dl>
+        <p className="settings-preview">
+          Aperçu
+          <code>{profileLoading ? '…' : pdfExportFilenameExample}</code>
+        </p>
+        <label className="settings-field">
+          Dossier d&apos;export (suggestion)
+          <input
+            className="ds-input"
+            type="text"
+            value={exportDossier}
+            onChange={(e) => setExportDossier(e.target.value)}
+            placeholder="Ex. Entreprise - Poste"
+            spellCheck={false}
+          />
+        </label>
+        <p className="settings-field-hint">
+          Mémorisé sur cet appareil.
+          {exportDirLabel ? <> Dernier dossier navigateur&nbsp;: <strong>{exportDirLabel}</strong></> : null}
+        </p>
         <div className="settings-actions">
-          <Button as={Link} to="/app/profil" variant="secondary" size="sm">
-            Ouvrir le profil CV
+          <Button type="button" variant="primary" size="sm" onClick={saveExportPrefs}>
+            Enregistrer
+          </Button>
+          <Button
+            type="button"
+            variant="tertiary"
+            size="sm"
+            onClick={() => setPdfPattern(DEFAULT_PDF_EXPORT_FILENAME_PATTERN)}
+          >
+            Réinitialiser le modèle
           </Button>
         </div>
+        <Button
+          type="button"
+          variant="tertiary"
+          size="sm"
+          className="settings-export-reset-prefs"
+          onClick={() => {
+            try {
+              localStorage.removeItem(STORAGE_PRE_EXPORT_TEMPLATE_OPTIONS_DONE);
+              showSuccess('Le panneau de personnalisation réapparaîtra avant le prochain export.');
+            } catch {
+              setError('Impossible de réinitialiser cette préférence.');
+            }
+          }}
+        >
+          Réafficher la personnalisation avant export
+        </Button>
       </SettingsSection>
 
-      <SettingsSection id="settings-editor-title" title="Éditeur">
+      <SettingsSection
+        id="settings-editor-title"
+        title="Éditeur"
+        lead="Mode Beta et données locales (non synchronisées entre appareils)."
+      >
         <div className="settings-row">
           <div className="settings-row__text">
             <strong>Mode Beta</strong>
@@ -507,13 +476,7 @@ export default function SettingsView({
           </div>
           <BetaModeToggle />
         </div>
-      </SettingsSection>
-
-      <SettingsSection
-        id="settings-local-title"
-        title="Données sur cet appareil"
-        lead="Brouillons et caches locaux (non synchronisés entre appareils)."
-      >
+        <h3 className="settings-subsection-title">Données sur cet appareil</h3>
         <div className="settings-list-grid">
           <div className="settings-list-grid__col">
             <SettingsListRow
@@ -555,16 +518,7 @@ export default function SettingsView({
         </div>
       </SettingsSection>
 
-      <SettingsSection id="settings-nav-title" title="Raccourcis">
-        <nav className="settings-nav-list" aria-label="Pages de l'application">
-          <Link to="/app/cv" className="settings-nav-link">Adapter un CV</Link>
-          <Link to="/app/postule" className="settings-nav-link">Mes candidatures</Link>
-          <Link to="/app/profil" className="settings-nav-link">Profil CV</Link>
-          <Link to="/app/support" className="settings-nav-link">Support</Link>
-        </nav>
-      </SettingsSection>
-
-      <SettingsSection id="settings-privacy-title" title="Confidentialité" lead="Préférences cookies et documents légaux.">
+      <SettingsSection id="settings-privacy-title" title="Confidentialité" lead="Cookies et documents légaux.">
         {typeof onCookieSettingsClick === 'function' && (
           <div className="settings-actions settings-actions--spaced">
             <Button type="button" variant="secondary" size="sm" onClick={onCookieSettingsClick}>
@@ -573,8 +527,8 @@ export default function SettingsView({
           </div>
         )}
         <nav className="settings-links" aria-label="Documents légaux">
-          <Link to="/confidentialite">Politique de confidentialité</Link>
-          <Link to="/cgu">Conditions d&apos;utilisation</Link>
+          <Link to="/confidentialite">Confidentialité</Link>
+          <Link to="/cgu">CGU</Link>
           <Link to="/mentions-legales">Mentions légales</Link>
         </nav>
       </SettingsSection>

--- a/frontend/src/styles/app/settings.css
+++ b/frontend/src/styles/app/settings.css
@@ -1,6 +1,5 @@
 /**
- * Page Paramètres — rail + stack 1 colonne (AXE-384).
- * CTA via `<Button>` + tokens `--ds-*` (AXE-385).
+ * Page Paramètres — rail + stack (AXE-384/385) + IA allégée (AXE-386).
  */
 
 .view-settings {
@@ -292,38 +291,55 @@
 
 .settings-links {
   display: flex;
-  flex-direction: column;
-  gap: 0;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--ds-space-xs, 0.35rem) var(--ds-space-md, 0.75rem);
 }
 
 .settings-links a {
-  display: block;
-  padding: 0.5rem 0;
-  font-size: 0.8125rem;
-  color: var(--ds-color-text-link);
-  text-decoration: underline;
-  text-underline-offset: 2px;
+  font-size: var(--ds-font-size-label-sm, 0.75rem);
+  color: var(--ds-color-text-muted);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
 }
 
 .settings-links a:hover {
-  opacity: 0.85;
+  color: var(--ds-color-text-link);
+  border-bottom-color: var(--ds-color-text-link);
 }
 
-.settings-split {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1.25rem 2rem;
-}
-
-.settings-split--balanced .settings-split__col {
+.settings-inline-meta {
   display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--ds-space-xs, 0.35rem) var(--ds-space-md, 0.75rem);
+  margin: var(--ds-space-md, 0.75rem) 0 0;
+  font-size: var(--ds-font-size-label-sm, 0.75rem);
 }
 
-.settings-split__col + .settings-split__col {
-  padding-left: 2rem;
-  border-left: 1px solid var(--ds-color-border-default);
+.settings-text-link {
+  color: var(--ds-color-text-link);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+}
+
+.settings-text-link:hover {
+  border-bottom-color: var(--ds-color-text-link);
+}
+
+.settings-inline-meta__muted {
+  color: var(--ds-color-text-muted);
+}
+
+.settings-subsection-title {
+  margin: var(--ds-space-lg, 1rem) 0 var(--ds-space-sm, 0.5rem);
+  font-size: var(--ds-font-size-label-md, 0.8125rem);
+  font-weight: 500;
+  color: var(--ds-color-text-default);
+}
+
+.settings-export-reset-prefs {
+  margin-top: var(--ds-space-sm, 0.5rem);
 }
 
 .settings-plan-badge {
@@ -380,46 +396,6 @@
 .settings-list-row__text span {
   font-size: 0.75rem;
   color: var(--ds-color-text-muted);
-}
-
-.settings-nav-list {
-  display: flex;
-  flex-direction: column;
-}
-
-.settings-nav-link {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.65rem 0;
-  font-size: 0.875rem;
-  font-weight: 400;
-  color: var(--ds-color-text-default);
-  text-decoration: none;
-  border-bottom: 1px solid var(--ds-color-border-default);
-  transition: color 0.15s ease;
-}
-
-.settings-nav-link::after {
-  content: '→';
-  flex-shrink: 0;
-  font-size: 0.875rem;
-  color: var(--ds-color-text-muted);
-  transition: transform 0.15s ease, color 0.15s ease;
-}
-
-.settings-nav-link:hover {
-  color: var(--ds-color-text-link);
-}
-
-.settings-nav-link:hover::after {
-  color: var(--ds-color-text-link);
-  transform: translateX(2px);
-}
-
-.settings-nav-link:last-child {
-  border-bottom: none;
 }
 
 /* Modal mot de passe */
@@ -520,17 +496,6 @@
   /* Rail sticky horizontal : marge ≥ hauteur approx. des chips */
   .settings-section {
     scroll-margin-top: 4.5rem;
-  }
-
-  .settings-split {
-    grid-template-columns: 1fr;
-  }
-
-  .settings-split__col + .settings-split__col {
-    padding-left: 0;
-    padding-top: 1.25rem;
-    border-left: none;
-    border-top: 1px solid var(--ds-color-border-default);
   }
 
   .settings-list-grid {

--- a/frontend/src/styles/app/settings.css
+++ b/frontend/src/styles/app/settings.css
@@ -13,25 +13,30 @@
 }
 
 .view-settings .page-content {
-  max-width: 56rem;
+  /* Pleine largeur app (aligné header) — plus de colonne centrale étroite */
+  max-width: none;
   width: 100%;
-  margin: 0 auto;
-  padding: 0 clamp(1rem, 2.5vw, 1.5rem) var(--ds-space-2xl, 2.5rem);
+  margin: 0;
+  padding: 0 var(--ds-space-xl) var(--ds-space-2xl);
   background: var(--ds-color-bg-default);
+  box-sizing: border-box;
 }
 
 .settings-page {
   display: flex;
   flex-direction: column;
+  width: 100%;
+  max-width: none;
 }
 
 /* ── Shell : rail + stack (pas de carte englobante) ── */
 .settings-shell {
   display: grid;
-  grid-template-columns: 11rem minmax(0, 1fr);
+  grid-template-columns: 12rem minmax(0, 1fr);
   align-items: start;
-  gap: var(--ds-space-lg, 1rem) var(--ds-space-xl, 1.5rem);
+  gap: var(--ds-space-lg, 1rem) var(--ds-space-2xl, 2rem);
   margin-top: var(--ds-space-md, 0.75rem);
+  width: 100%;
   border: none;
   border-radius: 0;
   overflow: visible;
@@ -150,10 +155,12 @@
 
 .settings-meta {
   display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0.35rem 1rem;
+  grid-template-columns: auto minmax(0, 1fr) auto minmax(0, 1fr);
+  column-gap: 1.25rem;
+  row-gap: 0.4rem;
   margin: 0 0 1rem;
   font-size: 0.8125rem;
+  max-width: 52rem;
 }
 
 .settings-meta dt {
@@ -342,6 +349,17 @@
   margin-top: var(--ds-space-sm, 0.5rem);
 }
 
+.settings-export-layout {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--ds-space-lg, 1rem) var(--ds-space-2xl, 2rem);
+  margin-bottom: var(--ds-space-md, 0.75rem);
+}
+
+.settings-export-layout__col {
+  min-width: 0;
+}
+
 .settings-plan-badge {
   display: inline-block;
   padding: 0.15rem 0.5rem;
@@ -501,6 +519,14 @@
   .settings-list-grid {
     grid-template-columns: 1fr;
     gap: 0;
+  }
+
+  .settings-export-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-meta {
+    grid-template-columns: auto minmax(0, 1fr);
   }
 
   .settings-divider--mobile-only {


### PR DESCRIPTION
## Summary
- Supprime **Raccourcis** et la tuile **CV & modèle**
- Compte + abonnement densifiés ; lien discret « Ouvrir le profil CV »
- Export PDF compact : **1 primary Enregistrer** (nom + dossier)
- Éditeur + données locales regroupés
- Confidentialité : liens légaux compacts (plus de look footer)
- Fixes AXE-386 · Closes #161

## Test plan
- [ ] Rail : Compte, Export PDF, Éditeur, Confidentialité seulement
- [ ] Compte : email / plan / adaptations + mdp / Pro ou portal + lien profil
- [ ] Export : un seul Enregistrer sauvegarde nom + dossier
- [ ] Éditeur : Beta + clears locaux
- [ ] Cookies + 3 liens légaux OK


Made with [Cursor](https://cursor.com)