### PR TITLE
Improve: modal DS à la place de window.confirm apply modèle (AXE-387)

### DIFF
--- a/frontend/src/components/editor/EditorCanvaSidebar.jsx
+++ b/frontend/src/components/editor/EditorCanvaSidebar.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   HiArrowUpTray,
   HiArrowsPointingOut,
@@ -42,6 +42,7 @@ import { deleteLayoutProposal, listLayoutProposals } from '../../lib/layoutPropo
 import CanvasIconGlyph from './CanvasIconGlyph.jsx';
 import EditorCanvaPositionDrawer from './EditorCanvaPositionDrawer.jsx';
 import TemplateMiniPreview from './TemplateMiniPreview.jsx';
+import ConfirmDialog from '../ui/ConfirmDialog.jsx';
 import '../../styles/EditorCanvaSidebar.css';
 
 /** Rail principal AXE-31 : 4 familles guidantes. */
@@ -85,13 +86,6 @@ const RAIL_SECTION_IDS = new Set(SECTIONS.map((s) => s.id));
 
 function layoutHasContent(layout) {
   return listAllBlocks(layout).length > 0;
-}
-
-function confirmDestructive(message) {
-  if (typeof window === 'undefined' || typeof window.confirm !== 'function') {
-    return true;
-  }
-  return window.confirm(message);
 }
 
 function ImageHistoryTile({ entry, disabled, onBeginPlacement, onRemove }) {
@@ -232,6 +226,8 @@ export default function EditorCanvaSidebar({
   const [importing, setImporting] = useState(false);
   const [transferSourceKey, setTransferSourceKey] = useState('');
   const [designTab, setDesignTab] = useState('models');
+  /** @type {[null | { title: string, message: string, confirmLabel: string, onConfirm: () => void }, Function]} */
+  const [pendingConfirm, setPendingConfirm] = useState(null);
   const fileInputRef = useRef(null);
 
   const refreshProposals = () => setProposals(listLayoutProposals());
@@ -264,12 +260,21 @@ export default function EditorCanvaSidebar({
     refreshProposals();
   };
 
+  const closeConfirm = () => setPendingConfirm(null);
+
   const handlePickBlankSafe = () => {
     if (layoutHasContent(layout)) {
-      const ok = confirmDestructive(
-        'Remplacer le canvas actuel par une page blanche ? Les blocs présents seront retirés de cette vue (le CV de base n’est pas effacé).',
-      );
-      if (!ok) return;
+      setPendingConfirm({
+        title: 'Page blanche ?',
+        message:
+          'Les blocs présents seront retirés de cette vue (le CV de base n’est pas effacé).',
+        confirmLabel: 'Remplacer',
+        onConfirm: () => {
+          setPendingConfirm(null);
+          onPickBlank?.();
+        },
+      });
+      return;
     }
     onPickBlank?.();
   };
@@ -278,20 +283,33 @@ export default function EditorCanvaSidebar({
     if (!template) return;
     if (layoutHasContent(layout)) {
       const name = template.name || template.id || 'ce modèle';
-      const ok = confirmDestructive(
-        `Appliquer le modèle « ${name} » ? La mise en page actuelle de ce canvas sera remplacée (brouillon local sauvegardé si possible).`,
-      );
-      if (!ok) return;
+      setPendingConfirm({
+        title: `Appliquer « ${name} » ?`,
+        message:
+          'La mise en page actuelle de ce canvas sera remplacée (brouillon local sauvegardé si possible).',
+        confirmLabel: 'Appliquer',
+        onConfirm: () => {
+          setPendingConfirm(null);
+          onApplyCanvasTemplate?.(template);
+        },
+      });
+      return;
     }
     onApplyCanvasTemplate?.(template);
   };
 
   const handleLoadProposalSafe = (proposalLayout) => {
     if (layoutHasContent(layout)) {
-      const ok = confirmDestructive(
-        'Appliquer cette proposition locale ? La mise en page actuelle de ce canvas sera remplacée.',
-      );
-      if (!ok) return;
+      setPendingConfirm({
+        title: 'Appliquer cette proposition ?',
+        message: 'La mise en page actuelle de ce canvas sera remplacée.',
+        confirmLabel: 'Appliquer',
+        onConfirm: () => {
+          setPendingConfirm(null);
+          onLoadProposal?.(proposalLayout);
+        },
+      });
+      return;
     }
     onLoadProposal?.(proposalLayout);
   };
@@ -326,6 +344,7 @@ export default function EditorCanvaSidebar({
   const effectiveDesignTab = openSection === 'models' ? 'models' : designTab;
 
   return (
+    <>
     <aside className={`editor-canva-shell${placementActive ? ' editor-canva-shell--placing' : ''}`} aria-label="Outils canvas">
       {placementActive && (
         <div className="editor-canva-shell__place-hint" role="status">
@@ -758,5 +777,17 @@ export default function EditorCanvaSidebar({
         </div>
       )}
     </aside>
+    <ConfirmDialog
+      open={Boolean(pendingConfirm)}
+      eyebrow="Canvas"
+      title={pendingConfirm?.title || ''}
+      message={pendingConfirm?.message || ''}
+      confirmLabel={pendingConfirm?.confirmLabel || 'Confirmer'}
+      cancelLabel="Annuler"
+      confirmVariant="primary"
+      onCancel={closeConfirm}
+      onConfirm={() => pendingConfirm?.onConfirm?.()}
+    />
+    </>
   );
 }

--- a/frontend/src/components/editor/EditorCanvaSidebar.jsx
+++ b/frontend/src/components/editor/EditorCanvaSidebar.jsx
@@ -260,7 +260,7 @@ export default function EditorCanvaSidebar({
     refreshProposals();
   };
 
-  const closeConfirm = () => setPendingConfirm(null);
+  const closeConfirm = useCallback(() => setPendingConfirm(null), []);
 
   const handlePickBlankSafe = () => {
     if (layoutHasContent(layout)) {

--- a/frontend/src/components/ui/ConfirmDialog.jsx
+++ b/frontend/src/components/ui/ConfirmDialog.jsx
@@ -1,0 +1,116 @@
+import { useEffect, useId, useRef } from 'react';
+
+import Button from './Button.jsx';
+import '../../styles/ConfirmDialog.css';
+
+/**
+ * Dialogue de confirmation design system (remplace `window.confirm`).
+ *
+ * @param {object} props
+ * @param {boolean} props.open
+ * @param {string} props.title
+ * @param {string} [props.message]
+ * @param {string} [props.eyebrow]
+ * @param {string} [props.confirmLabel]
+ * @param {string} [props.cancelLabel]
+ * @param {'primary' | 'danger'} [props.confirmVariant]
+ * @param {() => void} [props.onConfirm]
+ * @param {() => void} [props.onCancel]
+ */
+export default function ConfirmDialog({
+  open = false,
+  title,
+  message = '',
+  eyebrow = '',
+  confirmLabel = 'Confirmer',
+  cancelLabel = 'Annuler',
+  confirmVariant = 'primary',
+  onConfirm,
+  onCancel,
+}) {
+  const titleId = useId();
+  const descriptionId = useId();
+  const cardRef = useRef(null);
+  const previouslyFocusedRef = useRef(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    previouslyFocusedRef.current = document.activeElement;
+    const focusTimer = window.setTimeout(() => {
+      cardRef.current?.querySelector('[data-confirm-primary]')?.focus?.();
+    }, 0);
+    const onKeyDown = (event) => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      event.stopPropagation();
+      onCancel?.();
+    };
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => {
+      window.clearTimeout(focusTimer);
+      document.removeEventListener('keydown', onKeyDown, true);
+      const prev = previouslyFocusedRef.current;
+      if (prev && typeof prev.focus === 'function') {
+        prev.focus();
+      }
+    };
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="confirm-dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={message ? descriptionId : undefined}
+    >
+      <button
+        type="button"
+        className="confirm-dialog__backdrop"
+        aria-label={cancelLabel}
+        onClick={() => onCancel?.()}
+      />
+      <div className="confirm-dialog__card" ref={cardRef}>
+        <header className="confirm-dialog__head">
+          <div>
+            {eyebrow ? (
+              <span className="confirm-dialog__eyebrow ds-label-sm">{eyebrow}</span>
+            ) : null}
+            <h3 id={titleId} className="confirm-dialog__title ds-heading-md">
+              {title}
+            </h3>
+          </div>
+          <button
+            type="button"
+            className="confirm-dialog__close"
+            onClick={() => onCancel?.()}
+            aria-label="Fermer"
+          >
+            ×
+          </button>
+        </header>
+        {message ? (
+          <p id={descriptionId} className="confirm-dialog__copy ds-body-md">
+            {message}
+          </p>
+        ) : null}
+        <footer className="confirm-dialog__actions">
+          <Button type="button" variant="secondary" size="md" onClick={() => onCancel?.()}>
+            {cancelLabel}
+          </Button>
+          <Button
+            type="button"
+            variant={confirmVariant}
+            size="md"
+            data-confirm-primary=""
+            onClick={() => onConfirm?.()}
+          >
+            {confirmLabel}
+          </Button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/ConfirmDialog.jsx
+++ b/frontend/src/components/ui/ConfirmDialog.jsx
@@ -3,6 +3,22 @@ import { useEffect, useId, useRef } from 'react';
 import Button from './Button.jsx';
 import '../../styles/ConfirmDialog.css';
 
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+function listFocusable(container) {
+  if (!container) return [];
+  return Array.from(container.querySelectorAll(FOCUSABLE_SELECTOR)).filter(
+    (el) => !el.hasAttribute('disabled') && el.getAttribute('aria-hidden') !== 'true',
+  );
+}
+
 /**
  * Dialogue de confirmation design system (remplace `window.confirm`).
  *
@@ -39,12 +55,40 @@ export default function ConfirmDialog({
     const focusTimer = window.setTimeout(() => {
       cardRef.current?.querySelector('[data-confirm-primary]')?.focus?.();
     }, 0);
+
     const onKeyDown = (event) => {
-      if (event.key !== 'Escape') return;
-      event.preventDefault();
-      event.stopPropagation();
-      onCancel?.();
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        event.stopPropagation();
+        onCancel?.();
+        return;
+      }
+      if (event.key !== 'Tab') return;
+
+      const focusables = listFocusable(cardRef.current);
+      if (focusables.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement;
+      const inside = cardRef.current?.contains(active);
+
+      if (event.shiftKey) {
+        if (!inside || active === first) {
+          event.preventDefault();
+          last.focus();
+        }
+        return;
+      }
+      if (!inside || active === last) {
+        event.preventDefault();
+        first.focus();
+      }
     };
+
     document.addEventListener('keydown', onKeyDown, true);
     return () => {
       window.clearTimeout(focusTimer);
@@ -66,10 +110,9 @@ export default function ConfirmDialog({
       aria-labelledby={titleId}
       aria-describedby={message ? descriptionId : undefined}
     >
-      <button
-        type="button"
+      <div
         className="confirm-dialog__backdrop"
-        aria-label={cancelLabel}
+        aria-hidden="true"
         onClick={() => onCancel?.()}
       />
       <div className="confirm-dialog__card" ref={cardRef}>

--- a/frontend/src/styles/ConfirmDialog.css
+++ b/frontend/src/styles/ConfirmDialog.css
@@ -13,9 +13,6 @@
 .confirm-dialog__backdrop {
   position: absolute;
   inset: 0;
-  margin: 0;
-  padding: 0;
-  border: 0;
   cursor: pointer;
   background: color-mix(in srgb, var(--ds-color-bg-inverse-alt) 40%, transparent);
 }

--- a/frontend/src/styles/ConfirmDialog.css
+++ b/frontend/src/styles/ConfirmDialog.css
@@ -1,0 +1,85 @@
+/* ConfirmDialog — modal DS (tokens --ds-* uniquement) */
+
+.confirm-dialog {
+  position: fixed;
+  inset: 0;
+  z-index: var(--ds-z-modal);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--ds-space-xl);
+}
+
+.confirm-dialog__backdrop {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  cursor: pointer;
+  background: color-mix(in srgb, var(--ds-color-bg-inverse-alt) 40%, transparent);
+}
+
+.confirm-dialog__card {
+  position: relative;
+  z-index: 1;
+  width: min(26rem, 100%);
+  padding: var(--ds-space-lg);
+  background: var(--ds-color-bg-default);
+  border: 1px solid var(--ds-color-border-default);
+  border-radius: var(--ds-radius-md);
+}
+
+.confirm-dialog__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--ds-space-md);
+}
+
+.confirm-dialog__eyebrow {
+  display: block;
+  margin-bottom: var(--ds-space-xxs);
+  color: var(--ds-color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.confirm-dialog__title {
+  margin: 0;
+  color: var(--ds-color-text-default);
+}
+
+.confirm-dialog__close {
+  flex-shrink: 0;
+  border: 0;
+  background: transparent;
+  color: var(--ds-color-text-muted);
+  font-size: 1.375rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 var(--ds-space-xxs);
+  border-radius: var(--ds-radius-xs);
+}
+
+.confirm-dialog__close:hover {
+  color: var(--ds-color-text-default);
+}
+
+.confirm-dialog__close:focus-visible {
+  outline: 2px solid var(--ds-color-border-focus);
+  outline-offset: 2px;
+}
+
+.confirm-dialog__copy {
+  margin: var(--ds-space-md) 0 0;
+  color: var(--ds-color-text-muted);
+}
+
+.confirm-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: var(--ds-space-sm);
+  margin-top: var(--ds-space-lg);
+}


### PR DESCRIPTION
## Summary
- Nouveau `ConfirmDialog` (tokens `--ds-*`, `<Button>`, Escape/focus, `--ds-z-modal`)
- Remplace les 3 `window.confirm` de `EditorCanvaSidebar` (apply modèle, page blanche, proposition)

Fixes AXE-387
Closes #171

## Test plan
- [ ] Beta → Design → Modèles → appliquer un modèle avec canvas non vide → modal DS (pas dialog navigateur)
- [ ] Annuler / backdrop / Escape ferment sans appliquer
- [ ] Appliquer remplace bien le layout
- [ ] Page blanche + proposition locale : même modal


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Remplacement des confirmations natives par une boîte de dialogue personnalisée et accessible.
  * Ajout de titres, messages et libellés adaptés selon l’action à confirmer.
  * Prise en charge du clavier avec fermeture via Échap et restauration du focus.

* **Améliorations**
  * Les remplacements de pages, modèles et propositions locales nécessitent désormais une confirmation explicite.
  * Interface visuelle harmonisée avec les styles de l’application, incluant les états de survol et de focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->