### PR TITLE
Feat(templates): réplique canvas Beta Élégant (AXE-388)

### DIFF
--- a/docs/template-canvas-fidelity.md
+++ b/docs/template-canvas-fidelity.md
@@ -27,11 +27,11 @@ Le template virtuel `beta` (`betaCanvasTemplate.js`) n’est **pas** une twin HT
 
 | ID | Famille | Readiness | Fidelity CSS | Gaps principaux |
 |----|---------|-----------|--------------|-----------------|
-| `minimal` | single-column | projection | **rich** | Header/contact/exp/formation/compétences calqués ; checklist visuelle Stable↔Beta avant merge |
+| `minimal` | single-column | near-replica | **rich** | Checklist visuelle OK (PR #170) |
 | `classic` | sidebar-right | thin | thin | CSS Stable dense vs twin mince |
 | `modern` | sidebar-left | projection | medium | Sidebar / accents |
 | `creative` | sidebar-left | projection | medium | Titres creative-main |
-| `elegant` | single-column | projection | thin | Chips / centrage |
+| `elegant` | single-column | near-replica | **rich** | Checklist visuelle Stable↔Beta (AXE-388) |
 | `executive` | sidebar-right | projection | medium | Header band |
 | `bold` | sidebar-right | **near-replica** | rich | Écarts typo/exp résiduels |
 
@@ -40,10 +40,16 @@ Source de vérité code : `TEMPLATE_CANVAS_FIDELITY` + `STABLE_CANVAS_TEMPLATE_I
 ### Minimal — couches Stable à calquer
 
 1. **HTML** `templates/minimal/template.html` — structure (header sans photo, contact ` · `, titres Title Case, `Organisation :` / `Fonction :` inline)
-2. **CSS** `templates/minimal/template.css` — pad `18/28/8`, body `6/28/16`, règle `#d1d5db`, typo Georgia/Inter
+2. **CSS** `templates/minimal/template.css` — pad `18/28/8`, body `6/28/16`, rule `#d1d5db`, typo Georgia/Inter
 3. **Options** `meta.json` + `template_registry` — `show_photo=false`, couleurs/font injectées
 4. **Preview overlay** `cvPreviewA4Pages.js` — badge « Page N » (chrome preview, pas du template)
 5. **Canvas** `buildTemplateBlocks('minimal')` + `CanvasTemplateFidelity.css` + `FreeCanvasBlock` (`contact_layout`, `exp_style: minimal`)
+
+### Élégant — couches Stable à calquer (AXE-388)
+
+1. **HTML** `templates/elegant/template.html` — photo centrée, contact ` · `, titres Title Case (+ uppercase CSS), chips techniques+outils, exp ATS (Fonction ligne séparée)
+2. **CSS** `templates/elegant/template.css` — pad `22/30/16`, body `0/30`, filet `#e2e8f0`, chips `#edf2f7` / tools `#e2e8f0`
+3. **Canvas** `buildTemplateBlocks('elegant')` + twin CSS + `exp_style: elegant` + `format: chips` + `skills_nested_outils`
 
 ## Critères de « réplique native »
 
@@ -56,10 +62,10 @@ Pour un id catalogue :
 
 ## Suite chantier
 
-1. ~~Inventaire + contrat tests + premier lift `minimal`~~ (PR #165)
-2. **Tranche 2 `minimal`** : header sans photo, contact ` · `, Title Case, exp ATS inline, règle grise (cette PR — **ne pas merger** tant que la checklist visuelle Stable≠Beta n’est pas OK)
-3. Monter `classic` / `elegant` (fidelity CSS + géométrie)
-4. Finir `bold` en réplique validée (checklist visuelle)
+1. ~~Inventaire + contrat tests + premier lift `minimal`~~ (PR #165 / #170)
+2. ~~Tranche Minimal~~ validée checklist visuelle
+3. **Élégant** (AXE-388) — cette PR ; ne merger que si checklist visuelle OK
+4. Monter `classic` puis finir `bold`
 5. Option ultérieure : assets `default_layout.json` par template (voir `docs/editor-vision.md`)
 
 ## Hors scope

--- a/frontend/src/components/editor/FreeCanvasBlock.jsx
+++ b/frontend/src/components/editor/FreeCanvasBlock.jsx
@@ -225,40 +225,55 @@ function SemanticBlockBody({ block, cv, editing = false }) {
 
       if (style.contact_layout === 'header-bar') {
         const separator = style.contact_separator != null ? String(style.contact_separator) : ' ';
-        const segments = [];
+        /** @type {{ id: string, node: import('react').ReactNode }[]} */
+        const parts = [];
         if (showTel) {
-          segments.push(
-            <span key="tel" className="free-canvas-block__contact-segment">
-              {maybeIcon(HiPhone)}
-              {showIcons ? ' ' : null}
-              {renderContactValue('telephone', tel, 'Téléphone')}
-            </span>,
-          );
+          parts.push({
+            id: 'tel',
+            node: (
+              <>
+                {maybeIcon(HiPhone)}
+                {showIcons ? ' ' : null}
+                {renderContactValue('telephone', tel, 'Téléphone')}
+              </>
+            ),
+          });
         }
         if (showEmail) {
-          segments.push(
-            <span key="email" className="free-canvas-block__contact-segment">
-              {maybeIcon(HiEnvelope)}
-              {showIcons ? ' ' : null}
-              {renderContactValue('email', email, 'Email')}
-            </span>,
-          );
+          parts.push({
+            id: 'email',
+            node: (
+              <>
+                {maybeIcon(HiEnvelope)}
+                {showIcons ? ' ' : null}
+                {renderContactValue('email', email, 'Email')}
+              </>
+            ),
+          });
         }
         if (showLinkedin) {
-          segments.push(
-            <span key="linkedin" className="free-canvas-block__contact-segment">
-              {maybeIcon(HiLink)}
-              {showIcons ? ' ' : null}
-              {renderContactValue('linkedin', linkedin, 'LinkedIn')}
-            </span>,
-          );
+          parts.push({
+            id: 'linkedin',
+            node: (
+              <>
+                {maybeIcon(HiLink)}
+                {showIcons ? ' ' : null}
+                {renderContactValue('linkedin', linkedin, 'LinkedIn')}
+              </>
+            ),
+          });
         }
         return (
-          <p className={contactCls}>
-            {segments.map((seg, i) => (
-              <span key={seg.key}>
+          <p
+            className={contactCls}
+            style={style.align === 'left' || style.align === 'right'
+              ? { justifyContent: style.align === 'right' ? 'flex-end' : 'flex-start' }
+              : undefined}
+          >
+            {parts.map((part, i) => (
+              <span key={part.id}>
                 {i > 0 ? <span className="free-canvas-block__contact-spacer">{separator}</span> : null}
-                {seg}
+                <span className="free-canvas-block__contact-segment">{part.node}</span>
               </span>
             ))}
           </p>

--- a/frontend/src/components/editor/FreeCanvasBlock.jsx
+++ b/frontend/src/components/editor/FreeCanvasBlock.jsx
@@ -321,11 +321,13 @@ function SemanticBlockBody({ block, cv, editing = false }) {
     case 'experiences': {
       const items = resolveExperiences(cv, limit);
       if (items.length === 0) return <p className="free-canvas-block__placeholder">Expériences</p>;
-      const boldExp = style.exp_style === 'bold';
+      const boldExp = style.exp_style === 'bold' || style.exp_style === 'elegant';
+      const elegantExp = style.exp_style === 'elegant';
       const minimalExp = style.exp_style === 'minimal';
       const atsLabels = boldExp || minimalExp;
+      const hyphenDates = minimalExp || elegantExp;
       return (
-        <div className={`free-canvas-block__section-list${boldExp ? ' free-canvas-block__section-list--bold-exp' : ''}${minimalExp ? ' free-canvas-block__section-list--minimal-exp' : ''}`}>
+        <div className={`free-canvas-block__section-list${boldExp ? ' free-canvas-block__section-list--bold-exp' : ''}${minimalExp ? ' free-canvas-block__section-list--minimal-exp' : ''}${elegantExp ? ' free-canvas-block__section-list--elegant-exp' : ''}`}>
           <SectionHeading
             label={style.section_label || SECTION_LABELS.experiences}
             titleStyle={style.title_style}
@@ -334,7 +336,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
           {items.map((exp, i) => {
             const idx = findCvArrayIndex(cv, 'experiences', exp);
             if (idx < 0) return null;
-            const dateParts = [exp.date_debut, exp.date_fin].filter(Boolean).join(minimalExp ? ' - ' : ' – ');
+            const dateParts = [exp.date_debut, exp.date_fin].filter(Boolean).join(hyphenDates ? ' - ' : ' – ');
             const dateLine = minimalExp
               ? dateParts
               : [dateParts, exp.lieu].filter(Boolean).join(' · ');
@@ -359,7 +361,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
                     <CanvasEditableField path={`experiences.${idx}.date_debut`} editing>
                       {exp.date_debut || 'Début'}
                     </CanvasEditableField>
-                    {minimalExp ? ' - ' : ' – '}
+                    {hyphenDates ? ' - ' : ' – '}
                     <CanvasEditableField path={`experiences.${idx}.date_fin`} editing>
                       {exp.date_fin || 'Fin'}
                     </CanvasEditableField>
@@ -390,7 +392,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
               </p>
             ) : null;
             const bulletsNode = (
-              <ul className={`free-canvas-block__bullets${minimalExp ? ' free-canvas-block__bullets--dash' : ''}`}>
+              <ul className={`free-canvas-block__bullets${minimalExp || elegantExp ? ' free-canvas-block__bullets--dash' : ''}`}>
                 {(exp.bullet_points || []).filter((b) => editing || (b || '').trim()).map((b, j) => (
                   <li key={j}>
                     {editing ? (
@@ -407,7 +409,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
             return (
               <div
                 key={exp.id || i}
-                className={`free-canvas-block__exp${format === 'compact' ? ' free-canvas-block__exp--compact' : ''}${boldExp ? ' free-canvas-block__exp--bold' : ''}${minimalExp ? ' free-canvas-block__exp--minimal' : ''}`}
+                className={`free-canvas-block__exp${format === 'compact' ? ' free-canvas-block__exp--compact' : ''}${boldExp ? ' free-canvas-block__exp--bold' : ''}${minimalExp ? ' free-canvas-block__exp--minimal' : ''}${elegantExp ? ' free-canvas-block__exp--elegant' : ''}`}
               >
                 {minimalExp ? (
                   <>
@@ -631,7 +633,10 @@ function SemanticBlockBody({ block, cv, editing = false }) {
           ) : null}
           {chips ? (
             <div className="free-canvas-block__chips">
-              {items.map((s, i) => <span key={i} className="free-canvas-block__chip">{s}</span>)}
+              {items.map((s, i) => <span key={`t-${i}`} className="free-canvas-block__chip">{s}</span>)}
+              {outils.map((s, i) => (
+                <span key={`o-${i}`} className="free-canvas-block__chip free-canvas-block__chip--tool">{s}</span>
+              ))}
             </div>
           ) : asList ? (
             items.map((s, i) => <p key={i} className="free-canvas-block__sidebar-item">{s}</p>)
@@ -640,7 +645,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
               {items.join(', ')}
             </p>
           )}
-          {outils.length > 0 ? (
+          {!chips && outils.length > 0 ? (
             <p className="free-canvas-block__skills-outils">
               <strong>Outils :</strong>
               {' '}

--- a/frontend/src/lib/canvasCvImportAdapter.js
+++ b/frontend/src/lib/canvasCvImportAdapter.js
@@ -748,13 +748,19 @@ function estimateListHeight(count, itemHmm = 4.2, base = 10, max = 80) {
 
 function estimateSkillsHeight(block, cv) {
   const items = resolveCompetenceList(cv, block.bind || 'competences.techniques');
-  if (!items.length) return 0;
+  const outils = block.style?.skills_nested_outils
+    ? resolveCompetenceList(cv, 'competences.logiciels')
+    : [];
+  const total = items.length + outils.length;
+  if (!total) return 0;
   const isChips = block.style?.format === 'chips';
   if (isChips) {
-    const rows = Math.ceil(items.length / 5);
+    const rows = Math.ceil(total / 5);
     return Math.min(55, Math.max(16, 12 + rows * 5.5));
   }
-  return estimateListHeight(items.length, 3.8, 10, 50);
+  // Ligne « Outils : … » si nestés
+  const base = estimateListHeight(items.length, 3.8, 10, 50);
+  return outils.length ? Math.min(60, base + 6) : base;
 }
 
 const SEMANTIC_MIN_HEIGHT_MM = 10;
@@ -806,6 +812,48 @@ function patchBlockHeight(layout, blockId, h) {
     )),
   }));
   return { ...layout, pages };
+}
+
+const REPLICA_CASCADE_GAP_MM = 2.5;
+
+/**
+ * Réplique Stable (freeform) : ajuste h au contenu et empile sans chevauchement,
+ * en respectant `lock_geometry` / photo (header figé).
+ * Ne réordonne PAS les types (contrairement à ATS spatial).
+ */
+export function fitReplicaLayoutToContent(layout, cv) {
+  if (!layout?.pages?.length) return layout;
+  let next = layout;
+  for (let pageIndex = 0; pageIndex < next.pages.length; pageIndex += 1) {
+    const page = next.pages[pageIndex];
+    const blocks = [...(page.blocks || [])];
+    const sorted = [...blocks].sort((a, b) => (Number(a.y) || 0) - (Number(b.y) || 0));
+    let cursorBottom = null;
+    for (const block of sorted) {
+      const locked = Boolean(block.style?.lock_geometry)
+        || block.type === 'photo'
+        || DECORATIVE_TYPES.has(block.type);
+      let h = Number(block.h) || 0;
+      let y = Number(block.y) || 0;
+      if (!locked && !DECORATIVE_TYPES.has(block.type)) {
+        const est = estimateSemanticBlockHeight(block, cv, { respectCurrentMin: true });
+        if (est > 0 && Math.abs(est - h) > 0.8) {
+          h = est;
+          next = patchBlockHeight(next, block.id, h);
+        }
+      }
+      if (!locked && cursorBottom != null) {
+        const minY = cursorBottom + REPLICA_CASCADE_GAP_MM;
+        if (y < minY - 0.05) {
+          y = minY;
+          next = setBlockPosition(next, block.id, { x: Number(block.x) || 0, y });
+        }
+      }
+      const bottom = y + Math.max(h, 0.2);
+      cursorBottom = cursorBottom == null ? bottom : Math.max(cursorBottom, bottom);
+    }
+  }
+  return next;
 }
 
 function blockLane(block) {
@@ -933,10 +981,17 @@ export function adaptCanvasLayoutForCv(cv, layout, {
   }
 
   next = applyLayoutPagination(next);
-  next = applyAtsLayoutOptimizations(next);
-
+  // ATS spatial réordonne identity→contact→photo et casse les répliques Stable
+  // (ex. Élégant : photo centrée au-dessus du nom). Skip si géométrie préservée.
   if (keepGeometry) {
-    next = { ...next, freeform: true };
+    next = fitReplicaLayoutToContent(next, cv);
+    next = {
+      ...next,
+      freeform: true,
+      replica_cascade: true,
+    };
+  } else {
+    next = applyAtsLayoutOptimizations(next);
   }
 
   if (!fromVision && !forImport) {

--- a/frontend/src/lib/canvasCvImportAdapter.js
+++ b/frontend/src/lib/canvasCvImportAdapter.js
@@ -789,7 +789,8 @@ export function estimateSemanticBlockHeight(block, cv, { respectCurrentMin = fal
       if (block.style?.zone === 'header') {
         return Math.min(14, Math.max(10, 8 + chars * 0.06));
       }
-      return Math.max(16, Math.min(52, 12 + chars * 0.22));
+      // Titre section + corps 9pt : ancien 0.22 mm/char gonflait Profil→Expérience.
+      return Math.max(11, Math.min(40, 8 + chars * 0.12));
     }
     case 'experiences':
       return Math.max(floor, estimateExperiencesHeight(cv));

--- a/frontend/src/lib/canvasCvImportAdapter.js
+++ b/frontend/src/lib/canvasCvImportAdapter.js
@@ -649,9 +649,12 @@ export function buildLayoutFromVisionDetection(cv, visionMeta = {}, templatesLis
   layout = applyVisionPhotoShape(layout, visionMeta);
 
   const analysis2 = analyzeCvProfile(cv);
-  layout = reorderSemanticBlocksByPriority(layout, cv, analysis2, mergedHints);
-  for (let pi = 0; pi < (layout.pages?.length || 0); pi += 1) {
-    layout = reflowColumnBlocksOnPage(layout, pi);
+  // Répliques freeform (elegant/minimal) : ne pas réordonner / reflow ATS.
+  if (!layout.freeform) {
+    layout = reorderSemanticBlocksByPriority(layout, cv, analysis2, mergedHints);
+    for (let pi = 0; pi < (layout.pages?.length || 0); pi += 1) {
+      layout = reflowColumnBlocksOnPage(layout, pi);
+    }
   }
   layout = applyLayoutPagination(layout);
 
@@ -814,7 +817,7 @@ function patchBlockHeight(layout, blockId, h) {
   return { ...layout, pages };
 }
 
-const REPLICA_CASCADE_GAP_MM = 2.5;
+const REPLICA_CASCADE_GAP_MM = 1.2;
 
 /**
  * Réplique Stable (freeform) : ajuste h au contenu et empile sans chevauchement,

--- a/frontend/src/lib/canvasCvImportAdapter.js
+++ b/frontend/src/lib/canvasCvImportAdapter.js
@@ -736,17 +736,18 @@ function blockHasRenderableContent(block, cv, analysis) {
 function estimateExperiencesHeight(cv) {
   const exps = resolveExperiences(cv);
   if (!exps.length) return 0;
-  let h = 14;
+  let h = 8; // titre de section
   for (const e of exps) {
     const bullets = (e.bullet_points || []).filter((b) => String(b || '').trim()).length;
-    h += 10 + bullets * 3.8;
+    h += 8 + bullets * 3.2;
   }
-  return Math.min(220, Math.max(28, h));
+  return Math.min(220, Math.max(18, h));
 }
 
-function estimateListHeight(count, itemHmm = 4.2, base = 10, max = 80) {
+function estimateListHeight(count, itemHmm = 4.2, base = 8, max = 80) {
   if (!count) return 0;
-  return Math.min(max, Math.max(14, base + count * itemHmm));
+  // Floor bas : le padding CSS twin + auto-height finalisent la hauteur réelle.
+  return Math.min(max, Math.max(7, base + count * itemHmm));
 }
 
 function estimateSkillsHeight(block, cv) {
@@ -793,13 +794,13 @@ export function estimateSemanticBlockHeight(block, cv, { respectCurrentMin = fal
     case 'experiences':
       return Math.max(floor, estimateExperiencesHeight(cv));
     case 'formations':
-      return Math.max(floor, estimateListHeight(resolveFormations(cv).length, 9, 12, 70));
+      return Math.max(floor, estimateListHeight(resolveFormations(cv).length, 6, 8, 70));
     case 'certifications':
-      return Math.max(floor, estimateListHeight(resolveCertifications(cv).length, 7, 10, 45));
+      return Math.max(floor, estimateListHeight(resolveCertifications(cv).length, 5, 7, 45));
     case 'projets':
-      return Math.max(floor, estimateListHeight(resolveProjets(cv).length, 11, 12, 65));
+      return Math.max(floor, estimateListHeight(resolveProjets(cv).length, 8, 8, 65));
     case 'languages':
-      return Math.max(floor, estimateListHeight(resolveLangues(cv).length, 4.5, 10, 35));
+      return Math.max(floor, estimateListHeight(resolveLangues(cv).length, 4, 7, 35));
     case 'skills':
       return Math.max(floor, estimateSkillsHeight(block, cv));
     default:
@@ -817,7 +818,7 @@ function patchBlockHeight(layout, blockId, h) {
   return { ...layout, pages };
 }
 
-const REPLICA_CASCADE_GAP_MM = 1.2;
+const REPLICA_CASCADE_GAP_MM = 0;
 
 /**
  * Réplique Stable (freeform) : ajuste h au contenu et empile sans chevauchement,
@@ -839,7 +840,8 @@ export function fitReplicaLayoutToContent(layout, cv) {
       let h = Number(block.h) || 0;
       let y = Number(block.y) || 0;
       if (!locked && !DECORATIVE_TYPES.has(block.type)) {
-        const est = estimateSemanticBlockHeight(block, cv, { respectCurrentMin: true });
+        // Shrink to content — les hauteurs preset trop larges créaient des « trous » entre sections.
+        const est = estimateSemanticBlockHeight(block, cv, { respectCurrentMin: false });
         if (est > 0 && Math.abs(est - h) > 0.8) {
           h = est;
           next = patchBlockHeight(next, block.id, h);

--- a/frontend/src/lib/canvasCvImportAdapter.js
+++ b/frontend/src/lib/canvasCvImportAdapter.js
@@ -971,6 +971,7 @@ export function buildAdaptedCanvasLayoutForCv(cv, template, options = {}) {
   const preserveReplicaGeometry = Boolean(
     options.preserveReplicaGeometry
     || templateId === 'minimal'
+    || templateId === 'elegant'
     || base?.freeform,
   );
   const result = adaptCanvasLayoutForCv(cv, base, {

--- a/frontend/src/lib/canvasCvImportAdapter.js
+++ b/frontend/src/lib/canvasCvImportAdapter.js
@@ -986,17 +986,17 @@ export function adaptCanvasLayoutForCv(cv, layout, {
     }
   }
 
-  next = applyLayoutPagination(next);
   // ATS spatial réordonne identity→contact→photo et casse les répliques Stable
   // (ex. Élégant : photo centrée au-dessus du nom). Skip si géométrie préservée.
+  // Cascade verticale uniquement pour les répliques déclarées (`replica_cascade`),
+  // pas pour un freeform PDF multi-colonnes.
   if (keepGeometry) {
-    next = fitReplicaLayoutToContent(next, cv);
-    next = {
-      ...next,
-      freeform: true,
-      replica_cascade: true,
-    };
+    if (next.replica_cascade === true) {
+      next = fitReplicaLayoutToContent(next, cv);
+    }
+    next = applyLayoutPagination(next);
   } else {
+    next = applyLayoutPagination(next);
     next = applyAtsLayoutOptimizations(next);
   }
 

--- a/frontend/src/lib/canvasTemplateSpecs.js
+++ b/frontend/src/lib/canvasTemplateSpecs.js
@@ -710,11 +710,12 @@ export function buildTemplateBlocks(template) {
       const photoSize = ePx(56);
       const yPhoto = ePx(22);
       const yIdentity = yPhoto + photoSize + ePx(8);
-      const identityH = ePx(38);
-      const yContact = yIdentity + identityH + ePx(4);
-      const contactH = ePx(14);
-      const yRule = yContact + contactH + ePx(10);
-      const yBody = yRule + ePx(10);
+      // Name 20pt + title 10.5pt + marges (Stable header) — éviter overflow vers contact
+      const identityH = ePx(48);
+      const yContact = yIdentity + identityH + ePx(2);
+      const contactH = ePx(16);
+      const yRule = yContact + contactH + ePx(6);
+      const yBody = yRule + ePx(6);
       const section = (label, extra = {}) => ({
         ...main(),
         section_label: label,

--- a/frontend/src/lib/canvasTemplateSpecs.js
+++ b/frontend/src/lib/canvasTemplateSpecs.js
@@ -708,14 +708,18 @@ export function buildTemplateBlocks(template) {
       const pad = ePx(30);
       const W = PAGE_WIDTH_MM - pad * 2;
       const photoSize = ePx(56);
+      // Stable .cv-header { padding: 22px 30px 16px }
       const yPhoto = ePx(22);
+      // .header-photo { margin-bottom: 8px }
       const yIdentity = yPhoto + photoSize + ePx(8);
-      // Name 20pt + title 10.5pt + marges (Stable header) — éviter overflow vers contact
-      const identityH = ePx(48);
-      const yContact = yIdentity + identityH + ePx(2);
-      const contactH = ePx(16);
-      const yRule = yContact + contactH + ePx(6);
-      const yBody = yRule + ePx(6);
+      // name ~20pt×1.15 + title mt 4px + 10.5pt×1.3 ≈ 42–44px
+      const identityH = ePx(44);
+      // .header-contact { margin-top: 8px } sous le titre
+      const yContact = yIdentity + identityH + ePx(8);
+      const contactH = ePx(14);
+      // padding-bottom header 16px puis border
+      const yRule = yContact + contactH + ePx(16);
+      const yBody = yRule + ePx(8);
       const section = (label, extra = {}) => ({
         ...main(),
         section_label: label,
@@ -750,7 +754,7 @@ export function buildTemplateBlocks(template) {
           z: 3,
           style: {
             ...main(),
-            ...headerLock,
+            // Pas de lock : auto-height + replica_cascade gardent l’écart Stable sous le titre
             align: 'center',
             font_family: t.font_heading,
             identity_layout: 'elegant-header',
@@ -766,10 +770,10 @@ export function buildTemplateBlocks(template) {
           z: 3,
           style: {
             ...main(),
-            ...headerLock,
             align: 'center',
             contact_layout: 'header-bar',
-            contact_separator: ' · ',
+            // Stable : <span class="contact-sep">·</span> + margin 0 8px
+            contact_separator: '·',
             contact_icons: false,
           },
         },

--- a/frontend/src/lib/canvasTemplateSpecs.js
+++ b/frontend/src/lib/canvasTemplateSpecs.js
@@ -30,10 +30,9 @@ export const TEMPLATE_CANVAS_FIDELITY = Object.freeze({
   minimal: {
     name: 'Minimal',
     layoutFamily: 'single-column',
-    readiness: 'projection',
+    readiness: 'near-replica',
     fidelityCss: 'rich',
     gaps: [
-      'Checklist visuelle Stable↔Beta en cours (header + page 1)',
       'Typos injectées (--cv-fs-*) / densités Compact–Confort non projetées',
       'Pagination multi-page CV longs à valider',
     ],
@@ -65,9 +64,9 @@ export const TEMPLATE_CANVAS_FIDELITY = Object.freeze({
   elegant: {
     name: 'Élégant',
     layoutFamily: 'single-column',
-    readiness: 'projection',
-    fidelityCss: 'thin',
-    gaps: ['Centrage / chips compétences vs HTML Stable'],
+    readiness: 'near-replica',
+    fidelityCss: 'rich',
+    gaps: ['Checklist visuelle Stable↔Beta avant merge'],
   },
   executive: {
     name: 'Executive',
@@ -703,40 +702,155 @@ export function buildTemplateBlocks(template) {
     }
 
     case 'elegant': {
-      const pad = (30 * 25.4) / 96;
+      // Réplique templates/elegant : header centré + photo, titres uppercase via twin CSS,
+      // chips Compétences (+ outils nestés), géométrie verrouillée.
+      const ePx = (n) => (n * 25.4) / 96;
+      const pad = ePx(30);
       const W = PAGE_WIDTH_MM - pad * 2;
-      const cy = (22 * 25.4) / 96;
+      const photoSize = ePx(56);
+      const yPhoto = ePx(22);
+      const yIdentity = yPhoto + photoSize + ePx(8);
+      const identityH = ePx(38);
+      const yContact = yIdentity + identityH + ePx(4);
+      const contactH = ePx(14);
+      const yRule = yContact + contactH + ePx(10);
+      const yBody = yRule + ePx(10);
+      const section = (label, extra = {}) => ({
+        ...main(),
+        section_label: label,
+        title_style: 'elegant-section',
+        ...extra,
+      });
+      const headerLock = { lock_geometry: true };
       return [
-        bar(pad, cy + 52, W, 0.15, '#e2e8f0', 0),
-        { type: 'photo', x: PAGE_WIDTH_MM / 2 - 7, y: cy, w: 14, h: 14, z: 3, style: { shape: 'circle', zone: 'main', photo_border: 'accent-thin' } },
-        { type: 'identity', bind: ['prenom', 'nom', 'titre_professionnel'], x: pad, y: cy + 16, w: W, h: 20, z: 3, style: { ...main(), align: 'center', font_size: 20, font_family: t.font_heading, color: t.color_section_title } },
-        { type: 'contact', bind: ['email', 'telephone', 'linkedin'], x: pad, y: cy + 38, w: W, h: 8, z: 3, style: { ...main(), align: 'center', font_size: 8.5, color: '#64748b' } },
-        { type: 'resume', bind: 'resume', x: pad, y: cy + 56, w: W, h: 22, z: 2, style: { ...main(), section_label: 'PROFIL', title_style: 'elegant-section', font_style: 'italic', color: '#2d3748' } },
-        { type: 'experiences', bind: 'experiences', x: pad, y: cy + 82, w: W, h: 118, z: 1, style: { ...main(), section_label: 'EXPÉRIENCE PROFESSIONNELLE', title_style: 'elegant-section', font_family: t.font_heading, exp_style: 'bold' } },
-        { type: 'formations', bind: 'formations', x: pad, y: cy + 204, w: W, h: 28, z: 1, style: { ...main(), section_label: 'FORMATION', title_style: 'elegant-section', font_family: t.font_heading } },
+        {
+          type: 'photo',
+          x: PAGE_WIDTH_MM / 2 - photoSize / 2,
+          y: yPhoto,
+          w: photoSize,
+          h: photoSize,
+          z: 3,
+          style: {
+            ...headerLock,
+            shape: 'circle',
+            zone: 'main',
+            photo_border: 'accent-thin',
+            image_border_width_mm: (2 * 25.4) / 96,
+            image_border_color: t.color_accent,
+          },
+        },
+        {
+          type: 'identity',
+          bind: ['prenom', 'nom', 'titre_professionnel'],
+          x: pad,
+          y: yIdentity,
+          w: W,
+          h: identityH,
+          z: 3,
+          style: {
+            ...main(),
+            ...headerLock,
+            align: 'center',
+            font_family: t.font_heading,
+            identity_layout: 'elegant-header',
+          },
+        },
+        {
+          type: 'contact',
+          bind: ['telephone', 'email', 'linkedin'],
+          x: pad,
+          y: yContact,
+          w: W,
+          h: contactH,
+          z: 3,
+          style: {
+            ...main(),
+            ...headerLock,
+            align: 'center',
+            contact_layout: 'header-bar',
+            contact_separator: ' · ',
+            contact_icons: false,
+          },
+        },
+        bar(pad, yRule, W, 0.15, '#e2e8f0', 0),
+        {
+          type: 'resume',
+          bind: 'resume',
+          x: pad,
+          y: yBody,
+          w: W,
+          h: ePx(42),
+          z: 2,
+          style: section('Profil', { font_style: 'italic' }),
+        },
+        {
+          type: 'experiences',
+          bind: 'experiences',
+          x: pad,
+          y: yBody + ePx(48),
+          w: W,
+          h: ePx(118),
+          z: 1,
+          style: section('Expérience professionnelle', {
+            font_family: t.font_heading,
+            exp_style: 'elegant',
+          }),
+        },
+        {
+          type: 'formations',
+          bind: 'formations',
+          x: pad,
+          y: yBody + ePx(172),
+          w: W,
+          h: ePx(28),
+          z: 1,
+          style: section('Formation', {
+            font_family: t.font_heading,
+            formation_style: 'minimal',
+          }),
+        },
         {
           type: 'skills',
           bind: 'competences.techniques',
           x: pad,
-          y: cy + 236,
+          y: yBody + ePx(206),
           w: W,
-          h: 28,
+          h: ePx(32),
           z: 1,
-          style: { ...main(), section_label: 'COMPÉTENCES', title_style: 'elegant-section', format: 'chips' },
+          style: section('Compétences', {
+            format: 'chips',
+            skills_nested_outils: true,
+          }),
         },
         {
-          type: 'skills',
-          bind: 'competences.logiciels',
+          type: 'certifications',
+          bind: 'certifications',
           x: pad,
-          y: cy + 268,
+          y: yBody + ePx(244),
           w: W,
-          h: 22,
+          h: ePx(22),
           z: 1,
-          style: { ...main(), section_label: 'OUTILS', title_style: 'elegant-section', format: 'chips' },
+          style: section('Certifications', { list_format: 'list' }),
         },
-        { type: 'certifications', bind: 'certifications', x: pad, y: cy + 294, w: W, h: 22, z: 1, style: { ...main(), section_label: 'CERTIFICATIONS', title_style: 'elegant-section', list_format: 'list' } },
-        { type: 'languages', x: pad, y: cy + 320, w: W, h: 18, z: 1, style: { ...main(), section_label: 'LANGUES', title_style: 'elegant-section', list_format: 'list' } },
-        { type: 'projets', bind: 'projets', x: pad, y: cy + 342, w: W, h: 24, z: 1, style: { ...main(), section_label: 'PROJETS', title_style: 'elegant-section' } },
+        {
+          type: 'languages',
+          x: pad,
+          y: yBody + ePx(272),
+          w: W,
+          h: ePx(18),
+          z: 1,
+          style: section('Langues', { list_format: 'list' }),
+        },
+        {
+          type: 'projets',
+          bind: 'projets',
+          x: pad,
+          y: yBody + ePx(296),
+          w: W,
+          h: ePx(24),
+          z: 1,
+          style: section('Projets'),
+        },
       ];
     }
 

--- a/frontend/src/lib/cvLayoutModelV3.js
+++ b/frontend/src/lib/cvLayoutModelV3.js
@@ -392,6 +392,8 @@ export function sanitizeLayoutV3(input, { idHelpers } = {}) {
   // Layout "libre" (copie fidèle d'un PDF importé) : positions absolues à
   // préserver telles quelles, on ne doit JAMAIS le re-flow en colonnes.
   if (safe.freeform === true) out.freeform = true;
+  // Répliques Stable→Beta : freeform + cascade colonne après auto-height.
+  if (safe.replica_cascade === true) out.replica_cascade = true;
   // Polices embarquées du PDF (@font-face data-URL) : rendu fidèle.
   if (Array.isArray(safe.fonts) && safe.fonts.length) {
     const fonts = safe.fonts

--- a/frontend/src/lib/layoutReflow.js
+++ b/frontend/src/lib/layoutReflow.js
@@ -46,7 +46,9 @@ export function reflowColumnBlocksOnPage(layout, pageIndex = 0) {
   // Import "copie fidèle" : les blocs sont positionnés en absolu d'après le
   // PDF (titre + dates côte à côte, espacements serrés…). Les ré-empiler par
   // colonne casserait tout le rendu → on n'y touche pas.
-  if (layout.freeform === true) return layout;
+  // Exception : répliques Stable (minimal/elegant) avec `replica_cascade` —
+  // auto-height doit pousser les sections suivantes sans chevauchement.
+  if (layout.freeform === true && layout.replica_cascade !== true) return layout;
 
   const blocks = layout.pages[pageIndex].blocks;
   const lanes = new Map();

--- a/frontend/src/lib/layoutReflow.js
+++ b/frontend/src/lib/layoutReflow.js
@@ -25,7 +25,7 @@ const REFLOW_SKIP_TYPES = new Set([
 function laneKey(block) {
   if (!block || REFLOW_SKIP_TYPES.has(block.type) || isVectorShapeType(block.type)) return null;
   if (block.style?.zone === 'header') return null;
-  if (block.style?.lock_geometry) return null;
+  // lock_geometry : reste dans la lane comme ancre (y figé), les suivants poussent.
   if (block.style?.zone) return block.style.zone;
   const x = Number(block.x) || 0;
   if (x > PAGE_WIDTH_MM * 0.62) return 'sidebar';
@@ -34,12 +34,14 @@ function laneKey(block) {
 
 function shouldReflowBlock(block) {
   if (!block || REFLOW_SKIP_TYPES.has(block.type)) return false;
+  if (block.style?.lock_geometry) return true;
   return isAutoHeightBlockType(block.type);
 }
 
 /**
  * Réorganise les blocs d'une page par lane : chaque bloc suit le précédent (y + h + gap).
  * Le premier bloc de chaque lane conserve son y d'origine.
+ * Les blocs `lock_geometry` ne bougent pas mais bloquent la cascade.
  */
 export function reflowColumnBlocksOnPage(layout, pageIndex = 0) {
   if (!layout?.pages?.[pageIndex]?.blocks) return layout;
@@ -70,12 +72,17 @@ export function reflowColumnBlocksOnPage(layout, pageIndex = 0) {
     for (let i = 0; i < sorted.length; i += 1) {
       const b = sorted[i];
       const h = Number(b.h) || 0;
+      const locked = Boolean(b.style?.lock_geometry);
       if (bottom === null) {
         bottom = (Number(b.y) || 0) + h + REFLOW_GAP_MM;
         continue;
       }
-      const minY = bottom;
       const curY = Number(b.y) || 0;
+      if (locked) {
+        bottom = Math.max(bottom, curY + h + REFLOW_GAP_MM);
+        continue;
+      }
+      const minY = bottom;
       const y = curY < minY - 0.05 ? minY : curY;
       if (Math.abs(y - curY) > 0.08) {
         patches.set(b.id, { x: Number(b.x) || 0, y });

--- a/frontend/src/lib/layoutReflow.js
+++ b/frontend/src/lib/layoutReflow.js
@@ -10,6 +10,8 @@ import {
 } from './cvLayoutModelV3.js';
 
 const REFLOW_GAP_MM = 2;
+/** Gap nul pour répliques Stable : le padding CSS `.cv-section` (8px) fait l’écart. */
+const REFLOW_GAP_REPLICA_MM = 0;
 
 import { isVectorShapeType } from './canvasShapePresets.js';
 
@@ -65,6 +67,7 @@ export function reflowColumnBlocksOnPage(layout, pageIndex = 0) {
 
   let next = layout;
   const patches = new Map();
+  const gapMm = layout.replica_cascade === true ? REFLOW_GAP_REPLICA_MM : REFLOW_GAP_MM;
 
   for (const laneBlocks of lanes.values()) {
     const sorted = [...laneBlocks].sort((a, b) => (Number(a.y) || 0) - (Number(b.y) || 0));
@@ -74,12 +77,12 @@ export function reflowColumnBlocksOnPage(layout, pageIndex = 0) {
       const h = Number(b.h) || 0;
       const locked = Boolean(b.style?.lock_geometry);
       if (bottom === null) {
-        bottom = (Number(b.y) || 0) + h + REFLOW_GAP_MM;
+        bottom = (Number(b.y) || 0) + h + gapMm;
         continue;
       }
       const curY = Number(b.y) || 0;
       if (locked) {
-        bottom = Math.max(bottom, curY + h + REFLOW_GAP_MM);
+        bottom = Math.max(bottom, curY + h + gapMm);
         continue;
       }
       const minY = bottom;
@@ -87,7 +90,7 @@ export function reflowColumnBlocksOnPage(layout, pageIndex = 0) {
       if (Math.abs(y - curY) > 0.08) {
         patches.set(b.id, { x: Number(b.x) || 0, y });
       }
-      bottom = y + h + REFLOW_GAP_MM;
+      bottom = y + h + gapMm;
     }
   }
 

--- a/frontend/src/lib/layoutTemplatePresets.js
+++ b/frontend/src/lib/layoutTemplatePresets.js
@@ -11,8 +11,8 @@ export function createCanvasLayoutForTemplate(template) {
   const layout = createStarterLayoutV3();
   layout.pages[0].blocks = blocks;
   layout.theme = { ...layout.theme, ...parseCanvasTheme(template) };
-  // Minimal : géométrie mm calquée Stable — ne pas ré-empiler au reflow.
-  if (template.id === 'minimal') {
+  // Répliques mono-colonne : géométrie mm calquée Stable — ne pas ré-empiler au reflow.
+  if (template.id === 'minimal' || template.id === 'elegant') {
     layout.freeform = true;
   }
   return sanitizeLayoutV3(layout);

--- a/frontend/src/lib/layoutTemplatePresets.js
+++ b/frontend/src/lib/layoutTemplatePresets.js
@@ -11,9 +11,11 @@ export function createCanvasLayoutForTemplate(template) {
   const layout = createStarterLayoutV3();
   layout.pages[0].blocks = blocks;
   layout.theme = { ...layout.theme, ...parseCanvasTheme(template) };
-  // Répliques mono-colonne : géométrie mm calquée Stable — ne pas ré-empiler au reflow.
+  // Répliques mono-colonne : géométrie mm calquée Stable — ne pas ré-empiler au reflow ATS.
+  // `replica_cascade` : autorise le reflow colonne après auto-height (sans toucher lock_geometry).
   if (template.id === 'minimal' || template.id === 'elegant') {
     layout.freeform = true;
+    layout.replica_cascade = true;
   }
   return sanitizeLayoutV3(layout);
 }

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -508,14 +508,19 @@
   color: #718096 !important;
   font-size: 8.5pt !important;
   margin: 0;
-  text-align: center;
   letter-spacing: 0.02em;
   line-height: 1.4 !important;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__contact--header-bar {
+  justify-content: center;
 }
 
 .free-canvas-page--tpl-elegant .free-canvas-block__contact--header-bar .free-canvas-block__contact-spacer {
   white-space: pre;
   color: #cbd5e0;
+  /* Stable .contact-sep { margin: 0 8px } */
+  margin: 0 2mm;
 }
 
 .free-canvas-page--tpl-elegant .free-canvas-block__section-title--elegant-section {
@@ -532,7 +537,8 @@
 }
 
 .free-canvas-page--tpl-elegant .free-canvas-block__section-list {
-  padding: 2.1mm 0;
+  /* Stable .cv-section { padding: 8px 0 } ≈ 2.1mm — un seul côté pour éviter double gap */
+  padding: 1.6mm 0 0.8mm;
   border-bottom: 0.3mm solid #edf2f7;
 }
 

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -535,15 +535,20 @@
   border-bottom: 0;
   letter-spacing: 0.06em !important;
   text-transform: uppercase;
-  margin: 0 0 1.6mm !important;
+  /* Stable .section-title { margin: 0 0 6px } */
+  margin: 0 0 1.59mm !important;
   padding: 0;
   line-height: 1.2 !important;
 }
 
 .free-canvas-page--tpl-elegant .free-canvas-block__section-list {
-  /* Stable .cv-section { padding: 8px 0 } ≈ 2.1mm — un seul côté pour éviter double gap */
-  padding: 1.6mm 0 0.8mm;
-  border-bottom: 0.3mm solid #edf2f7;
+  /* Stable .cv-section { padding: 8px 0 } — blocs adjacents (gap reflow 0) */
+  padding: 2.12mm 0;
+  border-bottom: 0.26mm solid #edf2f7;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__pdf-fidelity-badge {
+  display: none;
 }
 
 .free-canvas-page--tpl-elegant .free-canvas-block__resume {
@@ -557,7 +562,8 @@
 
 .free-canvas-page--tpl-elegant .free-canvas-block__exp--elegant,
 .free-canvas-page--tpl-elegant .free-canvas-block__exp--bold {
-  margin-bottom: 1.6mm;
+  /* Stable .experience-item { margin-bottom: 6px } */
+  margin-bottom: 1.59mm;
 }
 
 .free-canvas-page--tpl-elegant .free-canvas-block__exp--elegant .free-canvas-block__exp-header,

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -487,9 +487,10 @@
   font-weight: 700 !important;
   letter-spacing: 0.04em !important;
   color: var(--free-canvas-accent) !important;
-  line-height: 1.15 !important;
+  line-height: 1.2 !important;
   text-align: center;
   margin: 0;
+  padding: 0;
 }
 
 .free-canvas-page--tpl-elegant .free-canvas-block__identity .free-canvas-block__identity-title {
@@ -498,7 +499,9 @@
   font-weight: 400 !important;
   font-style: italic !important;
   color: #718096 !important;
-  margin: 1mm 0 0 !important;
+  /* Stable .header-titre { margin: 4px 0 0 } */
+  margin: 1.06mm 0 0 !important;
+  padding: 0;
   text-align: center;
   line-height: 1.3 !important;
 }
@@ -519,8 +522,9 @@
 .free-canvas-page--tpl-elegant .free-canvas-block__contact--header-bar .free-canvas-block__contact-spacer {
   white-space: pre;
   color: #cbd5e0;
-  /* Stable .contact-sep { margin: 0 8px } */
-  margin: 0 2mm;
+  /* Stable .contact-sep { margin: 0 8px } — séparateur = « · » seul */
+  margin: 0 2.12mm;
+  padding: 0;
 }
 
 .free-canvas-page--tpl-elegant .free-canvas-block__section-title--elegant-section {

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -547,6 +547,15 @@
   border-bottom: 0.26mm solid #edf2f7;
 }
 
+/* Profil : un peu moins de padding bas pour coller Stable (texte court + section suivante) */
+.free-canvas-page--tpl-elegant .free-canvas-block[data-block-type='resume'] .free-canvas-block__section-list {
+  padding-bottom: 1.06mm;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block[data-block-type='experiences'] .free-canvas-block__section-list {
+  padding-top: 1.06mm;
+}
+
 .free-canvas-page--tpl-elegant .free-canvas-block__pdf-fidelity-badge {
   display: none;
 }

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -461,19 +461,215 @@
   color: #333333 !important;
 }
 
-/* ---------- Élégant ---------- */
+/* ---------- Élégant (réplique templates/elegant) ---------- */
 .free-canvas-page--tpl-elegant {
   color: #2d3748;
+  font-family: Inter, Arial, sans-serif;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__inner {
+  padding: 0;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__photo--border-accent,
+.free-canvas-page--tpl-elegant .free-canvas-block__photo {
+  border-radius: 50%;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__identity--elegant-header {
+  text-align: center;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__identity--elegant-header .free-canvas-block__identity-name,
+.free-canvas-page--tpl-elegant .free-canvas-block__identity .free-canvas-block__identity-name {
+  font-family: var(--free-canvas-font-heading) !important;
+  font-size: 20pt !important;
+  font-weight: 700 !important;
+  letter-spacing: 0.04em !important;
+  color: var(--free-canvas-accent) !important;
+  line-height: 1.15 !important;
+  text-align: center;
+  margin: 0;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__identity .free-canvas-block__identity-title {
+  font-family: var(--free-canvas-font-heading) !important;
+  font-size: 10.5pt !important;
+  font-weight: 400 !important;
+  font-style: italic !important;
+  color: #718096 !important;
+  margin: 1mm 0 0 !important;
+  text-align: center;
+  line-height: 1.3 !important;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__contact,
+.free-canvas-page--tpl-elegant .free-canvas-block__contact--header-bar {
+  color: #718096 !important;
+  font-size: 8.5pt !important;
+  margin: 0;
+  text-align: center;
+  letter-spacing: 0.02em;
+  line-height: 1.4 !important;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__contact--header-bar .free-canvas-block__contact-spacer {
+  white-space: pre;
+  color: #cbd5e0;
 }
 
 .free-canvas-page--tpl-elegant .free-canvas-block__section-title--elegant-section {
-  font-family: var(--free-canvas-font-heading);
-  font-size: 10pt;
-  font-weight: 700;
-  color: var(--free-canvas-accent);
-  border-bottom: 0.3mm solid #e2e8f0;
-  letter-spacing: 0.05em;
+  font-family: var(--free-canvas-font-heading) !important;
+  font-size: 10pt !important;
+  font-weight: 700 !important;
+  color: var(--free-canvas-accent) !important;
+  border-bottom: 0;
+  letter-spacing: 0.06em !important;
   text-transform: uppercase;
+  margin: 0 0 1.6mm !important;
+  padding: 0;
+  line-height: 1.2 !important;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__section-list {
+  padding: 2.1mm 0;
+  border-bottom: 0.3mm solid #edf2f7;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__resume {
+  font-style: italic;
+  font-size: 9pt !important;
+  line-height: 1.5;
+  color: #4a5568 !important;
+  margin: 0;
+  text-align: justify;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__exp--elegant,
+.free-canvas-page--tpl-elegant .free-canvas-block__exp--bold {
+  margin-bottom: 1.6mm;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__exp--elegant .free-canvas-block__exp-header,
+.free-canvas-page--tpl-elegant .free-canvas-block__exp--bold .free-canvas-block__exp-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 2.5mm;
+  margin-bottom: 0.3mm;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__exp--elegant .free-canvas-block__ats-label,
+.free-canvas-page--tpl-elegant .free-canvas-block__exp--bold .free-canvas-block__ats-label {
+  font-weight: 400;
+  font-size: 0.9em;
+  color: #999999;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__exp--elegant .free-canvas-block__exp-entreprise strong,
+.free-canvas-page--tpl-elegant .free-canvas-block__exp--bold .free-canvas-block__exp-entreprise strong {
+  font-weight: 700;
+  color: #1a202c;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__exp--elegant .free-canvas-block__exp-dates,
+.free-canvas-page--tpl-elegant .free-canvas-block__exp--bold .free-canvas-block__exp-dates {
+  font-size: 8.5pt !important;
+  color: var(--free-canvas-accent) !important;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__exp--elegant .free-canvas-block__exp-role,
+.free-canvas-page--tpl-elegant .free-canvas-block__exp--bold .free-canvas-block__exp-role {
+  font-size: 9pt !important;
+  color: #718096 !important;
+  font-style: italic;
+  margin: 0.3mm 0 0.8mm;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__exp--elegant .free-canvas-block__exp-clients,
+.free-canvas-page--tpl-elegant .free-canvas-block__exp--bold .free-canvas-block__exp-clients {
+  font-style: italic;
+  font-size: 8pt;
+  color: #a0aec0;
+  margin: 0.8mm 0 0;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__bullets--dash {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__bullets--dash li {
+  position: relative;
+  padding-left: 2.6mm;
+  margin: 0;
+  font-size: 8.5pt !important;
+  line-height: 1.4;
+  color: #2d3748 !important;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__bullets--dash li::before {
+  content: '-';
+  position: absolute;
+  left: 0;
+  color: var(--free-canvas-accent);
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__formation--minimal {
+  margin-bottom: 0.8mm;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__formation--minimal .free-canvas-block__formation-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 2.5mm;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__formation--minimal .free-canvas-block__formation-diplome {
+  font-weight: 600;
+  font-size: 9pt !important;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__formation--minimal .free-canvas-block__formation-date {
+  font-size: 8.5pt !important;
+  color: var(--free-canvas-accent) !important;
+  white-space: nowrap;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__formation--minimal .free-canvas-block__formation-mention {
+  font-style: italic;
+  font-size: 8.5pt !important;
+  color: #718096 !important;
+  margin: 0;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1mm;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__chip {
+  display: inline-block;
+  padding: 0.5mm 2.1mm;
+  background: #edf2f7;
+  border: 0;
+  border-radius: 3px;
+  font-size: 8pt !important;
+  color: #2d3748 !important;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__chip--tool {
+  background: #e2e8f0;
+}
+
+.free-canvas-page--tpl-elegant .free-canvas-block__sidebar-item {
+  font-size: 8.5pt !important;
+  margin: 0 0 0.5mm;
 }
 
 /* Listes sidebar (pas chips) */

--- a/frontend/src/styles/FreeCanvas.css
+++ b/frontend/src/styles/FreeCanvas.css
@@ -668,15 +668,13 @@
 .free-canvas-block__contact--header-bar {
   display: flex;
   flex-direction: row;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   justify-content: center;
   align-items: baseline;
   gap: 0;
   margin: 0;
-  white-space: nowrap;
   max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  overflow: visible;
 }
 
 .free-canvas-block__contact--header-bar > span {
@@ -684,8 +682,7 @@
   flex-direction: row;
   flex-wrap: nowrap;
   align-items: baseline;
-  flex-shrink: 1;
-  min-width: 0;
+  flex-shrink: 0;
 }
 
 .free-canvas-block__contact-segment {

--- a/frontend/src/styles/FreeCanvas.css
+++ b/frontend/src/styles/FreeCanvas.css
@@ -666,9 +666,36 @@
 }
 
 .free-canvas-block__contact--header-bar {
-  display: block;
-  text-align: center;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: center;
+  align-items: baseline;
+  gap: 0;
   margin: 0;
+  white-space: nowrap;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.free-canvas-block__contact--header-bar > span {
+  display: inline-flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: baseline;
+  flex-shrink: 1;
+  min-width: 0;
+}
+
+.free-canvas-block__contact-segment {
+  display: inline;
+  white-space: nowrap;
+}
+
+.free-canvas-block__contact-spacer {
+  white-space: pre;
+  flex-shrink: 0;
 }
 
 .free-canvas-block__inner--zone-main .free-canvas-block__section-title {

--- a/frontend/src/styles/FreeCanvas.css
+++ b/frontend/src/styles/FreeCanvas.css
@@ -668,7 +668,7 @@
 .free-canvas-block__contact--header-bar {
   display: flex;
   flex-direction: row;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   justify-content: center;
   align-items: baseline;
   gap: 0;

--- a/frontend/tests/unit/canvasCvImportAdapter.test.js
+++ b/frontend/tests/unit/canvasCvImportAdapter.test.js
@@ -303,6 +303,81 @@ test('reflowColumnBlocksOnPage : ne touche pas un layout freeform', () => {
   assert.equal(out.pages[0].blocks[1].y, 50);
 });
 
+test('reflowColumnBlocksOnPage : replica_cascade empile malgré freeform', () => {
+  const layout = {
+    version: 3,
+    format: 'A4',
+    grid: 'free',
+    unit: 'mm',
+    freeform: true,
+    replica_cascade: true,
+    pages: [{
+      id: 'p1',
+      blocks: [
+        { id: 'a', type: 'experiences', bind: 'experiences', x: 8, y: 40, w: 180, h: 40, z: 1, style: { zone: 'main' } },
+        { id: 'b', type: 'formations', bind: 'formations', x: 8, y: 50, w: 180, h: 20, z: 1, style: { zone: 'main' } },
+      ],
+    }],
+    theme: {},
+  };
+  const out = reflowColumnBlocksOnPage(layout, 0);
+  const formations = out.pages[0].blocks.find((b) => b.id === 'b');
+  assert.ok(formations.y >= 80, `formations poussé sous expériences, got y=${formations.y}`);
+});
+
+test('elegant preserveReplicaGeometry : photo au-dessus du nom, pas de restack ATS', () => {
+  const cv = {
+    prenom: 'Louis',
+    nom: 'Vedovato',
+    titre_professionnel: 'Product Owner',
+    telephone: '06',
+    email: 'a@b.fr',
+    resume: 'Stage Product Owner.',
+    experiences: [
+      {
+        entreprise: 'LOUITOS',
+        poste: 'Dirigeant',
+        date_debut: '2022',
+        date_fin: "Aujourd'hui",
+        lieu: 'Cusset',
+        bullet_points: ['Chef'],
+        clients: 'clients',
+      },
+      {
+        entreprise: 'AXEL',
+        poste: 'Président',
+        date_debut: '2024',
+        date_fin: "Aujourd'hui",
+        lieu: 'Cusset',
+        bullet_points: ['Crea'],
+        clients: 'monde',
+      },
+    ],
+    formations: [{ etablissement: 'ESSEC', diplome: 'BBA', date: '2023-2027' }],
+    competences: { techniques: ['Python'], logiciels: ['Notion'], langues: [{ langue: 'Français', niveau: 'Natif' }] },
+    certifications: [{ nom: 'Cert', organisme: 'Org', date: '2026' }],
+    projets: [{ nom: 'CRM', description: 'Desc' }],
+    photo_url: 'https://example.com/p.jpg',
+  };
+  const base = createCanvasLayoutForTemplate({ id: 'elegant' });
+  const { layout } = adaptCanvasLayoutForCv(cv, base, {
+    preserveReplicaGeometry: true,
+    templateId: 'elegant',
+  });
+  assert.equal(layout.freeform, true);
+  assert.equal(layout.replica_cascade, true);
+  const blocks = layout.pages[0].blocks;
+  const photo = blocks.find((b) => b.type === 'photo');
+  const identity = blocks.find((b) => b.type === 'identity');
+  const contact = blocks.find((b) => b.type === 'contact');
+  const experiences = blocks.find((b) => b.type === 'experiences');
+  const formations = blocks.find((b) => b.type === 'formations');
+  assert.ok(photo && identity && contact);
+  assert.ok(photo.y < identity.y, 'photo Stable au-dessus du nom');
+  assert.ok(identity.y < contact.y, 'contact sous identity');
+  assert.ok(experiences.y + experiences.h <= formations.y + 0.05, 'pas de chevauchement exp/formation');
+});
+
 test('reflowColumnBlocksOnPage : empile bien hors freeform (régression du flag)', () => {
   const layout = {
     version: 3,

--- a/frontend/tests/unit/canvasCvImportAdapter.test.js
+++ b/frontend/tests/unit/canvasCvImportAdapter.test.js
@@ -80,6 +80,13 @@ test('estimateSemanticBlockHeight : expériences volumineuses', () => {
   assert.ok(h > 50);
 });
 
+test('estimateSemanticBlockHeight : résumé court reste compact (Profil→Exp)', () => {
+  const cv = { resume: "J'ai fait un stage de 20 mois en tant que Product Owner chez Michelin." };
+  const h = estimateSemanticBlockHeight({ type: 'resume', h: 40, style: { zone: 'main' } }, cv);
+  assert.ok(h < 22, `resume trop haut: ${h}mm`);
+  assert.ok(h >= 11);
+});
+
 test('inferThemeFromProfile : hints accent prioritaire', () => {
   const analysis = analyzeCvProfile(DENSE_CV);
   const theme = inferThemeFromProfile(analysis, { accent_color: '#ff5500' });

--- a/frontend/tests/unit/canvasCvImportAdapter.test.js
+++ b/frontend/tests/unit/canvasCvImportAdapter.test.js
@@ -385,6 +385,39 @@ test('elegant preserveReplicaGeometry : photo au-dessus du nom, pas de restack A
   assert.ok(experiences.y + experiences.h <= formations.y + 0.05, 'pas de chevauchement exp/formation');
 });
 
+test('adaptCanvasLayoutForCv : freeform sans replica_cascade ne cascade pas', () => {
+  const freeformNoCascade = {
+    version: 3,
+    format: 'A4',
+    grid: 'free',
+    unit: 'mm',
+    freeform: true,
+    pages: [{
+      id: 'p1',
+      blocks: [
+        {
+          id: 'exp', type: 'experiences', bind: 'experiences',
+          x: 10, y: 40, w: 90, h: 20, z: 3, style: { zone: 'main' },
+        },
+        {
+          id: 'side', type: 'formations', bind: 'formations',
+          x: 110, y: 40, w: 80, h: 30, z: 3, style: { zone: 'sidebar' },
+        },
+      ],
+    }],
+    theme: {},
+  };
+  const cv = {
+    experiences: [{ entreprise: 'A', poste: 'B', bullet_points: ['x', 'y', 'z'] }],
+    formations: [{ etablissement: 'ESSEC', diplome: 'BBA', date: '2023' }],
+  };
+  const { layout } = adaptCanvasLayoutForCv(cv, freeformNoCascade, { forImport: true });
+  assert.notEqual(layout.replica_cascade, true);
+  const side = layout.pages[0].blocks.find((b) => b.id === 'side');
+  assert.ok(side, 'bloc sidebar conservé');
+  assert.equal(side.y, 40, 'colonne latérale non déplacée par cascade réplique');
+});
+
 test('reflowColumnBlocksOnPage : empile bien hors freeform (régression du flag)', () => {
   const layout = {
     version: 3,

--- a/frontend/tests/unit/canvasTemplateSpecs.test.js
+++ b/frontend/tests/unit/canvasTemplateSpecs.test.js
@@ -119,3 +119,45 @@ test('bold reste le plus proche d’une réplique (near-replica)', () => {
 test('minimal fidelity CSS marquée rich (twin page 1)', () => {
   assert.equal(getTemplateCanvasFidelity('minimal')?.fidelityCss, 'rich');
 });
+
+test('elegant réplique Stable : header centré + photo, chips, freeform', () => {
+  const blocks = buildTemplateBlocks({ id: 'elegant' });
+  const photo = blocks.find((b) => b.type === 'photo');
+  const identity = blocks.find((b) => b.type === 'identity');
+  const contact = blocks.find((b) => b.type === 'contact');
+  const experiences = blocks.find((b) => b.type === 'experiences');
+  const formations = blocks.find((b) => b.type === 'formations');
+  const skills = blocks.filter((b) => b.type === 'skills');
+  const shapes = blocks.filter((b) => b.type === 'shape:rect');
+
+  assert.ok(photo, 'elegant Stable show_photo=true : bloc photo');
+  assert.equal(photo.style?.lock_geometry, true);
+  assert.equal(photo.style?.photo_border, 'accent-thin');
+  assert.ok(Math.abs(photo.x + photo.w / 2 - 105) < 0.5, 'photo centrée A4');
+
+  assert.equal(identity.style?.align, 'center');
+  assert.equal(identity.style?.identity_layout, 'elegant-header');
+  assert.equal(identity.style?.lock_geometry, true);
+  assert.ok(identity.y >= photo.y + photo.h - 0.01, 'identity sous photo');
+
+  assert.equal(contact.style?.contact_layout, 'header-bar');
+  assert.equal(contact.style?.contact_separator, ' · ');
+  assert.equal(contact.style?.align, 'center');
+  assert.deepEqual(contact.bind, ['telephone', 'email', 'linkedin']);
+
+  assert.equal(experiences.style?.exp_style, 'elegant');
+  assert.equal(experiences.style?.section_label, 'Expérience professionnelle');
+  assert.equal(formations.style?.formation_style, 'minimal');
+
+  assert.equal(skills.length, 1, 'un seul bloc Compétences (outils nestés en chips)');
+  assert.equal(skills[0].style?.format, 'chips');
+  assert.equal(skills[0].style?.skills_nested_outils, true);
+
+  assert.equal(shapes.length, 1, 'filet header uniquement');
+  assert.ok(blocks.every((b) => b.type !== 'skills' || b.style?.section_label !== 'OUTILS'));
+
+  const layout = createCanvasLayoutForTemplate({ id: 'elegant' });
+  assert.equal(layout.freeform, true);
+  assert.equal(getTemplateCanvasFidelity('elegant')?.fidelityCss, 'rich');
+  assert.equal(getTemplateCanvasFidelity('elegant')?.readiness, 'near-replica');
+});

--- a/frontend/tests/unit/canvasTemplateSpecs.test.js
+++ b/frontend/tests/unit/canvasTemplateSpecs.test.js
@@ -137,12 +137,12 @@ test('elegant réplique Stable : header centré + photo, chips, freeform', () =>
 
   assert.equal(identity.style?.align, 'center');
   assert.equal(identity.style?.identity_layout, 'elegant-header');
-  assert.equal(identity.style?.lock_geometry, true);
   assert.ok(identity.y >= photo.y + photo.h - 0.01, 'identity sous photo');
 
   assert.equal(contact.style?.contact_layout, 'header-bar');
-  assert.equal(contact.style?.contact_separator, ' · ');
+  assert.equal(contact.style?.contact_separator, '·');
   assert.equal(contact.style?.align, 'center');
+  assert.ok(contact.y >= identity.y + identity.h - 0.01, 'contact sous identity');
   assert.deepEqual(contact.bind, ['telephone', 'email', 'linkedin']);
 
   assert.equal(experiences.style?.exp_style, 'elegant');

--- a/frontend/tests/unit/canvasTemplateSpecs.test.js
+++ b/frontend/tests/unit/canvasTemplateSpecs.test.js
@@ -158,6 +158,7 @@ test('elegant réplique Stable : header centré + photo, chips, freeform', () =>
 
   const layout = createCanvasLayoutForTemplate({ id: 'elegant' });
   assert.equal(layout.freeform, true);
+  assert.equal(layout.replica_cascade, true);
   assert.equal(getTemplateCanvasFidelity('elegant')?.fidelityCss, 'rich');
   assert.equal(getTemplateCanvasFidelity('elegant')?.readiness, 'near-replica');
 });


### PR DESCRIPTION
## Summary
- Réplique native Stable→Beta du template **Élégant** (header centré + photo, contact ` · `, chips compétences/outils, `freeform` + `lock_geometry`)
- Twin CSS riche + `exp_style: elegant` ; suite de [AXE-346](https://linear.app/axel-project/issue/AXE-346) / Minimal PR #170
- Linear [AXE-388](https://linear.app/axel-project/issue/AXE-388) · GitHub #173

## Test plan
- [ ] Apply modèle **Élégant** en Beta → comparer page 1 vs preview Stable
- [ ] Photo centrée + bordure accent ; titres uppercase ; chips techniques vs outils
- [ ] Expériences : Organisation / Fonction ATS, dates ` - `, bullets `-`
- [ ] Re-apply / reflow ne casse pas la géométrie header
- [ ] `npm run test:unit -- tests/unit/canvasTemplateSpecs.test.js`

**Ne pas merger** tant que la checklist visuelle Stable↔Beta n’est pas OK.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Amélioration majeure du modèle Élégant dans l’éditeur Canvas.
  * Ajout d’une mise en page mono-colonne avec en-tête centré, photo agrandie, contacts intégrés et séparateur visuel.
  * Affichage enrichi des expériences, formations et sections avec une typographie plus fidèle.
  * Présentation des compétences et outils sous forme de puces distinctes.
* **Améliorations**
  * Préservation de la géométrie des modèles répliqués lors de l’importation et de la mise en page des CV.
  * Réduction des chevauchements et amélioration de l’espacement des blocs.
* **Documentation**
  * Suivi de fidélité des modèles Minimal et Élégant mis à jour, désormais quasi identiques aux références.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->