### PR TITLE
Feat: CI obligatoire sur les PR vers prod (AXE-316)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, wip/innovation]
+    branches: [main, prod, wip/innovation]
   pull_request:
-    branches: [main, wip/innovation]
+    branches: [main, prod, wip/innovation]
 
 # Evite d'empiler des runs identiques (ex. Dependabot qui repousse plusieurs PRs / commits).
 concurrency:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,9 +2,9 @@ name: Security
 
 on:
   push:
-    branches: [main]
+    branches: [main, prod]
   pull_request:
-    branches: [main]
+    branches: [main, prod]
   schedule:
     - cron: "0 4 * * 1"
 


### PR DESCRIPTION
## Summary
- `ci.yml` et `security.yml` : `pull_request` + `push` incluent **`prod`**
- Prépare les status checks pour les protections de branche (AXE-318)
- Fixes AXE-316 · Closes #167

## Test plan
- [ ] Ouvrir une PR `main` → `prod` (ou feature → `prod`) : jobs Backend + Frontend (+ Security) démarrent
- [ ] PR vers `main` inchangées


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI**
  * Les vérifications automatisées s’exécutent désormais lors des changements ciblant également la branche `prod`.

* **Sécurité**
  * Les contrôles de sécurité sont maintenant déclenchés pour les changements visant les branches `main` et `prod`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->