### PR TITLE
Feat: Minimal Beta — réplique Stable header/contact/exp (AXE-346)

### DIFF
--- a/docs/template-canvas-fidelity.md
+++ b/docs/template-canvas-fidelity.md
@@ -27,7 +27,7 @@ Le template virtuel `beta` (`betaCanvasTemplate.js`) n’est **pas** une twin HT
 
 | ID | Famille | Readiness | Fidelity CSS | Gaps principaux |
 |----|---------|-----------|--------------|-----------------|
-| `minimal` | single-column | projection | medium | Header/contact/titres/exp alignés (tranche 2) ; Outils nestés + densités + multi-page à valider |
+| `minimal` | single-column | projection | **rich** | Header/contact/exp/formation/compétences calqués ; checklist visuelle Stable↔Beta avant merge |
 | `classic` | sidebar-right | thin | thin | CSS Stable dense vs twin mince |
 | `modern` | sidebar-left | projection | medium | Sidebar / accents |
 | `creative` | sidebar-left | projection | medium | Titres creative-main |

--- a/docs/template-canvas-fidelity.md
+++ b/docs/template-canvas-fidelity.md
@@ -27,7 +27,7 @@ Le template virtuel `beta` (`betaCanvasTemplate.js`) n’est **pas** une twin HT
 
 | ID | Famille | Readiness | Fidelity CSS | Gaps principaux |
 |----|---------|-----------|--------------|-----------------|
-| `minimal` | single-column | projection | thin→medium | Réplique mono-colonne en cours ; valider vs preview Stable |
+| `minimal` | single-column | projection | medium | Header/contact/titres/exp alignés (tranche 2) ; Outils nestés + densités + multi-page à valider |
 | `classic` | sidebar-right | thin | thin | CSS Stable dense vs twin mince |
 | `modern` | sidebar-left | projection | medium | Sidebar / accents |
 | `creative` | sidebar-left | projection | medium | Titres creative-main |
@@ -36,6 +36,14 @@ Le template virtuel `beta` (`betaCanvasTemplate.js`) n’est **pas** une twin HT
 | `bold` | sidebar-right | **near-replica** | rich | Écarts typo/exp résiduels |
 
 Source de vérité code : `TEMPLATE_CANVAS_FIDELITY` + `STABLE_CANVAS_TEMPLATE_IDS`.
+
+### Minimal — couches Stable à calquer
+
+1. **HTML** `templates/minimal/template.html` — structure (header sans photo, contact ` · `, titres Title Case, `Organisation :` / `Fonction :` inline)
+2. **CSS** `templates/minimal/template.css` — pad `18/28/8`, body `6/28/16`, règle `#d1d5db`, typo Georgia/Inter
+3. **Options** `meta.json` + `template_registry` — `show_photo=false`, couleurs/font injectées
+4. **Preview overlay** `cvPreviewA4Pages.js` — badge « Page N » (chrome preview, pas du template)
+5. **Canvas** `buildTemplateBlocks('minimal')` + `CanvasTemplateFidelity.css` + `FreeCanvasBlock` (`contact_layout`, `exp_style: minimal`)
 
 ## Critères de « réplique native »
 
@@ -48,10 +56,11 @@ Pour un id catalogue :
 
 ## Suite chantier
 
-1. ~~Inventaire + contrat tests + premier lift `minimal`~~ (cette PR)
-2. Monter `classic` / `elegant` (fidelity CSS + géométrie)
-3. Finir `bold` en réplique validée (checklist visuelle)
-4. Option ultérieure : assets `default_layout.json` par template (voir `docs/editor-vision.md`)
+1. ~~Inventaire + contrat tests + premier lift `minimal`~~ (PR #165)
+2. **Tranche 2 `minimal`** : header sans photo, contact ` · `, Title Case, exp ATS inline, règle grise (cette PR — **ne pas merger** tant que la checklist visuelle Stable≠Beta n’est pas OK)
+3. Monter `classic` / `elegant` (fidelity CSS + géométrie)
+4. Finir `bold` en réplique validée (checklist visuelle)
+5. Option ultérieure : assets `default_layout.json` par template (voir `docs/editor-vision.md`)
 
 ## Hors scope
 

--- a/frontend/src/components/editor/FreeCanvasBlock.jsx
+++ b/frontend/src/components/editor/FreeCanvasBlock.jsx
@@ -458,6 +458,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
     case 'formations': {
       const items = resolveFormations(cv, limit);
       if (items.length === 0) return <p className="free-canvas-block__placeholder">Formations</p>;
+      const minimalForm = style.formation_style === 'minimal';
       return (
         <div className="free-canvas-block__section-list">
           <SectionHeading
@@ -468,6 +469,55 @@ function SemanticBlockBody({ block, cv, editing = false }) {
           {items.map((f, i) => {
             const idx = findCvArrayIndex(cv, 'formations', f);
             if (idx < 0) return null;
+            if (minimalForm) {
+              const leftLabel = [f.etablissement, f.diplome].filter(Boolean).join(' - ')
+                || f.diplome
+                || f.etablissement
+                || 'Formation';
+              return (
+                <div key={f.id || i} className="free-canvas-block__formation free-canvas-block__formation--minimal">
+                  <div className="free-canvas-block__formation-header">
+                    <span className="free-canvas-block__formation-diplome">
+                      {editing ? (
+                        <>
+                          <CanvasEditableField path={`formations.${idx}.etablissement`} editing>
+                            {f.etablissement || 'Établissement'}
+                          </CanvasEditableField>
+                          {(editing || (f.etablissement && f.diplome)) ? ' - ' : null}
+                          <CanvasEditableField path={`formations.${idx}.diplome`} editing>
+                            {f.diplome || 'Diplôme'}
+                          </CanvasEditableField>
+                        </>
+                      ) : (
+                        leftLabel
+                      )}
+                    </span>
+                    {(editing || f.date) ? (
+                      <span className="free-canvas-block__formation-date">
+                        {editing ? (
+                          <CanvasEditableField path={`formations.${idx}.date`} editing>
+                            {f.date || 'Année'}
+                          </CanvasEditableField>
+                        ) : (
+                          f.date
+                        )}
+                      </span>
+                    ) : null}
+                  </div>
+                  {(editing || (f.mention || '').trim()) ? (
+                    <p className="free-canvas-block__formation-mention">
+                      {editing ? (
+                        <CanvasEditableField path={`formations.${idx}.mention`} editing>
+                          {f.mention || 'Mention'}
+                        </CanvasEditableField>
+                      ) : (
+                        f.mention
+                      )}
+                    </p>
+                  ) : null}
+                </div>
+              );
+            }
             return (
               <p key={f.id || i} className="free-canvas-block__formation-line">
                 {editing ? (
@@ -519,13 +569,16 @@ function SemanticBlockBody({ block, cv, editing = false }) {
             return editing ? (
               <p key={c.id || i}>
                 <CanvasEditableField path={`certifications.${idx}.nom`} editing>{c.nom || 'Nom'}</CanvasEditableField>
-                {' · '}
+                {' - '}
                 <CanvasEditableField path={`certifications.${idx}.organisme`} editing>{c.organisme || 'Organisme'}</CanvasEditableField>
                 {' · '}
                 <CanvasEditableField path={`certifications.${idx}.date`} editing>{c.date || 'Date'}</CanvasEditableField>
               </p>
             ) : (
-              <p key={c.id || i} className="free-canvas-block__sidebar-item">{[c.nom, c.organisme, c.date].filter(Boolean).join(' · ')}</p>
+              <p key={c.id || i} className="free-canvas-block__sidebar-item">
+                {[c.nom, c.organisme].filter(Boolean).join(' - ')}
+                {c.date ? `${c.nom || c.organisme ? ' · ' : ''}${c.date}` : ''}
+              </p>
             );
           })}
         </div>
@@ -559,11 +612,15 @@ function SemanticBlockBody({ block, cv, editing = false }) {
     }
     case 'skills': {
       const items = resolveCompetenceList(cv, bind);
-      if (items.length === 0 && !style.section_label && !style.sidebar_category) {
+      const outils = style.skills_nested_outils
+        ? resolveCompetenceList(cv, 'competences.logiciels')
+        : [];
+      if (items.length === 0 && outils.length === 0 && !style.section_label && !style.sidebar_category) {
         return <p className="free-canvas-block__placeholder">Compétences</p>;
       }
       const chips = format === 'chips';
       const asList = format === 'list' || style.list_format === 'list';
+      const asInline = style.list_format === 'inline' || (!chips && !asList);
       return (
         <div className="free-canvas-block__section-list">
           {style.section_label ? (
@@ -579,14 +636,24 @@ function SemanticBlockBody({ block, cv, editing = false }) {
           ) : asList ? (
             items.map((s, i) => <p key={i} className="free-canvas-block__sidebar-item">{s}</p>)
           ) : (
-            <p>{items.join(', ')}</p>
+            <p className={asInline ? 'free-canvas-block__skills-line' : undefined}>
+              {items.join(', ')}
+            </p>
           )}
+          {outils.length > 0 ? (
+            <p className="free-canvas-block__skills-outils">
+              <strong>Outils :</strong>
+              {' '}
+              {outils.join(', ')}
+            </p>
+          ) : null}
         </div>
       );
     }
     case 'languages': {
       const items = resolveLangues(cv);
       if (items.length === 0) return <p className="free-canvas-block__placeholder">Langues</p>;
+      const asInline = style.list_format === 'inline';
       return (
         <div className="free-canvas-block__section-list">
           <SectionHeading
@@ -594,11 +661,17 @@ function SemanticBlockBody({ block, cv, editing = false }) {
             titleStyle={style.title_style}
             zone={style.zone}
           />
-          {items.map((l, i) => (
-            <p key={i} className="free-canvas-block__sidebar-item">
-              {`${l.langue}${l.niveau ? ` - ${l.niveau}` : ''}`}
+          {asInline ? (
+            <p className="free-canvas-block__skills-line">
+              {items.map((l) => `${l.langue}${l.niveau ? ` (${l.niveau})` : ''}`).join(', ')}
             </p>
-          ))}
+          ) : (
+            items.map((l, i) => (
+              <p key={i} className="free-canvas-block__sidebar-item">
+                {`${l.langue}${l.niveau ? ` - ${l.niveau}` : ''}`}
+              </p>
+            ))
+          )}
         </div>
       );
     }

--- a/frontend/src/components/editor/FreeCanvasBlock.jsx
+++ b/frontend/src/components/editor/FreeCanvasBlock.jsx
@@ -224,6 +224,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
       );
 
       if (style.contact_layout === 'header-bar') {
+        const separator = style.contact_separator != null ? String(style.contact_separator) : ' ';
         const segments = [];
         if (showTel) {
           segments.push(
@@ -256,7 +257,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
           <p className={contactCls}>
             {segments.map((seg, i) => (
               <span key={seg.key}>
-                {i > 0 ? <span className="free-canvas-block__contact-spacer"> </span> : null}
+                {i > 0 ? <span className="free-canvas-block__contact-spacer">{separator}</span> : null}
                 {seg}
               </span>
             ))}
@@ -321,8 +322,10 @@ function SemanticBlockBody({ block, cv, editing = false }) {
       const items = resolveExperiences(cv, limit);
       if (items.length === 0) return <p className="free-canvas-block__placeholder">Expériences</p>;
       const boldExp = style.exp_style === 'bold';
+      const minimalExp = style.exp_style === 'minimal';
+      const atsLabels = boldExp || minimalExp;
       return (
-        <div className={`free-canvas-block__section-list${boldExp ? ' free-canvas-block__section-list--bold-exp' : ''}`}>
+        <div className={`free-canvas-block__section-list${boldExp ? ' free-canvas-block__section-list--bold-exp' : ''}${minimalExp ? ' free-canvas-block__section-list--minimal-exp' : ''}`}>
           <SectionHeading
             label={style.section_label || SECTION_LABELS.experiences}
             titleStyle={style.title_style}
@@ -331,83 +334,121 @@ function SemanticBlockBody({ block, cv, editing = false }) {
           {items.map((exp, i) => {
             const idx = findCvArrayIndex(cv, 'experiences', exp);
             if (idx < 0) return null;
-            const dateParts = [exp.date_debut, exp.date_fin].filter(Boolean).join(' – ');
-            const dateLine = [dateParts, exp.lieu].filter(Boolean).join(' · ');
+            const dateParts = [exp.date_debut, exp.date_fin].filter(Boolean).join(minimalExp ? ' - ' : ' – ');
+            const dateLine = minimalExp
+              ? dateParts
+              : [dateParts, exp.lieu].filter(Boolean).join(' · ');
+            const entrepriseNode = editing ? (
+              <CanvasEditableField path={`experiences.${idx}.entreprise`} editing tag="strong">
+                {exp.entreprise || exp.poste || 'Organisation'}
+              </CanvasEditableField>
+            ) : (
+              <strong>{exp.entreprise || exp.poste}</strong>
+            );
+            const posteNode = editing ? (
+              <CanvasEditableField path={`experiences.${idx}.poste`} editing>
+                {exp.poste || 'Poste'}
+              </CanvasEditableField>
+            ) : (
+              exp.poste
+            );
+            const datesNode = (editing || dateLine) && (
+              <span className="free-canvas-block__exp-dates">
+                {editing ? (
+                  <>
+                    <CanvasEditableField path={`experiences.${idx}.date_debut`} editing>
+                      {exp.date_debut || 'Début'}
+                    </CanvasEditableField>
+                    {minimalExp ? ' - ' : ' – '}
+                    <CanvasEditableField path={`experiences.${idx}.date_fin`} editing>
+                      {exp.date_fin || 'Fin'}
+                    </CanvasEditableField>
+                    {minimalExp ? null : (
+                      <>
+                        {' · '}
+                        <CanvasEditableField path={`experiences.${idx}.lieu`} editing>
+                          {exp.lieu || 'Lieu'}
+                        </CanvasEditableField>
+                      </>
+                    )}
+                  </>
+                ) : (
+                  dateLine
+                )}
+              </span>
+            );
+            const clientsNode = (editing || (exp.clients || '').trim()) ? (
+              <p className="free-canvas-block__exp-clients">
+                Clients :{' '}
+                {editing ? (
+                  <CanvasEditableField path={`experiences.${idx}.clients`} editing>
+                    {exp.clients || 'Clients'}
+                  </CanvasEditableField>
+                ) : (
+                  exp.clients
+                )}
+              </p>
+            ) : null;
+            const bulletsNode = (
+              <ul className={`free-canvas-block__bullets${minimalExp ? ' free-canvas-block__bullets--dash' : ''}`}>
+                {(exp.bullet_points || []).filter((b) => editing || (b || '').trim()).map((b, j) => (
+                  <li key={j}>
+                    {editing ? (
+                      <CanvasEditableField path={`experiences.${idx}.bullet_points.${j}`} editing tag="span">
+                        {(b || '').trim() || 'Point clé'}
+                      </CanvasEditableField>
+                    ) : (
+                      b
+                    )}
+                  </li>
+                ))}
+              </ul>
+            );
             return (
               <div
                 key={exp.id || i}
-                className={`free-canvas-block__exp${format === 'compact' ? ' free-canvas-block__exp--compact' : ''}${boldExp ? ' free-canvas-block__exp--bold' : ''}`}
+                className={`free-canvas-block__exp${format === 'compact' ? ' free-canvas-block__exp--compact' : ''}${boldExp ? ' free-canvas-block__exp--bold' : ''}${minimalExp ? ' free-canvas-block__exp--minimal' : ''}`}
               >
-                <div className="free-canvas-block__exp-header">
-                  <span className="free-canvas-block__exp-entreprise">
-                    {boldExp ? <span className="free-canvas-block__ats-label">Organisation : </span> : null}
-                    {editing ? (
-                      <CanvasEditableField path={`experiences.${idx}.entreprise`} editing tag="strong">
-                        {exp.entreprise || exp.poste || 'Organisation'}
-                      </CanvasEditableField>
-                    ) : (
-                      <strong>{exp.entreprise || exp.poste}</strong>
-                    )}
-                  </span>
-                  {(editing || dateLine) && (
-                    <span className="free-canvas-block__exp-dates">
-                      {editing ? (
-                        <>
-                          <CanvasEditableField path={`experiences.${idx}.date_debut`} editing>
-                            {exp.date_debut || 'Début'}
-                          </CanvasEditableField>
-                          {' – '}
-                          <CanvasEditableField path={`experiences.${idx}.date_fin`} editing>
-                            {exp.date_fin || 'Fin'}
-                          </CanvasEditableField>
-                          {' · '}
-                          <CanvasEditableField path={`experiences.${idx}.lieu`} editing>
-                            {exp.lieu || 'Lieu'}
-                          </CanvasEditableField>
-                        </>
-                      ) : (
-                        dateLine
-                      )}
-                    </span>
-                  )}
-                </div>
-                {(editing || exp.poste) ? (
-                  <p className="free-canvas-block__exp-role">
-                    {boldExp ? <span className="free-canvas-block__ats-label">Fonction : </span> : null}
-                    {editing ? (
-                      <CanvasEditableField path={`experiences.${idx}.poste`} editing>
-                        {exp.poste || 'Poste'}
-                      </CanvasEditableField>
-                    ) : (
-                      exp.poste
-                    )}
-                  </p>
-                ) : null}
-                {(editing || (exp.clients || '').trim()) ? (
-                  <p className="free-canvas-block__exp-clients">
-                    Clients :{' '}
-                    {editing ? (
-                      <CanvasEditableField path={`experiences.${idx}.clients`} editing>
-                        {exp.clients || 'Clients'}
-                      </CanvasEditableField>
-                    ) : (
-                      exp.clients
-                    )}
-                  </p>
-                ) : null}
-                <ul className="free-canvas-block__bullets">
-                  {(exp.bullet_points || []).filter((b) => editing || (b || '').trim()).map((b, j) => (
-                    <li key={j}>
-                      {editing ? (
-                        <CanvasEditableField path={`experiences.${idx}.bullet_points.${j}`} editing tag="span">
-                          {(b || '').trim() || 'Point clé'}
-                        </CanvasEditableField>
-                      ) : (
-                        b
-                      )}
-                    </li>
-                  ))}
-                </ul>
+                {minimalExp ? (
+                  <>
+                    <div className="free-canvas-block__exp-header">
+                      <span className="free-canvas-block__exp-left">
+                        <span className="free-canvas-block__exp-entreprise">
+                          <span className="free-canvas-block__ats-label">Organisation : </span>
+                          {entrepriseNode}
+                        </span>
+                        {(editing || exp.poste) ? (
+                          <span className="free-canvas-block__exp-poste-inline">
+                            {' - '}
+                            <span className="free-canvas-block__ats-label">Fonction : </span>
+                            {posteNode}
+                          </span>
+                        ) : null}
+                      </span>
+                      {datesNode}
+                    </div>
+                    {bulletsNode}
+                    {clientsNode}
+                  </>
+                ) : (
+                  <>
+                    <div className="free-canvas-block__exp-header">
+                      <span className="free-canvas-block__exp-entreprise">
+                        {atsLabels ? <span className="free-canvas-block__ats-label">Organisation : </span> : null}
+                        {entrepriseNode}
+                      </span>
+                      {datesNode}
+                    </div>
+                    {(editing || exp.poste) ? (
+                      <p className="free-canvas-block__exp-role">
+                        {atsLabels ? <span className="free-canvas-block__ats-label">Fonction : </span> : null}
+                        {posteNode}
+                      </p>
+                    ) : null}
+                    {clientsNode}
+                    {bulletsNode}
+                  </>
+                )}
               </div>
             );
           })}

--- a/frontend/src/lib/canvasCvImportAdapter.js
+++ b/frontend/src/lib/canvasCvImportAdapter.js
@@ -839,6 +839,7 @@ export function reorderSemanticBlocksByPriority(layout, cv, analysis, layoutHint
       if (DECORATIVE_TYPES.has(block.type)) continue;
       const zone = block.style?.zone;
       if (zone === 'header') continue;
+      if (block.style?.lock_geometry) continue;
       const lane = blockLane(block);
       if (HEADER_ZONE_TYPES.has(lane)) continue;
       if (!lanes.has(lane)) lanes.set(lane, []);
@@ -878,6 +879,7 @@ export function adaptCanvasLayoutForCv(cv, layout, {
   layoutHints = {},
   fromVision = false,
   forImport = false,
+  preserveReplicaGeometry = false,
 } = {}) {
   const analysis = analyzeCvProfile(cv);
   const recommendedTemplateId = recommendTemplateId(
@@ -899,6 +901,7 @@ export function adaptCanvasLayoutForCv(cv, layout, {
   }
 
   let next = sanitizeLayoutV3(layout);
+  const keepGeometry = Boolean(preserveReplicaGeometry || next.freeform);
   let removedBlockCount = 0;
   let resizedBlockCount = 0;
 
@@ -909,6 +912,7 @@ export function adaptCanvasLayoutForCv(cv, layout, {
         removedBlockCount += 1;
         continue;
       }
+      if (keepGeometry || block.style?.lock_geometry) continue;
       const est = estimateSemanticBlockHeight(block, cv, { respectCurrentMin: false });
       const cur = Number(block.h) || 0;
       if (est > 0 && Math.abs(est - cur) > 1.5) {
@@ -918,16 +922,22 @@ export function adaptCanvasLayoutForCv(cv, layout, {
     }
   }
 
-  if (!fromVision && !forImport) {
+  if (!keepGeometry && !fromVision && !forImport) {
     next = reorderSemanticBlocksByPriority(next, cv, analysis, layoutHints);
   }
 
-  for (let pi = 0; pi < (next.pages?.length || 0); pi += 1) {
-    next = reflowColumnBlocksOnPage(next, pi);
+  if (!keepGeometry) {
+    for (let pi = 0; pi < (next.pages?.length || 0); pi += 1) {
+      next = reflowColumnBlocksOnPage(next, pi);
+    }
   }
 
   next = applyLayoutPagination(next);
   next = applyAtsLayoutOptimizations(next);
+
+  if (keepGeometry) {
+    next = { ...next, freeform: true };
+  }
 
   if (!fromVision && !forImport) {
     const themePatch = inferThemeFromProfile(analysis, layoutHints);
@@ -958,14 +968,20 @@ export function adaptCanvasLayoutForCv(cv, layout, {
 export function buildAdaptedCanvasLayoutForCv(cv, template, options = {}) {
   const base = createCanvasLayoutForTemplate(template);
   const templateId = template?.id || options.templateId || '';
+  const preserveReplicaGeometry = Boolean(
+    options.preserveReplicaGeometry
+    || templateId === 'minimal'
+    || base?.freeform,
+  );
   const result = adaptCanvasLayoutForCv(cv, base, {
     templatesList: options.templatesList,
     templateId,
     layoutHints: options.layoutHints || {},
     forImport: Boolean(options.forImport),
+    preserveReplicaGeometry,
   });
   let layout = result.layout;
-  if (!options.skipAdaptReorder) {
+  if (!options.skipAdaptReorder && !preserveReplicaGeometry) {
     for (let pi = 0; pi < (layout.pages?.length || 0); pi += 1) {
       layout = reflowColumnBlocksOnPage(layout, pi);
     }

--- a/frontend/src/lib/canvasTemplateSpecs.js
+++ b/frontend/src/lib/canvasTemplateSpecs.js
@@ -33,8 +33,10 @@ export const TEMPLATE_CANVAS_FIDELITY = Object.freeze({
     readiness: 'projection',
     fidelityCss: 'medium',
     gaps: [
-      'Pas encore une réplique pixel-perfect du HTML Stable',
+      'Header/contact/titres/exp alignés Stable (tranche 2) — checklist visuelle en cours',
+      'Compétences + Outils nestés (Stable) vs blocs skills séparés',
       'Pagination multi-page / densités CV longs à valider',
+      'Typos injectées (--cv-fs-*) / densités Compact–Confort non projetées',
     ],
   },
   classic: {
@@ -575,23 +577,136 @@ export function buildTemplateBlocks(template) {
     }
 
     case 'minimal': {
-      // Aligné templates/minimal : mono-colonne, pas de barre accent sous le header
-      // (la séparation suit les titres .section-title / title_style: minimal-section).
-      const pad = (28 * 25.4) / 96;
+      // Réplique templates/minimal : mono-colonne, pas de photo (backend force show_photo=false),
+      // contact inline « · », titres Title Case, règle grise sous section (CSS twin).
+      const px = (n) => (n * 25.4) / 96;
+      const pad = px(28);
       const W = PAGE_WIDTH_MM - pad * 2;
-      const photoMm = (52 * 25.4) / 96; // --cv-photo-size 52px
+      const yHeader = px(18);
+      const identityH = px(36);
+      const contactY = yHeader + px(34);
+      const contactH = px(14);
+      // header pad-bottom 8px + body pad-top 6px
+      const yBody = contactY + contactH + px(8) + px(6);
+      const section = (label, extra = {}) => ({
+        ...main(),
+        section_label: label,
+        title_style: 'minimal-section',
+        ...extra,
+      });
       return [
-        { type: 'photo', x: pad, y: (18 * 25.4) / 96, w: photoMm, h: photoMm, z: 2, style: { shape: 'circle', zone: 'main' } },
-        { type: 'identity', bind: ['prenom', 'nom', 'titre_professionnel'], x: pad + photoMm + (14 * 25.4) / 96, y: (18 * 25.4) / 96, w: W - photoMm - (14 * 25.4) / 96, h: 18, z: 2, style: { ...main(), font_size: 18, font_family: t.font_heading, color: t.color_section_title, identity_layout: 'minimal-header' } },
-        { type: 'contact', bind: ['email', 'telephone', 'linkedin'], x: pad + photoMm + (14 * 25.4) / 96, y: (40 * 25.4) / 96, w: W - photoMm - (14 * 25.4) / 96, h: 8, z: 2, style: { ...main(), font_size: 8.5, color: '#4b5563' } },
-        { type: 'resume', bind: 'resume', x: pad, y: (56 * 25.4) / 96, w: W, h: 22, z: 1, style: { ...main(), section_label: 'PROFIL', title_style: 'minimal-section', font_style: 'italic' } },
-        { type: 'experiences', bind: 'experiences', x: pad, y: (82 * 25.4) / 96, w: W, h: 114, z: 1, style: { ...main(), section_label: 'EXPÉRIENCE PROFESSIONNELLE', title_style: 'minimal-section', font_family: t.font_heading } },
-        { type: 'formations', bind: 'formations', x: pad, y: (200 * 25.4) / 96, w: W, h: 28, z: 1, style: { ...main(), section_label: 'FORMATION', title_style: 'minimal-section', font_family: t.font_heading } },
-        { type: 'skills', bind: 'competences.techniques', x: pad, y: (232 * 25.4) / 96, w: W, h: 22, z: 1, style: { ...main(), section_label: 'COMPÉTENCES', title_style: 'minimal-section', list_format: 'list' } },
-        { type: 'skills', bind: 'competences.logiciels', x: pad, y: (258 * 25.4) / 96, w: W, h: 18, z: 1, style: { ...main(), section_label: 'OUTILS', title_style: 'minimal-section', list_format: 'list' } },
-        { type: 'certifications', bind: 'certifications', x: pad, y: (280 * 25.4) / 96, w: W, h: 20, z: 1, style: { ...main(), section_label: 'CERTIFICATIONS', title_style: 'minimal-section', list_format: 'list' } },
-        { type: 'languages', x: pad, y: (304 * 25.4) / 96, w: W, h: 16, z: 1, style: { ...main(), section_label: 'LANGUES', title_style: 'minimal-section', list_format: 'list' } },
-        { type: 'projets', bind: 'projets', x: pad, y: (324 * 25.4) / 96, w: W, h: 22, z: 1, style: { ...main(), section_label: 'PROJETS', title_style: 'minimal-section' } },
+        {
+          type: 'identity',
+          bind: ['prenom', 'nom', 'titre_professionnel'],
+          x: pad,
+          y: yHeader,
+          w: W,
+          h: identityH,
+          z: 2,
+          style: {
+            ...main(),
+            font_size: 18,
+            font_family: t.font_heading,
+            color: t.color_section_title,
+            identity_layout: 'minimal-header',
+          },
+        },
+        {
+          type: 'contact',
+          bind: ['telephone', 'email', 'linkedin'],
+          x: pad,
+          y: contactY,
+          w: W,
+          h: contactH,
+          z: 2,
+          style: {
+            ...main(),
+            font_size: 8.5,
+            color: '#666666',
+            contact_layout: 'header-bar',
+            contact_separator: ' · ',
+            contact_icons: false,
+          },
+        },
+        {
+          type: 'resume',
+          bind: 'resume',
+          x: pad,
+          y: yBody,
+          w: W,
+          h: px(42),
+          z: 1,
+          style: section('Profil', { font_style: 'italic' }),
+        },
+        {
+          type: 'experiences',
+          bind: 'experiences',
+          x: pad,
+          y: yBody + px(48),
+          w: W,
+          h: px(140),
+          z: 1,
+          style: section('Expérience professionnelle', { exp_style: 'minimal' }),
+        },
+        {
+          type: 'formations',
+          bind: 'formations',
+          x: pad,
+          y: yBody + px(194),
+          w: W,
+          h: px(36),
+          z: 1,
+          style: section('Formation'),
+        },
+        {
+          type: 'skills',
+          bind: 'competences.techniques',
+          x: pad,
+          y: yBody + px(236),
+          w: W,
+          h: px(28),
+          z: 1,
+          style: section('Compétences', { list_format: 'list' }),
+        },
+        {
+          type: 'skills',
+          bind: 'competences.logiciels',
+          x: pad,
+          y: yBody + px(268),
+          w: W,
+          h: px(22),
+          z: 1,
+          style: section('Outils', { list_format: 'list' }),
+        },
+        {
+          type: 'certifications',
+          bind: 'certifications',
+          x: pad,
+          y: yBody + px(296),
+          w: W,
+          h: px(24),
+          z: 1,
+          style: section('Certifications', { list_format: 'list' }),
+        },
+        {
+          type: 'languages',
+          x: pad,
+          y: yBody + px(326),
+          w: W,
+          h: px(20),
+          z: 1,
+          style: section('Langues', { list_format: 'list' }),
+        },
+        {
+          type: 'projets',
+          bind: 'projets',
+          x: pad,
+          y: yBody + px(352),
+          w: W,
+          h: px(28),
+          z: 1,
+          style: section('Projets'),
+        },
       ];
     }
 

--- a/frontend/src/lib/canvasTemplateSpecs.js
+++ b/frontend/src/lib/canvasTemplateSpecs.js
@@ -31,12 +31,11 @@ export const TEMPLATE_CANVAS_FIDELITY = Object.freeze({
     name: 'Minimal',
     layoutFamily: 'single-column',
     readiness: 'projection',
-    fidelityCss: 'medium',
+    fidelityCss: 'rich',
     gaps: [
-      'Header/contact/titres/exp alignés Stable (tranche 2) — checklist visuelle en cours',
-      'Compétences + Outils nestés (Stable) vs blocs skills séparés',
-      'Pagination multi-page / densités CV longs à valider',
+      'Checklist visuelle Stable↔Beta en cours (header + page 1)',
       'Typos injectées (--cv-fs-*) / densités Compact–Confort non projetées',
+      'Pagination multi-page CV longs à valider',
     ],
   },
   classic: {
@@ -577,16 +576,16 @@ export function buildTemplateBlocks(template) {
     }
 
     case 'minimal': {
-      // Réplique templates/minimal : mono-colonne, pas de photo (backend force show_photo=false),
-      // contact inline « · », titres Title Case, règle grise sous section (CSS twin).
+      // Réplique templates/minimal : mono-colonne, pas de photo, contact « · »,
+      // titres Title Case, géométrie verrouillée (freeform + lock_geometry).
       const px = (n) => (n * 25.4) / 96;
       const pad = px(28);
       const W = PAGE_WIDTH_MM - pad * 2;
       const yHeader = px(18);
-      const identityH = px(36);
-      const contactY = yHeader + px(34);
+      // name 18pt×1.15 + title 10pt + marges ≈ 32–34px
+      const identityH = px(34);
+      const contactY = yHeader + identityH + px(4);
       const contactH = px(14);
-      // header pad-bottom 8px + body pad-top 6px
       const yBody = contactY + contactH + px(8) + px(6);
       const section = (label, extra = {}) => ({
         ...main(),
@@ -594,6 +593,7 @@ export function buildTemplateBlocks(template) {
         title_style: 'minimal-section',
         ...extra,
       });
+      const headerLock = { lock_geometry: true };
       return [
         {
           type: 'identity',
@@ -605,9 +605,9 @@ export function buildTemplateBlocks(template) {
           z: 2,
           style: {
             ...main(),
-            font_size: 18,
+            ...headerLock,
+            // Pas de font_size/color ici : twin CSS gère (évite inherit !important).
             font_family: t.font_heading,
-            color: t.color_section_title,
             identity_layout: 'minimal-header',
           },
         },
@@ -621,8 +621,7 @@ export function buildTemplateBlocks(template) {
           z: 2,
           style: {
             ...main(),
-            font_size: 8.5,
-            color: '#666666',
+            ...headerLock,
             contact_layout: 'header-bar',
             contact_separator: ' · ',
             contact_icons: false,
@@ -656,7 +655,7 @@ export function buildTemplateBlocks(template) {
           w: W,
           h: px(36),
           z: 1,
-          style: section('Formation'),
+          style: section('Formation', { formation_style: 'minimal' }),
         },
         {
           type: 'skills',
@@ -664,44 +663,37 @@ export function buildTemplateBlocks(template) {
           x: pad,
           y: yBody + px(236),
           w: W,
-          h: px(28),
+          h: px(36),
           z: 1,
-          style: section('Compétences', { list_format: 'list' }),
-        },
-        {
-          type: 'skills',
-          bind: 'competences.logiciels',
-          x: pad,
-          y: yBody + px(268),
-          w: W,
-          h: px(22),
-          z: 1,
-          style: section('Outils', { list_format: 'list' }),
+          style: section('Compétences', {
+            list_format: 'inline',
+            skills_nested_outils: true,
+          }),
         },
         {
           type: 'certifications',
           bind: 'certifications',
           x: pad,
-          y: yBody + px(296),
+          y: yBody + px(278),
           w: W,
           h: px(24),
           z: 1,
-          style: section('Certifications', { list_format: 'list' }),
+          style: section('Certifications', { list_format: 'inline' }),
         },
         {
           type: 'languages',
           x: pad,
-          y: yBody + px(326),
+          y: yBody + px(308),
           w: W,
           h: px(20),
           z: 1,
-          style: section('Langues', { list_format: 'list' }),
+          style: section('Langues', { list_format: 'inline' }),
         },
         {
           type: 'projets',
           bind: 'projets',
           x: pad,
-          y: yBody + px(352),
+          y: yBody + px(334),
           w: W,
           h: px(28),
           z: 1,

--- a/frontend/src/lib/designModeBridge.js
+++ b/frontend/src/lib/designModeBridge.js
@@ -53,6 +53,7 @@ export function applyStableDesignToCanvas(cv, template, options = {}) {
   const result = buildAdaptedCanvasLayoutForCv(cv, template, {
     templatesList: options.templatesList,
     templateId: template.id,
+    preserveReplicaGeometry: true,
   });
   return {
     ok: true,

--- a/frontend/src/lib/layoutReflow.js
+++ b/frontend/src/lib/layoutReflow.js
@@ -25,6 +25,7 @@ const REFLOW_SKIP_TYPES = new Set([
 function laneKey(block) {
   if (!block || REFLOW_SKIP_TYPES.has(block.type) || isVectorShapeType(block.type)) return null;
   if (block.style?.zone === 'header') return null;
+  if (block.style?.lock_geometry) return null;
   if (block.style?.zone) return block.style.zone;
   const x = Number(block.x) || 0;
   if (x > PAGE_WIDTH_MM * 0.62) return 'sidebar';

--- a/frontend/src/lib/layoutTemplatePresets.js
+++ b/frontend/src/lib/layoutTemplatePresets.js
@@ -11,6 +11,10 @@ export function createCanvasLayoutForTemplate(template) {
   const layout = createStarterLayoutV3();
   layout.pages[0].blocks = blocks;
   layout.theme = { ...layout.theme, ...parseCanvasTheme(template) };
+  // Minimal : géométrie mm calquée Stable — ne pas ré-empiler au reflow.
+  if (template.id === 'minimal') {
+    layout.freeform = true;
+  }
   return sanitizeLayoutV3(layout);
 }
 

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -287,6 +287,7 @@
 /* ---------- Minimal (réplique mono-colonne — AXE-346) ---------- */
 .free-canvas-page--tpl-minimal {
   color: #1a1a1a;
+  font-family: Inter, Arial, sans-serif;
 }
 
 .free-canvas-page--tpl-minimal .free-canvas-block__identity--minimal-header .free-canvas-block__identity-name,
@@ -294,37 +295,115 @@
   font-family: var(--free-canvas-font-heading);
   font-size: 18pt;
   font-weight: 700;
-  letter-spacing: -0.02em;
-  color: var(--free-canvas-accent, #111827);
+  letter-spacing: 0;
+  line-height: 1.15;
+  color: var(--free-canvas-section-title, var(--free-canvas-accent, #111827));
+  margin: 0;
 }
 
 .free-canvas-page--tpl-minimal .free-canvas-block__identity .free-canvas-block__identity-title {
   font-size: 10pt;
   font-weight: 400;
-  color: #374151;
-  margin-top: 0.4mm;
+  color: #555555;
+  margin: 0.5mm 0 0;
+  line-height: 1.3;
 }
 
-.free-canvas-page--tpl-minimal .free-canvas-block__contact {
-  color: #4b5563;
+.free-canvas-page--tpl-minimal .free-canvas-block__contact,
+.free-canvas-page--tpl-minimal .free-canvas-block__contact--header-bar {
+  color: #666666;
   font-size: 8.5pt;
+  margin: 0;
+  line-height: 1.35;
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__contact--header-bar .free-canvas-block__contact-spacer {
+  white-space: pre;
 }
 
 .free-canvas-page--tpl-minimal .free-canvas-block__section-title--minimal-section {
   font-family: var(--free-canvas-font-heading);
   font-size: 10.5pt;
   font-weight: 700;
-  color: var(--free-canvas-accent, #111827);
-  border-bottom: 0.35mm solid var(--free-canvas-accent, #111827);
-  padding-bottom: 1mm;
-  margin-bottom: 1.5mm;
+  color: var(--free-canvas-section-title, var(--free-canvas-accent, #111827));
+  border-bottom: 1px solid #d1d5db;
+  padding-bottom: 0.5mm;
+  margin: 0 0 1mm;
   text-transform: none;
-  letter-spacing: 0;
+  letter-spacing: 0.02em;
 }
 
 .free-canvas-page--tpl-minimal .free-canvas-block__resume {
   font-style: italic;
+  font-size: 9pt;
+  line-height: 1.45;
   color: #1a1a1a;
+  text-align: justify;
+  margin: 0;
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__exp--minimal {
+  margin-bottom: 1.6mm;
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__exp--minimal .free-canvas-block__exp-header {
+  align-items: baseline;
+  font-weight: 400;
+  margin-bottom: 0.3mm;
+  gap: 2mm;
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__exp--minimal .free-canvas-block__exp-left {
+  flex: 1;
+  min-width: 0;
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__exp--minimal .free-canvas-block__ats-label {
+  font-weight: 400;
+  font-size: 0.9em;
+  color: #888888;
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__exp--minimal .free-canvas-block__exp-entreprise strong {
+  font-weight: 700;
+  color: #1a1a1a;
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__exp--minimal .free-canvas-block__exp-poste-inline {
+  font-weight: 400;
+  color: #555555;
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__exp--minimal .free-canvas-block__exp-dates {
+  font-weight: 600;
+  font-size: 8.5pt;
+  color: #444444;
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__exp--minimal .free-canvas-block__exp-clients {
+  font-style: italic;
+  font-size: 8pt;
+  color: #666666;
+  margin: 0.8mm 0 0;
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__bullets--dash {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__bullets--dash li {
+  position: relative;
+  padding-left: 0;
+  margin: 0;
+  font-size: 9pt;
+  line-height: 1.35;
+  color: #1a1a1a;
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__bullets--dash li::before {
+  content: '- ';
 }
 
 /* ---------- Élégant ---------- */

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -290,31 +290,40 @@
   font-family: Inter, Arial, sans-serif;
 }
 
+/* Annule le padding défaut des blocs sémantiques (Stable = flux sans inset). */
+.free-canvas-page--tpl-minimal .free-canvas-block__inner {
+  padding: 0;
+}
+
 .free-canvas-page--tpl-minimal .free-canvas-block__identity--minimal-header .free-canvas-block__identity-name,
 .free-canvas-page--tpl-minimal .free-canvas-block__identity .free-canvas-block__identity-name {
-  font-family: var(--free-canvas-font-heading);
-  font-size: 18pt;
-  font-weight: 700;
+  font-family: var(--free-canvas-font-heading) !important;
+  font-size: 18pt !important;
+  font-weight: 700 !important;
   letter-spacing: 0;
   line-height: 1.15;
-  color: var(--free-canvas-section-title, var(--free-canvas-accent, #111827));
+  color: var(--free-canvas-section-title, var(--free-canvas-accent, #111827)) !important;
   margin: 0;
 }
 
 .free-canvas-page--tpl-minimal .free-canvas-block__identity .free-canvas-block__identity-title {
-  font-size: 10pt;
-  font-weight: 400;
-  color: #555555;
+  font-family: Inter, Arial, sans-serif !important;
+  font-size: 10pt !important;
+  font-weight: 400 !important;
+  color: #555555 !important;
   margin: 0.5mm 0 0;
   line-height: 1.3;
+  font-style: normal !important;
+  opacity: 1 !important;
 }
 
 .free-canvas-page--tpl-minimal .free-canvas-block__contact,
 .free-canvas-page--tpl-minimal .free-canvas-block__contact--header-bar {
-  color: #666666;
-  font-size: 8.5pt;
+  color: #666666 !important;
+  font-size: 8.5pt !important;
   margin: 0;
   line-height: 1.35;
+  text-align: left !important;
 }
 
 .free-canvas-page--tpl-minimal .free-canvas-block__contact--header-bar .free-canvas-block__contact-spacer {
@@ -322,22 +331,22 @@
 }
 
 .free-canvas-page--tpl-minimal .free-canvas-block__section-title--minimal-section {
-  font-family: var(--free-canvas-font-heading);
-  font-size: 10.5pt;
-  font-weight: 700;
-  color: var(--free-canvas-section-title, var(--free-canvas-accent, #111827));
-  border-bottom: 1px solid #d1d5db;
+  font-family: var(--free-canvas-font-heading) !important;
+  font-size: 10.5pt !important;
+  font-weight: 700 !important;
+  color: var(--free-canvas-section-title, var(--free-canvas-accent, #111827)) !important;
+  border-bottom: 1px solid #d1d5db !important;
   padding-bottom: 0.5mm;
   margin: 0 0 1mm;
-  text-transform: none;
+  text-transform: none !important;
   letter-spacing: 0.02em;
 }
 
 .free-canvas-page--tpl-minimal .free-canvas-block__resume {
   font-style: italic;
-  font-size: 9pt;
+  font-size: 9pt !important;
   line-height: 1.45;
-  color: #1a1a1a;
+  color: #1a1a1a !important;
   text-align: justify;
   margin: 0;
 }
@@ -376,8 +385,8 @@
 
 .free-canvas-page--tpl-minimal .free-canvas-block__exp--minimal .free-canvas-block__exp-dates {
   font-weight: 600;
-  font-size: 8.5pt;
-  color: #444444;
+  font-size: 8.5pt !important;
+  color: #444444 !important;
 }
 
 .free-canvas-page--tpl-minimal .free-canvas-block__exp--minimal .free-canvas-block__exp-clients {
@@ -397,13 +406,59 @@
   position: relative;
   padding-left: 0;
   margin: 0;
-  font-size: 9pt;
+  font-size: 9pt !important;
   line-height: 1.35;
-  color: #1a1a1a;
+  color: #1a1a1a !important;
 }
 
 .free-canvas-page--tpl-minimal .free-canvas-block__bullets--dash li::before {
   content: '- ';
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__formation--minimal {
+  margin-bottom: 0.8mm;
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__formation--minimal .free-canvas-block__formation-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 2mm;
+  margin: 0;
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__formation--minimal .free-canvas-block__formation-diplome {
+  font-weight: 700;
+  color: #1a1a1a;
+  font-size: 9pt !important;
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__formation--minimal .free-canvas-block__formation-date {
+  font-weight: 600;
+  font-size: 8.5pt !important;
+  color: #444444 !important;
+  white-space: nowrap;
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__formation--minimal .free-canvas-block__formation-mention {
+  font-style: italic;
+  font-size: 8.5pt !important;
+  color: #555555 !important;
+  margin: 0.3mm 0 0;
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__skills-line {
+  font-size: 8.5pt !important;
+  line-height: 1.4;
+  margin: 0 0 0.5mm;
+  color: #333333 !important;
+}
+
+.free-canvas-page--tpl-minimal .free-canvas-block__skills-outils {
+  font-size: 8.5pt !important;
+  line-height: 1.4;
+  margin: 0;
+  color: #333333 !important;
 }
 
 /* ---------- Élégant ---------- */

--- a/frontend/tests/unit/canvasTemplateSpecs.test.js
+++ b/frontend/tests/unit/canvasTemplateSpecs.test.js
@@ -63,8 +63,37 @@ test('minimal n’ajoute plus de barre accent décorative sous le header', () =>
   const blocks = buildTemplateBlocks({ id: 'minimal' });
   const shapes = blocks.filter((b) => b.type === 'shape:rect');
   assert.equal(shapes.length, 0, 'minimal mono-colonne : pas de shape:rect de chrome');
-  assert.ok(blocks.some((b) => b.type === 'photo'));
+  assert.equal(
+    blocks.some((b) => b.type === 'photo'),
+    false,
+    'minimal Stable force show_photo=false : pas de bloc photo',
+  );
   assert.ok(blocks.some((b) => b.style?.title_style === 'minimal-section'));
+});
+
+test('minimal réplique Stable : contact inline ·, titres Title Case, exp ATS', () => {
+  const blocks = buildTemplateBlocks({ id: 'minimal' });
+  const identity = blocks.find((b) => b.type === 'identity');
+  const contact = blocks.find((b) => b.type === 'contact');
+  const experiences = blocks.find((b) => b.type === 'experiences');
+  const resume = blocks.find((b) => b.type === 'resume');
+
+  assert.ok(identity);
+  assert.equal(identity.x, contact.x, 'identity et contact alignés (pas de décalage photo)');
+  assert.equal(contact.style?.contact_layout, 'header-bar');
+  assert.equal(contact.style?.contact_separator, ' · ');
+  assert.equal(contact.style?.contact_icons, false);
+  assert.deepEqual(contact.bind, ['telephone', 'email', 'linkedin']);
+
+  assert.equal(resume.style?.section_label, 'Profil');
+  assert.equal(experiences.style?.section_label, 'Expérience professionnelle');
+  assert.equal(experiences.style?.exp_style, 'minimal');
+
+  const uppercaseTitles = blocks.filter(
+    (b) => typeof b.style?.section_label === 'string' && b.style.section_label === b.style.section_label.toUpperCase()
+      && /[A-ZÀ-Ü]/.test(b.style.section_label),
+  );
+  assert.equal(uppercaseTitles.length, 0, 'titres Title Case comme Stable HTML, pas UPPERCASE');
 });
 
 test('bold reste le plus proche d’une réplique (near-replica)', () => {

--- a/frontend/tests/unit/canvasTemplateSpecs.test.js
+++ b/frontend/tests/unit/canvasTemplateSpecs.test.js
@@ -76,24 +76,36 @@ test('minimal réplique Stable : contact inline ·, titres Title Case, exp ATS',
   const identity = blocks.find((b) => b.type === 'identity');
   const contact = blocks.find((b) => b.type === 'contact');
   const experiences = blocks.find((b) => b.type === 'experiences');
+  const formations = blocks.find((b) => b.type === 'formations');
   const resume = blocks.find((b) => b.type === 'resume');
+  const skills = blocks.filter((b) => b.type === 'skills');
 
   assert.ok(identity);
   assert.equal(identity.x, contact.x, 'identity et contact alignés (pas de décalage photo)');
+  assert.equal(identity.style?.lock_geometry, true);
+  assert.equal(contact.style?.lock_geometry, true);
   assert.equal(contact.style?.contact_layout, 'header-bar');
   assert.equal(contact.style?.contact_separator, ' · ');
   assert.equal(contact.style?.contact_icons, false);
   assert.deepEqual(contact.bind, ['telephone', 'email', 'linkedin']);
+  assert.ok(contact.y >= identity.y + identity.h - 0.01, 'contact sous identity sans overlap');
 
   assert.equal(resume.style?.section_label, 'Profil');
   assert.equal(experiences.style?.section_label, 'Expérience professionnelle');
   assert.equal(experiences.style?.exp_style, 'minimal');
+  assert.equal(formations.style?.formation_style, 'minimal');
+  assert.equal(skills.length, 1, 'un seul bloc Compétences (Outils nestés)');
+  assert.equal(skills[0].style?.skills_nested_outils, true);
+  assert.equal(skills[0].style?.list_format, 'inline');
 
   const uppercaseTitles = blocks.filter(
     (b) => typeof b.style?.section_label === 'string' && b.style.section_label === b.style.section_label.toUpperCase()
       && /[A-ZÀ-Ü]/.test(b.style.section_label),
   );
   assert.equal(uppercaseTitles.length, 0, 'titres Title Case comme Stable HTML, pas UPPERCASE');
+
+  const layout = createCanvasLayoutForTemplate({ id: 'minimal' });
+  assert.equal(layout.freeform, true, 'minimal freeform pour préserver la géométrie Stable');
 });
 
 test('bold reste le plus proche d’une réplique (near-replica)', () => {
@@ -102,4 +114,8 @@ test('bold reste le plus proche d’une réplique (near-replica)', () => {
   const summary = summarizeTemplateCanvasLayout({ id: 'bold' });
   assert.ok(summary.blockCount >= 10);
   assert.ok(summary.zones.includes('header') || summary.zones.includes('sidebar-light'));
+});
+
+test('minimal fidelity CSS marquée rich (twin page 1)', () => {
+  assert.equal(getTemplateCanvasFidelity('minimal')?.fidelityCss, 'rich');
 });


### PR DESCRIPTION
## Summary
- **Tranche 2 AXE-346** : Minimal canvas calqué sur `templates/minimal/` (header sans photo, contact ` · `, titres Title Case, `exp_style: minimal`, CSS twin règle `#d1d5db`)
- Couches documentées dans `docs/template-canvas-fidelity.md`
- Tests structurels renforcés

**Ne pas merger** tant que le Minimal Beta n’est pas un copié visuel OK du Stable (checklist header + page 1).

Fixes AXE-346
Closes #169

## Test plan
- [ ] Apply design Minimal Stable → Beta : **pas de photo**, contact une ligne `tel · email · linkedin`
- [ ] Titres `Profil` / `Expérience professionnelle` (pas UPPERCASE)
- [ ] Exp : `Organisation : X - Fonction : Y` + dates `YYYY - YYYY` (sans lieu)
- [ ] Règle sous titre = gris `#d1d5db` (pas accent noir épais)
- [ ] Comparer pixel/visuel vs preview Stable Minimal (mêmes données)
- [ ] `node --test tests/unit/canvasTemplateSpecs.test.js`


Made with [Cursor](https://cursor.com)