### PR TITLE
Feat: templates Stable — inventaire fidélité + réplique Minimal (AXE-346)

### DIFF
--- a/docs/template-canvas-fidelity.md
+++ b/docs/template-canvas-fidelity.md
@@ -1,0 +1,59 @@
+# Fidélité templates Stable ↔ canvas Beta (AXE-346)
+
+## Objectif
+
+Chaque template catalogue Stable (`templates/<id>/`) doit avoir une **réplique native** canvas Beta (blocs + thème + CSS twin), pas seulement une projection approximative.
+
+État actuel : `buildTemplateBlocks` dans `frontend/src/lib/canvasTemplateSpecs.js` **projette** des géométries mm à la main. Ce document + `TEMPLATE_CANVAS_FIDELITY` mesurent l’écart.
+
+## Architecture
+
+```
+templates/<id>/{meta.json,template.html,template.css}  ← Stable (Jinja)
+        │
+        ▼  projection manuelle (à remplacer progressivement par réplique)
+canvasTemplateSpecs.js → buildTemplateBlocks / parseCanvasTheme
+        │
+        ▼
+layoutTemplatePresets.createCanvasLayoutForTemplate
+        │
+        ├─ pont Stable→Beta (designModeBridge.applyStableDesignToCanvas)
+        └─ FreeCanvas + CanvasTemplateFidelity.css (.free-canvas-page--tpl-{id})
+```
+
+Le template virtuel `beta` (`betaCanvasTemplate.js`) n’est **pas** une twin HTML : c’est le layout canvas libre du profil.
+
+## Matrice (août 2026)
+
+| ID | Famille | Readiness | Fidelity CSS | Gaps principaux |
+|----|---------|-----------|--------------|-----------------|
+| `minimal` | single-column | projection | thin→medium | Réplique mono-colonne en cours ; valider vs preview Stable |
+| `classic` | sidebar-right | thin | thin | CSS Stable dense vs twin mince |
+| `modern` | sidebar-left | projection | medium | Sidebar / accents |
+| `creative` | sidebar-left | projection | medium | Titres creative-main |
+| `elegant` | single-column | projection | thin | Chips / centrage |
+| `executive` | sidebar-right | projection | medium | Header band |
+| `bold` | sidebar-right | **near-replica** | rich | Écarts typo/exp résiduels |
+
+Source de vérité code : `TEMPLATE_CANVAS_FIDELITY` + `STABLE_CANVAS_TEMPLATE_IDS`.
+
+## Critères de « réplique native »
+
+Pour un id catalogue :
+
+1. Apply Stable→Beta produit un layout non vide (`theme.template_id` = id)
+2. Checklist visuelle vs preview Stable (header, colonnes, titres, sidebar)
+3. Écarts résiduels listés ici / dans `gaps[]`
+4. Tests structurels verts (`canvasTemplateSpecs.test.js`)
+
+## Suite chantier
+
+1. ~~Inventaire + contrat tests + premier lift `minimal`~~ (cette PR)
+2. Monter `classic` / `elegant` (fidelity CSS + géométrie)
+3. Finir `bold` en réplique validée (checklist visuelle)
+4. Option ultérieure : assets `default_layout.json` par template (voir `docs/editor-vision.md`)
+
+## Hors scope
+
+- Fidélité **canvas ↔ PDF** → `docs/pdf-block-fidelity.md` (AXE-38)
+- Carte picker « Beta » → AXE-374 (Done)

--- a/frontend/src/components/editor/FreeCanvasBlock.jsx
+++ b/frontend/src/components/editor/FreeCanvasBlock.jsx
@@ -140,6 +140,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
             className={[
               'free-canvas-block__identity',
               'free-canvas-block__identity--inline-title',
+              style.identity_layout ? `free-canvas-block__identity--${style.identity_layout}` : '',
               style.identity_divider ? 'free-canvas-block__identity--divider' : '',
             ].filter(Boolean).join(' ')}
           >
@@ -156,7 +157,11 @@ function SemanticBlockBody({ block, cv, editing = false }) {
         );
       }
       return (
-        <div className={`free-canvas-block__identity${style.identity_divider ? ' free-canvas-block__identity--divider' : ''}`}>
+        <div className={[
+          'free-canvas-block__identity',
+          style.identity_layout ? `free-canvas-block__identity--${style.identity_layout}` : '',
+          style.identity_divider ? 'free-canvas-block__identity--divider' : '',
+        ].filter(Boolean).join(' ')}>
           {nameEl ? (
             <div className="free-canvas-block__identity-name" style={{ textAlign: style.align || 'left' }}>
               {nameEl}

--- a/frontend/src/lib/canvasCvImportAdapter.js
+++ b/frontend/src/lib/canvasCvImportAdapter.js
@@ -15,6 +15,7 @@ import {
   parseCanvasTheme,
   SIDE_PAD_X,
   SIDE_PAD_Y,
+  STABLE_CANVAS_TEMPLATE_IDS,
 } from './canvasTemplateSpecs.js';
 import { createCanvasLayoutForTemplate } from './layoutTemplatePresets.js';
 import { reflowColumnBlocksOnPage } from './layoutReflow.js';
@@ -205,9 +206,7 @@ function isValidHexColor(value) {
   return /^#[0-9a-fA-F]{6}$/.test(String(value || '').trim());
 }
 
-const KNOWN_TEMPLATE_IDS = new Set([
-  'modern', 'creative', 'executive', 'bold', 'classic', 'minimal', 'elegant',
-]);
+const KNOWN_TEMPLATE_IDS = new Set(STABLE_CANVAS_TEMPLATE_IDS);
 
 /** Choisit le template le plus adapté au profil importé. */
 export function recommendTemplateId(analysis, templatesList = [], currentTemplateId = '', layoutHints = {}) {

--- a/frontend/src/lib/canvasTemplateSpecs.js
+++ b/frontend/src/lib/canvasTemplateSpecs.js
@@ -1,8 +1,99 @@
 /**
  * Spécifications canvas calquées sur templates/*.css (mm, typo, blocs).
+ * AXE-346 : viser des répliques natives ; la matrice de fidélité documente l’écart actuel.
  */
 import { fontStackFromTemplateOption } from './canvasFontOptions.js';
 import { PAGE_HEIGHT_MM, PAGE_WIDTH_MM } from './cvLayoutModelV3.js';
+
+/** Catalogue Stable avec projection canvas (hors `custom_*` / `beta`). */
+export const STABLE_CANVAS_TEMPLATE_IDS = Object.freeze([
+  'minimal',
+  'classic',
+  'modern',
+  'creative',
+  'elegant',
+  'executive',
+  'bold',
+]);
+
+/**
+ * Matrice AXE-346 — readiness réplique native (état projection actuelle).
+ * @type {Readonly<Record<string, {
+ *   name: string,
+ *   layoutFamily: 'single-column' | 'sidebar-left' | 'sidebar-right',
+ *   readiness: 'thin' | 'projection' | 'near-replica',
+ *   fidelityCss: 'thin' | 'medium' | 'rich',
+ *   gaps: string[],
+ * }>>}
+ */
+export const TEMPLATE_CANVAS_FIDELITY = Object.freeze({
+  minimal: {
+    name: 'Minimal',
+    layoutFamily: 'single-column',
+    readiness: 'projection',
+    fidelityCss: 'medium',
+    gaps: [
+      'Pas encore une réplique pixel-perfect du HTML Stable',
+      'Pagination multi-page / densités CV longs à valider',
+    ],
+  },
+  classic: {
+    name: 'Classique',
+    layoutFamily: 'sidebar-right',
+    readiness: 'thin',
+    fidelityCss: 'thin',
+    gaps: [
+      'CSS Stable très dense vs twin canvas mince',
+      'Sidebar compétences / typo header à rapprocher',
+    ],
+  },
+  modern: {
+    name: 'Moderne',
+    layoutFamily: 'sidebar-left',
+    readiness: 'projection',
+    fidelityCss: 'medium',
+    gaps: ['Détails sidebar (outils/langues) et accents underline à peaufiner'],
+  },
+  creative: {
+    name: 'Créatif',
+    layoutFamily: 'sidebar-left',
+    readiness: 'projection',
+    fidelityCss: 'medium',
+    gaps: ['Titres creative-main et bordures photo à valider visuellement'],
+  },
+  elegant: {
+    name: 'Élégant',
+    layoutFamily: 'single-column',
+    readiness: 'projection',
+    fidelityCss: 'thin',
+    gaps: ['Centrage / chips compétences vs HTML Stable'],
+  },
+  executive: {
+    name: 'Executive',
+    layoutFamily: 'sidebar-right',
+    readiness: 'projection',
+    fidelityCss: 'medium',
+    gaps: ['Bandeau header + barre accent vs CSS Stable'],
+  },
+  bold: {
+    name: 'Impact',
+    layoutFamily: 'sidebar-right',
+    readiness: 'near-replica',
+    fidelityCss: 'rich',
+    gaps: ['Écarts résiduels typo/exp (meilleure base actuelle)'],
+  },
+});
+
+/** @param {string|null|undefined} id */
+export function isStableCanvasTemplateId(id) {
+  return STABLE_CANVAS_TEMPLATE_IDS.includes(String(id || '').trim());
+}
+
+/** @param {string|null|undefined} id */
+export function getTemplateCanvasFidelity(id) {
+  const key = String(id || '').trim();
+  return TEMPLATE_CANVAS_FIDELITY[key] || null;
+}
 
 /** 200px @ 96dpi */
 export const SIDEBAR_W_MM = (200 * 25.4) / 96;
@@ -484,15 +575,17 @@ export function buildTemplateBlocks(template) {
     }
 
     case 'minimal': {
+      // Aligné templates/minimal : mono-colonne, pas de barre accent sous le header
+      // (la séparation suit les titres .section-title / title_style: minimal-section).
       const pad = (28 * 25.4) / 96;
       const W = PAGE_WIDTH_MM - pad * 2;
+      const photoMm = (52 * 25.4) / 96; // --cv-photo-size 52px
       return [
-        bar(pad, (18 * 25.4) / 96, W, 0.4, t.color_accent, 0),
-        { type: 'photo', x: pad, y: (20 * 25.4) / 96, w: 14, h: 14, z: 2, style: { shape: 'circle', zone: 'main' } },
-        { type: 'identity', bind: ['prenom', 'nom', 'titre_professionnel'], x: pad + 18, y: (18 * 25.4) / 96, w: W - 18, h: 20, z: 2, style: { ...main(), font_size: 18, font_family: t.font_heading, color: t.color_section_title } },
-        { type: 'contact', bind: ['email', 'telephone', 'linkedin'], x: pad + 18, y: (40 * 25.4) / 96, w: W - 18, h: 8, z: 2, style: { ...main(), font_size: 8.5, color: '#666666' } },
-        { type: 'resume', bind: 'resume', x: pad, y: (52 * 25.4) / 96, w: W, h: 22, z: 1, style: { ...main(), section_label: 'PROFIL', title_style: 'minimal-section', font_style: 'italic' } },
-        { type: 'experiences', bind: 'experiences', x: pad, y: (78 * 25.4) / 96, w: W, h: 118, z: 1, style: { ...main(), section_label: 'EXPÉRIENCE PROFESSIONNELLE', title_style: 'minimal-section', font_family: t.font_heading } },
+        { type: 'photo', x: pad, y: (18 * 25.4) / 96, w: photoMm, h: photoMm, z: 2, style: { shape: 'circle', zone: 'main' } },
+        { type: 'identity', bind: ['prenom', 'nom', 'titre_professionnel'], x: pad + photoMm + (14 * 25.4) / 96, y: (18 * 25.4) / 96, w: W - photoMm - (14 * 25.4) / 96, h: 18, z: 2, style: { ...main(), font_size: 18, font_family: t.font_heading, color: t.color_section_title, identity_layout: 'minimal-header' } },
+        { type: 'contact', bind: ['email', 'telephone', 'linkedin'], x: pad + photoMm + (14 * 25.4) / 96, y: (40 * 25.4) / 96, w: W - photoMm - (14 * 25.4) / 96, h: 8, z: 2, style: { ...main(), font_size: 8.5, color: '#4b5563' } },
+        { type: 'resume', bind: 'resume', x: pad, y: (56 * 25.4) / 96, w: W, h: 22, z: 1, style: { ...main(), section_label: 'PROFIL', title_style: 'minimal-section', font_style: 'italic' } },
+        { type: 'experiences', bind: 'experiences', x: pad, y: (82 * 25.4) / 96, w: W, h: 114, z: 1, style: { ...main(), section_label: 'EXPÉRIENCE PROFESSIONNELLE', title_style: 'minimal-section', font_family: t.font_heading } },
         { type: 'formations', bind: 'formations', x: pad, y: (200 * 25.4) / 96, w: W, h: 28, z: 1, style: { ...main(), section_label: 'FORMATION', title_style: 'minimal-section', font_family: t.font_heading } },
         { type: 'skills', bind: 'competences.techniques', x: pad, y: (232 * 25.4) / 96, w: W, h: 22, z: 1, style: { ...main(), section_label: 'COMPÉTENCES', title_style: 'minimal-section', list_format: 'list' } },
         { type: 'skills', bind: 'competences.logiciels', x: pad, y: (258 * 25.4) / 96, w: W, h: 18, z: 1, style: { ...main(), section_label: 'OUTILS', title_style: 'minimal-section', list_format: 'list' } },
@@ -543,4 +636,33 @@ export function buildTemplateBlocks(template) {
     default:
       return [];
   }
+}
+
+/**
+ * Résumé structurel d’une projection (tests + inventaire AXE-346).
+ * @param {object} template
+ */
+export function summarizeTemplateCanvasLayout(template) {
+  const theme = parseCanvasTheme(template);
+  const blocks = buildTemplateBlocks(template);
+  /** @type {Record<string, number>} */
+  const blockTypes = {};
+  /** @type {Set<string>} */
+  const zones = new Set();
+  for (const block of blocks) {
+    const type = String(block?.type || 'unknown');
+    blockTypes[type] = (blockTypes[type] || 0) + 1;
+    const zone = block?.style?.zone;
+    if (zone) zones.add(String(zone));
+  }
+  const fidelity = getTemplateCanvasFidelity(theme.template_id);
+  return {
+    templateId: theme.template_id,
+    blockCount: blocks.length,
+    blockTypes,
+    zones: [...zones].sort(),
+    themeTemplateId: theme.template_id,
+    readiness: fidelity?.readiness || null,
+    layoutFamily: fidelity?.layoutFamily || null,
+  };
 }

--- a/frontend/src/lib/designModeBridge.js
+++ b/frontend/src/lib/designModeBridge.js
@@ -7,7 +7,7 @@
  */
 
 import { buildAdaptedCanvasLayoutForCv } from './canvasCvImportAdapter.js';
-import { buildTemplateBlocks } from './canvasTemplateSpecs.js';
+import { buildTemplateBlocks, isStableCanvasTemplateId } from './canvasTemplateSpecs.js';
 import { detectTransferCandidates } from './canvasLayoutTransfer.js';
 import { createCanvasLayoutForTemplate } from './layoutTemplatePresets.js';
 import { isEmptyLayoutV3 } from './cvLayoutModelV3.js';
@@ -29,7 +29,7 @@ export function resolveTemplateFromList(templatesList, templateId) {
  * @param {object|null|undefined} template
  */
 export function canBuildCanvasForTemplate(template) {
-  if (!template?.id) return false;
+  if (!template?.id || !isStableCanvasTemplateId(template.id)) return false;
   try {
     return buildTemplateBlocks(template).length > 0;
   } catch {

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -284,14 +284,47 @@
   text-transform: uppercase;
 }
 
-/* ---------- Minimal ---------- */
+/* ---------- Minimal (réplique mono-colonne — AXE-346) ---------- */
+.free-canvas-page--tpl-minimal {
+  color: #1a1a1a;
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__identity--minimal-header .free-canvas-block__identity-name,
+.free-canvas-page--tpl-minimal .free-canvas-block__identity .free-canvas-block__identity-name {
+  font-family: var(--free-canvas-font-heading);
+  font-size: 18pt;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--free-canvas-accent, #111827);
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__identity .free-canvas-block__identity-title {
+  font-size: 10pt;
+  font-weight: 400;
+  color: #374151;
+  margin-top: 0.4mm;
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__contact {
+  color: #4b5563;
+  font-size: 8.5pt;
+}
+
 .free-canvas-page--tpl-minimal .free-canvas-block__section-title--minimal-section {
   font-family: var(--free-canvas-font-heading);
   font-size: 10.5pt;
   font-weight: 700;
-  color: var(--free-canvas-accent);
-  border-bottom: 0.35mm solid var(--free-canvas-accent);
+  color: var(--free-canvas-accent, #111827);
+  border-bottom: 0.35mm solid var(--free-canvas-accent, #111827);
   padding-bottom: 1mm;
+  margin-bottom: 1.5mm;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__resume {
+  font-style: italic;
+  color: #1a1a1a;
 }
 
 /* ---------- Élégant ---------- */

--- a/frontend/tests/unit/canvasTemplateSpecs.test.js
+++ b/frontend/tests/unit/canvasTemplateSpecs.test.js
@@ -1,0 +1,76 @@
+/**
+ * Contrat projection Stable → canvas (AXE-346).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  STABLE_CANVAS_TEMPLATE_IDS,
+  TEMPLATE_CANVAS_FIDELITY,
+  buildTemplateBlocks,
+  getTemplateCanvasFidelity,
+  isStableCanvasTemplateId,
+  parseCanvasTheme,
+  summarizeTemplateCanvasLayout,
+} from '../../src/lib/canvasTemplateSpecs.js';
+import { createCanvasLayoutForTemplate } from '../../src/lib/layoutTemplatePresets.js';
+import { canBuildCanvasForTemplate } from '../../src/lib/designModeBridge.js';
+
+test('STABLE_CANVAS_TEMPLATE_IDS couvre la matrice de fidélité', () => {
+  assert.equal(STABLE_CANVAS_TEMPLATE_IDS.length, 7);
+  for (const id of STABLE_CANVAS_TEMPLATE_IDS) {
+    assert.ok(TEMPLATE_CANVAS_FIDELITY[id], `fidélité manquante pour ${id}`);
+    assert.equal(isStableCanvasTemplateId(id), true);
+  }
+  assert.equal(isStableCanvasTemplateId('custom_foo'), false);
+  assert.equal(isStableCanvasTemplateId('beta'), false);
+});
+
+test('chaque template catalogue produit des blocs + theme.template_id', () => {
+  for (const id of STABLE_CANVAS_TEMPLATE_IDS) {
+    const template = { id, name: id };
+    const blocks = buildTemplateBlocks(template);
+    const theme = parseCanvasTheme(template);
+    assert.ok(blocks.length > 0, `${id}: blocs vides`);
+    assert.equal(theme.template_id, id);
+    assert.equal(canBuildCanvasForTemplate(template), true);
+
+    const layout = createCanvasLayoutForTemplate(template);
+    assert.ok(layout.pages?.[0]?.blocks?.length > 0, `${id}: layout vide`);
+    assert.equal(layout.theme?.template_id, id);
+  }
+});
+
+test('ids inconnus / custom → pas de projection', () => {
+  assert.deepEqual(buildTemplateBlocks({ id: 'custom_x' }), []);
+  assert.deepEqual(buildTemplateBlocks({ id: 'unknown' }), []);
+  assert.equal(canBuildCanvasForTemplate({ id: 'custom_x' }), false);
+  assert.equal(getTemplateCanvasFidelity('nope'), null);
+});
+
+test('summarizeTemplateCanvasLayout expose readiness + types', () => {
+  const summary = summarizeTemplateCanvasLayout({ id: 'minimal' });
+  assert.equal(summary.templateId, 'minimal');
+  assert.ok(summary.blockCount >= 8);
+  assert.ok(summary.blockTypes.identity >= 1);
+  assert.ok(summary.blockTypes.experiences >= 1);
+  assert.equal(summary.layoutFamily, 'single-column');
+  assert.ok(['thin', 'projection', 'near-replica'].includes(summary.readiness));
+});
+
+test('minimal n’ajoute plus de barre accent décorative sous le header', () => {
+  const blocks = buildTemplateBlocks({ id: 'minimal' });
+  const shapes = blocks.filter((b) => b.type === 'shape:rect');
+  assert.equal(shapes.length, 0, 'minimal mono-colonne : pas de shape:rect de chrome');
+  assert.ok(blocks.some((b) => b.type === 'photo'));
+  assert.ok(blocks.some((b) => b.style?.title_style === 'minimal-section'));
+});
+
+test('bold reste le plus proche d’une réplique (near-replica)', () => {
+  assert.equal(getTemplateCanvasFidelity('bold')?.readiness, 'near-replica');
+  assert.equal(getTemplateCanvasFidelity('bold')?.fidelityCss, 'rich');
+  const summary = summarizeTemplateCanvasLayout({ id: 'bold' });
+  assert.ok(summary.blockCount >= 10);
+  assert.ok(summary.zones.includes('header') || summary.zones.includes('sidebar-light'));
+});


### PR DESCRIPTION
## Summary
- Inventaire AXE-346 : `docs/template-canvas-fidelity.md` + `TEMPLATE_CANVAS_FIDELITY` / `STABLE_CANVAS_TEMPLATE_IDS`
- Contrat tests `canvasTemplateSpecs.test.js` (7 templates catalogue)
- Premier lift **Minimal** : géométrie alignée HTML Stable + CSS twin enrichi
- Pont Stable→Beta : gate via ids catalogue stables
- Refs AXE-346 · tranche 1 (suite classic / elegant / bold)

## Test plan
- [ ] `node --test tests/unit/canvasTemplateSpecs.test.js`
- [ ] Beta : appliquer design **Minimal** depuis Stable → layout proche du preview
- [ ] Autres templates toujours projectables
- [ ] `custom_*` / `beta` non projectés comme twins HTML