### PR TITLE
Fix(templates): contact Minimal à gauche (align header-bar)

### DIFF
--- a/docs/template-canvas-fidelity.md
+++ b/docs/template-canvas-fidelity.md
@@ -31,7 +31,7 @@ Le template virtuel `beta` (`betaCanvasTemplate.js`) n’est **pas** une twin HT
 | `classic` | sidebar-right | thin | thin | CSS Stable dense vs twin mince |
 | `modern` | sidebar-left | projection | medium | Sidebar / accents |
 | `creative` | sidebar-left | projection | medium | Titres creative-main |
-| `elegant` | single-column | near-replica | **rich** | Checklist visuelle Stable↔Beta (AXE-388) |
+| `elegant` | single-column | near-replica | **rich** | Checklist visuelle OK (PR #174 / AXE-388) |
 | `executive` | sidebar-right | projection | medium | Header band |
 | `bold` | sidebar-right | **near-replica** | rich | Écarts typo/exp résiduels |
 
@@ -64,9 +64,14 @@ Pour un id catalogue :
 
 1. ~~Inventaire + contrat tests + premier lift `minimal`~~ (PR #165 / #170)
 2. ~~Tranche Minimal~~ validée checklist visuelle
-3. **Élégant** (AXE-388) — cette PR ; ne merger que si checklist visuelle OK
-4. Monter `classic` puis finir `bold`
-5. Option ultérieure : assets `default_layout.json` par template (voir `docs/editor-vision.md`)
+3. ~~Élégant~~ (AXE-388 / PR #174) — near-replica
+4. **Classic** (sidebar-right) — prochain twin
+5. Finir `bold` (écarts typo/exp résiduels)
+6. Option ultérieure : assets `default_layout.json` par template (voir `docs/editor-vision.md`)
+
+## Alignement contact header-bar
+
+Le bloc contact `header-bar` est **gauche par défaut**. Le centrage est opt-in via `style.align: 'center'` (+ classe `--align-center`) — Élégant / Bold. Ne pas remettre `justify-content: center` sur le sélecteur global `.free-canvas-block__contact--header-bar`.
 
 ## Hors scope
 

--- a/frontend/src/components/editor/FreeCanvasBlock.jsx
+++ b/frontend/src/components/editor/FreeCanvasBlock.jsx
@@ -204,12 +204,18 @@ function SemanticBlockBody({ block, cv, editing = false }) {
       const email = showEmail ? getFieldDisplayValue(cv, 'email') : '';
       const linkedin = showLinkedin ? getFieldDisplayValue(cv, 'linkedin') : '';
       const showIcons = Boolean(style.contact_icons);
+      // Alignement explicite : défaut gauche (Minimal). Élégant/Bold = center via style.align.
+      // Évite qu’un justify-content global centre tous les header-bar.
+      const contactAlign = style.align === 'center' || style.align === 'right' || style.align === 'left'
+        ? style.align
+        : 'left';
       const contactCls = [
         'free-canvas-block__contact',
         style.contact_divider ? 'free-canvas-block__contact--divider' : '',
         style.contact_uppercase ? 'free-canvas-block__contact--uppercase' : '',
         showIcons ? 'free-canvas-block__contact--icons' : '',
         style.contact_layout === 'header-bar' ? 'free-canvas-block__contact--header-bar' : '',
+        style.contact_layout === 'header-bar' ? `free-canvas-block__contact--align-${contactAlign}` : '',
       ].filter(Boolean).join(' ');
 
       const renderContactValue = (path, value, placeholder) => {
@@ -266,9 +272,14 @@ function SemanticBlockBody({ block, cv, editing = false }) {
         return (
           <p
             className={contactCls}
-            style={style.align === 'left' || style.align === 'right'
-              ? { justifyContent: style.align === 'right' ? 'flex-end' : 'flex-start' }
-              : undefined}
+            style={{
+              justifyContent: contactAlign === 'right'
+                ? 'flex-end'
+                : contactAlign === 'center'
+                  ? 'center'
+                  : 'flex-start',
+              textAlign: contactAlign,
+            }}
           >
             {parts.map((part, i) => (
               <span key={part.id}>

--- a/frontend/src/lib/canvasTemplateSpecs.js
+++ b/frontend/src/lib/canvasTemplateSpecs.js
@@ -456,6 +456,7 @@ export function buildTemplateBlocks(template) {
           z: 5,
           style: {
             ...hdr(),
+            align: 'center',
             contact_layout: 'header-bar',
             font_size: 8.5,
             contact_icons: true,
@@ -621,6 +622,7 @@ export function buildTemplateBlocks(template) {
           style: {
             ...main(),
             ...headerLock,
+            align: 'left',
             contact_layout: 'header-bar',
             contact_separator: ' · ',
             contact_icons: false,

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -213,6 +213,7 @@
 
 .free-canvas-page--tpl-bold .free-canvas-block__contact--header-bar {
   text-align: center;
+  justify-content: center;
   margin: 0;
   color: rgba(255, 255, 255, 0.75);
 }
@@ -324,6 +325,7 @@
   margin: 0;
   line-height: 1.35;
   text-align: left !important;
+  justify-content: flex-start !important;
 }
 
 .free-canvas-page--tpl-minimal .free-canvas-block__contact--header-bar .free-canvas-block__contact-spacer {

--- a/frontend/src/styles/FreeCanvas.css
+++ b/frontend/src/styles/FreeCanvas.css
@@ -669,12 +669,24 @@
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
-  justify-content: center;
+  /* Défaut gauche — le centrage est opt-in (Élégant/Bold via --align-center). */
+  justify-content: flex-start;
   align-items: baseline;
   gap: 0;
   margin: 0;
   max-width: 100%;
   overflow: visible;
+  text-align: left;
+}
+
+.free-canvas-block__contact--header-bar.free-canvas-block__contact--align-center {
+  justify-content: center;
+  text-align: center;
+}
+
+.free-canvas-block__contact--header-bar.free-canvas-block__contact--align-right {
+  justify-content: flex-end;
+  text-align: right;
 }
 
 .free-canvas-block__contact--header-bar > span {

--- a/frontend/tests/unit/canvasTemplateSpecs.test.js
+++ b/frontend/tests/unit/canvasTemplateSpecs.test.js
@@ -85,6 +85,7 @@ test('minimal réplique Stable : contact inline ·, titres Title Case, exp ATS',
   assert.equal(identity.style?.lock_geometry, true);
   assert.equal(contact.style?.lock_geometry, true);
   assert.equal(contact.style?.contact_layout, 'header-bar');
+  assert.equal(contact.style?.align, 'left', 'Minimal : contact à gauche (pas center Élégant)');
   assert.equal(contact.style?.contact_separator, ' · ');
   assert.equal(contact.style?.contact_icons, false);
   assert.deepEqual(contact.bind, ['telephone', 'email', 'linkedin']);


### PR DESCRIPTION
## Summary
- Régression : `justify-content: center` global sur `.contact--header-bar` centrait Minimal.
- Défaut **gauche** ; centrage opt-in (`style.align: 'center'` + `--align-center`) pour Élégant/Bold.
- Housekeeping doc matrice (Élégant Done) + note anti-régression.

## Test plan
- [ ] Minimal : contact sous le titre, aligné à gauche
- [ ] Élégant : contact toujours centré
- [ ] `npm run test:unit` (canvasTemplateSpecs)


Made with [Cursor](https://cursor.com)