### PR TITLE
Feat(templates): réplique canvas Beta Classic (AXE-389)

### DIFF
--- a/docs/template-canvas-fidelity.md
+++ b/docs/template-canvas-fidelity.md
@@ -28,7 +28,7 @@ Le template virtuel `beta` (`betaCanvasTemplate.js`) n’est **pas** une twin HT
 | ID | Famille | Readiness | Fidelity CSS | Gaps principaux |
 |----|---------|-----------|--------------|-----------------|
 | `minimal` | single-column | near-replica | **rich** | Checklist visuelle OK (PR #170) |
-| `classic` | sidebar-right | near-replica | **rich** | Checklist visuelle (AXE-389) |
+| `classic` | sidebar-right | near-replica | **rich** | Checklist visuelle + densité PDF (AXE-389 / PR #177) |
 | `modern` | sidebar-left | projection | medium | Sidebar / accents |
 | `creative` | sidebar-left | projection | medium | Titres creative-main |
 | `elegant` | single-column | near-replica | **rich** | Checklist visuelle OK (PR #174 / AXE-388) |
@@ -71,13 +71,17 @@ Pour un id catalogue :
 1. ~~Inventaire + contrat tests + premier lift `minimal`~~ (PR #165 / #170)
 2. ~~Tranche Minimal~~ validée checklist visuelle
 3. ~~Élégant~~ (AXE-388 / PR #174) — near-replica
-4. **Classic** (sidebar-right) — prochain twin
+4. ~~Classic~~ (AXE-389 / PR #177) — near-replica ; checklist visuelle + densité PDF à valider
 5. Finir `bold` (écarts typo/exp résiduels)
 6. Option ultérieure : assets `default_layout.json` par template (voir `docs/editor-vision.md`)
 
 ## Alignement contact header-bar
 
-Le bloc contact `header-bar` est **gauche par défaut**. Le centrage est opt-in via `style.align: 'center'` (+ classe `--align-center`) — Élégant / Bold. Ne pas remettre `justify-content: center` sur le sélecteur global `.free-canvas-block__contact--header-bar`.
+Le bloc contact `header-bar` est **gauche par défaut**. Le centrage est opt-in via `style.align: 'center'` (+ classe `--align-center`) — Classic / Élégant / Bold. Ne pas remettre `justify-content: center` sur le sélecteur global `.free-canvas-block__contact--header-bar`.
+
+## Twin CSS vs design system app
+
+`CanvasTemplateFidelity.css` calque volontairement les couleurs / graisses Stable (`templates/*/template.css`) — hex et `font-weight` 600/700 inclus. Ce n’est pas du chrome produit : la règle `--ds-*` / poids 400–500 s’applique à l’UI éditeur, pas aux répliques CV.
 
 ## Hors scope
 

--- a/docs/template-canvas-fidelity.md
+++ b/docs/template-canvas-fidelity.md
@@ -28,7 +28,7 @@ Le template virtuel `beta` (`betaCanvasTemplate.js`) n’est **pas** une twin HT
 | ID | Famille | Readiness | Fidelity CSS | Gaps principaux |
 |----|---------|-----------|--------------|-----------------|
 | `minimal` | single-column | near-replica | **rich** | Checklist visuelle OK (PR #170) |
-| `classic` | sidebar-right | thin | thin | CSS Stable dense vs twin mince |
+| `classic` | sidebar-right | near-replica | **rich** | Checklist visuelle (AXE-389) |
 | `modern` | sidebar-left | projection | medium | Sidebar / accents |
 | `creative` | sidebar-left | projection | medium | Titres creative-main |
 | `elegant` | single-column | near-replica | **rich** | Checklist visuelle OK (PR #174 / AXE-388) |
@@ -50,6 +50,12 @@ Source de vérité code : `TEMPLATE_CANVAS_FIDELITY` + `STABLE_CANVAS_TEMPLATE_I
 1. **HTML** `templates/elegant/template.html` — photo centrée, contact ` · `, titres Title Case (+ uppercase CSS), chips techniques+outils, exp ATS (Fonction ligne séparée)
 2. **CSS** `templates/elegant/template.css` — pad `22/30/16`, body `0/30`, filet `#e2e8f0`, chips `#edf2f7` / tools `#e2e8f0`
 3. **Canvas** `buildTemplateBlocks('elegant')` + twin CSS + `exp_style: elegant` + `format: chips` + `skills_nested_outils`
+
+### Classique — couches Stable à calquer (AXE-389)
+
+1. **HTML** `templates/classic/template.html` — header sombre (photo + nom/titre inline, résumé, contact icônes centré), main (exp/formation/projets), sidebar droite compétences
+2. **CSS** `templates/classic/template.css` — pad header `12/16`, photo 52px, sidebar 200px, titres uppercase + filet accent
+3. **Canvas** `buildTemplateBlocks('classic')` + twin CSS + `exp_style: classic` + `freeform` / `replica_cascade`
 
 ## Critères de « réplique native »
 

--- a/docs/template-canvas-fidelity.md
+++ b/docs/template-canvas-fidelity.md
@@ -31,7 +31,7 @@ Le template virtuel `beta` (`betaCanvasTemplate.js`) n’est **pas** une twin HT
 | `classic` | sidebar-right | thin | thin | CSS Stable dense vs twin mince |
 | `modern` | sidebar-left | projection | medium | Sidebar / accents |
 | `creative` | sidebar-left | projection | medium | Titres creative-main |
-| `elegant` | single-column | near-replica | **rich** | Checklist visuelle Stable↔Beta (AXE-388) |
+| `elegant` | single-column | near-replica | **rich** | Checklist visuelle OK (PR #174 / AXE-388) |
 | `executive` | sidebar-right | projection | medium | Header band |
 | `bold` | sidebar-right | **near-replica** | rich | Écarts typo/exp résiduels |
 
@@ -64,9 +64,14 @@ Pour un id catalogue :
 
 1. ~~Inventaire + contrat tests + premier lift `minimal`~~ (PR #165 / #170)
 2. ~~Tranche Minimal~~ validée checklist visuelle
-3. **Élégant** (AXE-388) — cette PR ; ne merger que si checklist visuelle OK
-4. Monter `classic` puis finir `bold`
-5. Option ultérieure : assets `default_layout.json` par template (voir `docs/editor-vision.md`)
+3. ~~Élégant~~ (AXE-388 / PR #174) — near-replica
+4. **Classic** (sidebar-right) — prochain twin
+5. Finir `bold` (écarts typo/exp résiduels)
+6. Option ultérieure : assets `default_layout.json` par template (voir `docs/editor-vision.md`)
+
+## Alignement contact header-bar
+
+Le bloc contact `header-bar` est **gauche par défaut**. Le centrage est opt-in via `style.align: 'center'` (+ classe `--align-center`) — Élégant / Bold. Ne pas remettre `justify-content: center` sur le sélecteur global `.free-canvas-block__contact--header-bar`.
 
 ## Hors scope
 

--- a/frontend/src/components/editor/FreeCanvasBlock.jsx
+++ b/frontend/src/components/editor/FreeCanvasBlock.jsx
@@ -325,11 +325,13 @@ function SemanticBlockBody({ block, cv, editing = false }) {
       const resumeText = resolveBoundText(cv, resumeBind);
       return (
         <div className="free-canvas-block__section-list">
-          <SectionHeading
-            label={style.section_label || 'PROFIL'}
-            titleStyle={style.title_style}
-            zone={style.zone}
-          />
+          {style.show_section_title === false ? null : (
+            <SectionHeading
+              label={style.section_label || 'PROFIL'}
+              titleStyle={style.title_style}
+              zone={style.zone}
+            />
+          )}
           <p className="free-canvas-block__resume">
             {editing ? (
               <CanvasEditableField path={resumePath} editing tag="span">
@@ -347,9 +349,10 @@ function SemanticBlockBody({ block, cv, editing = false }) {
     case 'experiences': {
       const items = resolveExperiences(cv, limit);
       if (items.length === 0) return <p className="free-canvas-block__placeholder">Expériences</p>;
-      const boldExp = style.exp_style === 'bold' || style.exp_style === 'elegant';
+      const boldExp = style.exp_style === 'bold' || style.exp_style === 'elegant' || style.exp_style === 'classic';
       const elegantExp = style.exp_style === 'elegant';
       const minimalExp = style.exp_style === 'minimal';
+      const classicExp = style.exp_style === 'classic';
       const atsLabels = boldExp || minimalExp;
       const hyphenDates = minimalExp || elegantExp;
       return (
@@ -435,7 +438,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
             return (
               <div
                 key={exp.id || i}
-                className={`free-canvas-block__exp${format === 'compact' ? ' free-canvas-block__exp--compact' : ''}${boldExp ? ' free-canvas-block__exp--bold' : ''}${minimalExp ? ' free-canvas-block__exp--minimal' : ''}${elegantExp ? ' free-canvas-block__exp--elegant' : ''}`}
+                className={`free-canvas-block__exp${format === 'compact' ? ' free-canvas-block__exp--compact' : ''}${boldExp ? ' free-canvas-block__exp--bold' : ''}${minimalExp ? ' free-canvas-block__exp--minimal' : ''}${elegantExp ? ' free-canvas-block__exp--elegant' : ''}${classicExp ? ' free-canvas-block__exp--classic' : ''}`}
               >
                 {minimalExp ? (
                   <>
@@ -486,7 +489,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
     case 'formations': {
       const items = resolveFormations(cv, limit);
       if (items.length === 0) return <p className="free-canvas-block__placeholder">Formations</p>;
-      const minimalForm = style.formation_style === 'minimal';
+      const minimalForm = style.formation_style === 'minimal' || style.formation_style === 'classic';
       return (
         <div className="free-canvas-block__section-list">
           <SectionHeading

--- a/frontend/src/components/editor/FreeCanvasBlock.jsx
+++ b/frontend/src/components/editor/FreeCanvasBlock.jsx
@@ -421,7 +421,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
               </p>
             ) : null;
             const bulletsNode = (
-              <ul className={`free-canvas-block__bullets${minimalExp || elegantExp ? ' free-canvas-block__bullets--dash' : ''}`}>
+              <ul className={`free-canvas-block__bullets${minimalExp || elegantExp || classicExp ? ' free-canvas-block__bullets--dash' : ''}`}>
                 {(exp.bullet_points || []).filter((b) => editing || (b || '').trim()).map((b, j) => (
                   <li key={j}>
                     {editing ? (
@@ -476,8 +476,18 @@ function SemanticBlockBody({ block, cv, editing = false }) {
                         {posteNode}
                       </p>
                     ) : null}
-                    {clientsNode}
-                    {bulletsNode}
+                    {/* Stable Classic : bullets puis Clients (filet au-dessus) */}
+                    {classicExp ? (
+                      <>
+                        {bulletsNode}
+                        {clientsNode}
+                      </>
+                    ) : (
+                      <>
+                        {clientsNode}
+                        {bulletsNode}
+                      </>
+                    )}
                   </>
                 )}
               </div>

--- a/frontend/src/components/editor/FreeCanvasBlock.jsx
+++ b/frontend/src/components/editor/FreeCanvasBlock.jsx
@@ -204,12 +204,18 @@ function SemanticBlockBody({ block, cv, editing = false }) {
       const email = showEmail ? getFieldDisplayValue(cv, 'email') : '';
       const linkedin = showLinkedin ? getFieldDisplayValue(cv, 'linkedin') : '';
       const showIcons = Boolean(style.contact_icons);
+      // Alignement explicite : défaut gauche (Minimal). Élégant/Bold = center via style.align.
+      // Évite qu’un justify-content global centre tous les header-bar.
+      const contactAlign = style.align === 'center' || style.align === 'right' || style.align === 'left'
+        ? style.align
+        : 'left';
       const contactCls = [
         'free-canvas-block__contact',
         style.contact_divider ? 'free-canvas-block__contact--divider' : '',
         style.contact_uppercase ? 'free-canvas-block__contact--uppercase' : '',
         showIcons ? 'free-canvas-block__contact--icons' : '',
         style.contact_layout === 'header-bar' ? 'free-canvas-block__contact--header-bar' : '',
+        style.contact_layout === 'header-bar' ? `free-canvas-block__contact--align-${contactAlign}` : '',
       ].filter(Boolean).join(' ');
 
       const renderContactValue = (path, value, placeholder) => {
@@ -266,9 +272,14 @@ function SemanticBlockBody({ block, cv, editing = false }) {
         return (
           <p
             className={contactCls}
-            style={style.align === 'left' || style.align === 'right'
-              ? { justifyContent: style.align === 'right' ? 'flex-end' : 'flex-start' }
-              : undefined}
+            style={{
+              justifyContent: contactAlign === 'right'
+                ? 'flex-end'
+                : contactAlign === 'center'
+                  ? 'center'
+                  : 'flex-start',
+              textAlign: contactAlign,
+            }}
           >
             {parts.map((part, i) => (
               <span key={part.id}>

--- a/frontend/src/lib/canvasCvImportAdapter.js
+++ b/frontend/src/lib/canvasCvImportAdapter.js
@@ -1033,6 +1033,7 @@ export function buildAdaptedCanvasLayoutForCv(cv, template, options = {}) {
     options.preserveReplicaGeometry
     || templateId === 'minimal'
     || templateId === 'elegant'
+    || templateId === 'classic'
     || base?.freeform,
   );
   const result = adaptCanvasLayoutForCv(cv, base, {

--- a/frontend/src/lib/canvasCvImportAdapter.js
+++ b/frontend/src/lib/canvasCvImportAdapter.js
@@ -824,6 +824,8 @@ const REPLICA_CASCADE_GAP_MM = 0;
 /**
  * Réplique Stable (freeform) : ajuste h au contenu et empile sans chevauchement,
  * en respectant `lock_geometry` / photo (header figé).
+ * Cascade **par lane** (header / main / sidebar) — un seul curseur vertical
+ * cassait Classic (sidebar-right) et poussait le texte en page 2.
  * Ne réordonne PAS les types (contrairement à ATS spatial).
  */
 export function fitReplicaLayoutToContent(layout, cv) {
@@ -832,31 +834,37 @@ export function fitReplicaLayoutToContent(layout, cv) {
   for (let pageIndex = 0; pageIndex < next.pages.length; pageIndex += 1) {
     const page = next.pages[pageIndex];
     const blocks = [...(page.blocks || [])];
-    const sorted = [...blocks].sort((a, b) => (Number(a.y) || 0) - (Number(b.y) || 0));
-    let cursorBottom = null;
-    for (const block of sorted) {
-      const locked = Boolean(block.style?.lock_geometry)
-        || block.type === 'photo'
-        || DECORATIVE_TYPES.has(block.type);
-      let h = Number(block.h) || 0;
-      let y = Number(block.y) || 0;
-      if (!locked && !DECORATIVE_TYPES.has(block.type)) {
-        // Shrink to content — les hauteurs preset trop larges créaient des « trous » entre sections.
-        const est = estimateSemanticBlockHeight(block, cv, { respectCurrentMin: false });
-        if (est > 0 && Math.abs(est - h) > 0.8) {
-          h = est;
-          next = patchBlockHeight(next, block.id, h);
+    const lanes = new Map();
+    for (const block of blocks) {
+      if (DECORATIVE_TYPES.has(block.type)) continue;
+      const lane = blockLane(block);
+      if (!lanes.has(lane)) lanes.set(lane, []);
+      lanes.get(lane).push(block);
+    }
+    for (const laneBlocks of lanes.values()) {
+      const sorted = [...laneBlocks].sort((a, b) => (Number(a.y) || 0) - (Number(b.y) || 0));
+      let cursorBottom = null;
+      for (const block of sorted) {
+        const locked = Boolean(block.style?.lock_geometry) || block.type === 'photo';
+        let h = Number(block.h) || 0;
+        let y = Number(block.y) || 0;
+        if (!locked) {
+          const est = estimateSemanticBlockHeight(block, cv, { respectCurrentMin: false });
+          if (est > 0 && Math.abs(est - h) > 0.8) {
+            h = est;
+            next = patchBlockHeight(next, block.id, h);
+          }
         }
-      }
-      if (!locked && cursorBottom != null) {
-        const minY = cursorBottom + REPLICA_CASCADE_GAP_MM;
-        if (y < minY - 0.05) {
-          y = minY;
-          next = setBlockPosition(next, block.id, { x: Number(block.x) || 0, y });
+        if (!locked && cursorBottom != null) {
+          const minY = cursorBottom + REPLICA_CASCADE_GAP_MM;
+          if (y < minY - 0.05) {
+            y = minY;
+            next = setBlockPosition(next, block.id, { x: Number(block.x) || 0, y });
+          }
         }
+        const bottom = y + Math.max(h, 0.2);
+        cursorBottom = cursorBottom == null ? bottom : Math.max(cursorBottom, bottom);
       }
-      const bottom = y + Math.max(h, 0.2);
-      cursorBottom = cursorBottom == null ? bottom : Math.max(cursorBottom, bottom);
     }
   }
   return next;

--- a/frontend/src/lib/canvasCvImportAdapter.js
+++ b/frontend/src/lib/canvasCvImportAdapter.js
@@ -762,16 +762,21 @@ function estimateSkillsHeight(block, cv) {
     const rows = Math.ceil(total / 5);
     return Math.min(55, Math.max(16, 12 + rows * 5.5));
   }
-  // Ligne « Outils : … » si nestés
-  const base = estimateListHeight(items.length, 3.8, 10, 50);
+  // Sidebar catégorie seule (sans titre COMPÉTENCES) : base plus basse.
+  const baseHmm = block.style?.section_label ? 9 : 5.5;
+  const base = estimateListHeight(items.length, 3.4, baseHmm, 50);
   return outils.length ? Math.min(60, base + 6) : base;
 }
 
 const SEMANTIC_MIN_HEIGHT_MM = 10;
+/** Floor bas quand on shrink-to-content (répliques) — évite des blocs sidebar trop hauts. */
+const SEMANTIC_SHRINK_FLOOR_MM = 7;
 
 /** Hauteur estimée (mm) d'un bloc sémantique selon le CV. */
 export function estimateSemanticBlockHeight(block, cv, { respectCurrentMin = false } = {}) {
-  const floor = respectCurrentMin ? (Number(block.h) || SEMANTIC_MIN_HEIGHT_MM) : SEMANTIC_MIN_HEIGHT_MM;
+  const floor = respectCurrentMin
+    ? (Number(block.h) || SEMANTIC_MIN_HEIGHT_MM)
+    : SEMANTIC_SHRINK_FLOOR_MM;
   if (!block || DECORATIVE_TYPES.has(block.type)) return floor;
 
   switch (block.type) {
@@ -796,12 +801,15 @@ export function estimateSemanticBlockHeight(block, cv, { respectCurrentMin = fal
       return Math.max(floor, estimateExperiencesHeight(cv));
     case 'formations':
       return Math.max(floor, estimateListHeight(resolveFormations(cv).length, 6, 8, 70));
-    case 'certifications':
-      return Math.max(floor, estimateListHeight(resolveCertifications(cv).length, 5, 7, 45));
+    case 'certifications': {
+      const n = resolveCertifications(cv).length;
+      const base = block.style?.sidebar_category && !block.style?.section_label ? 5 : 7;
+      return Math.max(floor, estimateListHeight(n, 4.5, base, 45));
+    }
     case 'projets':
       return Math.max(floor, estimateListHeight(resolveProjets(cv).length, 8, 8, 65));
     case 'languages':
-      return Math.max(floor, estimateListHeight(resolveLangues(cv).length, 4, 7, 35));
+      return Math.max(floor, estimateListHeight(resolveLangues(cv).length, 3.6, 7, 35));
     case 'skills':
       return Math.max(floor, estimateSkillsHeight(block, cv));
     default:
@@ -856,9 +864,11 @@ export function fitReplicaLayoutToContent(layout, cv) {
           }
         }
         if (!locked && cursorBottom != null) {
-          const minY = cursorBottom + REPLICA_CASCADE_GAP_MM;
-          if (y < minY - 0.05) {
-            y = minY;
+          // Snap (monter ou descendre) — sinon les y preset trop bas laissent des trous
+          // après shrink (sidebar Classic : Logiciels/Certifs/Langues trop espacés).
+          const targetY = cursorBottom + REPLICA_CASCADE_GAP_MM;
+          if (Math.abs(y - targetY) > 0.05) {
+            y = targetY;
             next = setBlockPosition(next, block.id, { x: Number(block.x) || 0, y });
           }
         }

--- a/frontend/src/lib/canvasTemplateSpecs.js
+++ b/frontend/src/lib/canvasTemplateSpecs.js
@@ -40,11 +40,11 @@ export const TEMPLATE_CANVAS_FIDELITY = Object.freeze({
   classic: {
     name: 'Classique',
     layoutFamily: 'sidebar-right',
-    readiness: 'thin',
-    fidelityCss: 'thin',
+    readiness: 'near-replica',
+    fidelityCss: 'rich',
     gaps: [
-      'CSS Stable très dense vs twin canvas mince',
-      'Sidebar compétences / typo header à rapprocher',
+      'Checklist visuelle Stable↔Beta (AXE-389)',
+      'Densité PDF (pad compact) vs preview à valider',
     ],
   },
   modern: {
@@ -556,22 +556,152 @@ export function buildTemplateBlocks(template) {
     }
 
     case 'classic': {
+      // Réplique templates/classic : header sombre (photo + nom inline + résumé + contact
+      // centré icônes), accent optionnel, main gauche, sidebar droite compétences.
       const { SB, SB_X, PAD, MAIN_W, SB_INSET } = rightSidebarMetrics();
-      const headerH = 46;
-      const bodyY = headerH + 1;
+      const PHOTO_TOP = px(12);
+      const PHOTO_H = px(52);
+      const GAP = px(6);
+      const RESUME_H = px(42);
+      const CONTACT_H = px(14);
+      const headerPadBottom = px(12);
+      const headerH = PHOTO_TOP + PHOTO_H + GAP + RESUME_H + GAP + CONTACT_H + headerPadBottom;
+      const bodyY = headerH;
+      const resumeY = PHOTO_TOP + PHOTO_H + GAP;
+      const contactY = resumeY + RESUME_H + GAP;
       const bodyH = H - bodyY;
+      const headerLock = { lock_geometry: true };
+      const hdr = (extra = {}) => ({
+        zone: 'header',
+        color: '#ffffff',
+        font_family: t.font_heading,
+        ...headerLock,
+        ...extra,
+      });
+      const mainCol = (extra = {}) => ({
+        zone: 'main',
+        font_size: 9,
+        color: '#1a1a1a',
+        font_family: t.font_heading,
+        ...extra,
+      });
+      const sideCol = (extra = {}) => ({
+        zone: 'sidebar-light',
+        font_size: 8.5,
+        color: '#333333',
+        list_format: 'list',
+        ...extra,
+      });
       return [
         bg(0, 0, PAGE_WIDTH_MM, headerH, t.color_header, 0),
-        bar(0, headerH, PAGE_WIDTH_MM, 0.8, t.color_accent, 1),
         bg(SB_X, bodyY, SB, bodyH, t.color_sidebar, 0),
-        { type: 'photo', x: 8, y: 6, w: 14, h: 14, z: 4, style: { shape: 'circle', zone: 'header' } },
-        { type: 'identity', bind: ['prenom', 'nom', 'titre_professionnel'], x: 26, y: 8, w: PAGE_WIDTH_MM - SB - 34, h: 14, z: 4, style: { ...header(), font_size: 15 } },
-        { type: 'contact', bind: ['email', 'telephone', 'linkedin'], x: 8, y: 30, w: PAGE_WIDTH_MM - SB - 16, h: 10, z: 4, style: { ...header(), contact_layout: 'header-bar', contact_icons: true, font_size: 8.5 } },
-        { type: 'experiences', bind: 'experiences', x: PAD, y: bodyY + 4, w: MAIN_W, h: 120, z: 2, style: { ...main(), section_label: 'EXPÉRIENCE PROFESSIONNELLE', title_style: 'classic-main', exp_style: 'bold' } },
-        { type: 'formations', bind: 'formations', x: PAD, y: bodyY + 128, w: MAIN_W, h: 28, z: 2, style: { ...main(), section_label: 'FORMATION', title_style: 'classic-main' } },
-        { type: 'resume', bind: 'resume', x: PAD, y: bodyY + 160, w: MAIN_W, h: 20, z: 2, style: { ...main(), section_label: 'PROFIL', font_style: 'italic' } },
-        { type: 'projets', bind: 'projets', x: PAD, y: bodyY + 184, w: MAIN_W, h: 24, z: 2, style: { ...main(), section_label: 'PROJETS', title_style: 'classic-main' } },
-        ...sidebarCompetenceBlocksDetailed(SB_X + SB_INSET, SB - SB_INSET * 2, bodyY + 6, sideLight(), 3),
+        {
+          type: 'photo',
+          x: px(16),
+          y: PHOTO_TOP,
+          w: PHOTO_H,
+          h: PHOTO_H,
+          z: 5,
+          style: { shape: 'circle', zone: 'header', photo_border: 'light', ...headerLock },
+        },
+        {
+          type: 'identity',
+          bind: ['prenom', 'nom', 'titre_professionnel'],
+          x: px(16) + PHOTO_H + px(12),
+          y: PHOTO_TOP + px(4),
+          w: PAGE_WIDTH_MM - px(16) - PHOTO_H - px(12) - px(16),
+          h: PHOTO_H - px(8),
+          z: 5,
+          style: {
+            ...hdr(),
+            font_size: 15,
+            bold: true,
+            header_layout: 'inline-title',
+            identity_layout: 'classic-header',
+          },
+        },
+        {
+          type: 'resume',
+          bind: 'resume',
+          x: px(16),
+          y: resumeY,
+          w: PAGE_WIDTH_MM - px(32),
+          h: RESUME_H,
+          z: 5,
+          style: {
+            ...hdr(),
+            align: 'justify',
+            font_size: 9,
+            font_style: 'italic',
+            color: 'rgba(255,255,255,0.95)',
+            // Pas de section_label : résumé dans le header Stable (pas « Profil » main)
+            show_section_title: false,
+          },
+        },
+        {
+          type: 'contact',
+          bind: ['telephone', 'email', 'linkedin'],
+          x: px(16),
+          y: contactY,
+          w: PAGE_WIDTH_MM - px(32),
+          h: CONTACT_H,
+          z: 5,
+          style: {
+            ...hdr(),
+            align: 'center',
+            contact_layout: 'header-bar',
+            contact_icons: true,
+            contact_separator: ' ',
+            font_size: 9,
+          },
+        },
+        {
+          type: 'experiences',
+          bind: 'experiences',
+          x: PAD,
+          y: bodyY + px(8),
+          w: MAIN_W,
+          h: px(200),
+          z: 2,
+          style: {
+            ...mainCol(),
+            section_label: 'EXPÉRIENCE PROFESSIONNELLE',
+            title_style: 'classic-main',
+            exp_style: 'classic',
+          },
+        },
+        {
+          type: 'formations',
+          bind: 'formations',
+          x: PAD,
+          y: bodyY + px(214),
+          w: MAIN_W,
+          h: px(36),
+          z: 2,
+          style: {
+            ...mainCol(),
+            section_label: 'FORMATION',
+            title_style: 'classic-main',
+            formation_style: 'classic',
+          },
+        },
+        {
+          type: 'projets',
+          bind: 'projets',
+          x: PAD,
+          y: bodyY + px(254),
+          w: MAIN_W,
+          h: px(28),
+          z: 2,
+          style: { ...mainCol(), section_label: 'PROJETS', title_style: 'classic-main' },
+        },
+        ...sidebarCompetenceBlocksDetailed(
+          SB_X + SB_INSET,
+          SB - SB_INSET * 2,
+          bodyY + px(12),
+          sideCol(),
+          3,
+        ),
       ];
     }
 

--- a/frontend/src/lib/canvasTemplateSpecs.js
+++ b/frontend/src/lib/canvasTemplateSpecs.js
@@ -712,9 +712,9 @@ export function buildTemplateBlocks(template) {
       const pad = px(28);
       const W = PAGE_WIDTH_MM - pad * 2;
       const yHeader = px(18);
-      // name 18pt×1.15 + title 10pt + marges ≈ 32–34px
-      const identityH = px(34);
-      const contactY = yHeader + identityH + px(4);
+      // name 18pt×1.15 + title 10pt×1.3 + marge titre ≈ 48px (34px overflowait sur le contact)
+      const identityH = px(48);
+      const contactY = yHeader + identityH + px(6);
       const contactH = px(14);
       const yBody = contactY + contactH + px(8) + px(6);
       const section = (label, extra = {}) => ({

--- a/frontend/src/lib/canvasTemplateSpecs.js
+++ b/frontend/src/lib/canvasTemplateSpecs.js
@@ -456,6 +456,7 @@ export function buildTemplateBlocks(template) {
           z: 5,
           style: {
             ...hdr(),
+            align: 'center',
             contact_layout: 'header-bar',
             font_size: 8.5,
             contact_icons: true,
@@ -621,6 +622,7 @@ export function buildTemplateBlocks(template) {
           style: {
             ...main(),
             ...headerLock,
+            align: 'left',
             contact_layout: 'header-bar',
             contact_separator: ' · ',
             contact_icons: false,

--- a/frontend/src/lib/layoutTemplatePresets.js
+++ b/frontend/src/lib/layoutTemplatePresets.js
@@ -13,7 +13,7 @@ export function createCanvasLayoutForTemplate(template) {
   layout.theme = { ...layout.theme, ...parseCanvasTheme(template) };
   // Répliques mono-colonne : géométrie mm calquée Stable — ne pas ré-empiler au reflow ATS.
   // `replica_cascade` : autorise le reflow colonne après auto-height (sans toucher lock_geometry).
-  if (template.id === 'minimal' || template.id === 'elegant') {
+  if (template.id === 'minimal' || template.id === 'elegant' || template.id === 'classic') {
     layout.freeform = true;
     layout.replica_cascade = true;
   }

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -366,8 +366,9 @@
   font-size: 9.5pt !important;
   font-weight: 700 !important;
   color: var(--free-canvas-section-title, var(--free-canvas-accent, #1e2a3a)) !important;
-  border-bottom: 0.53mm solid var(--free-canvas-accent, #1e2a3a) !important;
-  padding-bottom: 0.26mm;
+  /* Stable .section-title { border-bottom: 2px solid accent } */
+  border-bottom: 2px solid var(--free-canvas-accent, #1e2a3a) !important;
+  padding-bottom: 1px;
   margin: 0 0 1.06mm !important;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -397,8 +398,14 @@
 .free-canvas-page--tpl-classic .free-canvas-block__exp--classic .free-canvas-block__exp-dates,
 .free-canvas-page--tpl-classic .free-canvas-block__exp--bold .free-canvas-block__exp-dates {
   font-size: 8.5pt !important;
+  font-weight: 700;
   white-space: nowrap;
   flex-shrink: 0;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__exp--classic .free-canvas-block__exp-entreprise strong,
+.free-canvas-page--tpl-classic .free-canvas-block__exp--bold .free-canvas-block__exp-entreprise strong {
+  font-weight: 700;
 }
 
 .free-canvas-page--tpl-classic .free-canvas-block__exp--classic .free-canvas-block__exp-role,
@@ -411,7 +418,33 @@
 .free-canvas-page--tpl-classic .free-canvas-block__exp--bold .free-canvas-block__exp-clients {
   font-style: italic;
   font-size: 8.5pt;
-  margin: 1.06mm 0 0;
+  color: #555555;
+  /* Stable .exp-clients { border-top: 1px solid #e8e8e8; margin-top: 6px; padding-top: 4px } */
+  margin: 1.59mm 0 0;
+  padding-top: 1.06mm;
+  border-top: 1px solid #e8e8e8;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__bullets--dash {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__bullets--dash li {
+  position: relative;
+  padding-left: 2.6mm;
+  margin: 0;
+  font-size: 8.5pt !important;
+  line-height: 1.35;
+  color: #1a1a1a !important;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__bullets--dash li::before {
+  content: '-';
+  position: absolute;
+  left: 0;
+  color: #1a1a1a;
 }
 
 .free-canvas-page--tpl-classic .free-canvas-block__formation--minimal .free-canvas-block__formation-header {
@@ -422,12 +455,13 @@
 }
 
 .free-canvas-page--tpl-classic .free-canvas-block__formation--minimal .free-canvas-block__formation-diplome {
-  font-weight: 600;
+  font-weight: 700;
   font-size: 9pt !important;
 }
 
 .free-canvas-page--tpl-classic .free-canvas-block__formation--minimal .free-canvas-block__formation-date {
   font-size: 8.5pt !important;
+  font-weight: 700;
   white-space: nowrap;
 }
 
@@ -438,7 +472,6 @@
 }
 
 .free-canvas-page--tpl-classic .free-canvas-block__section-title--bold-sidebar-section,
-.free-canvas-page--tpl-classic .free-canvas-block__section-title--bold-sidebar-category,
 .free-canvas-page--tpl-classic .free-canvas-block__section-title--bold-main,
 .free-canvas-page--tpl-classic .free-canvas-block__section-title--sidebar-category {
   font-family: var(--free-canvas-font-heading) !important;
@@ -447,18 +480,21 @@
   color: var(--free-canvas-accent, #1e2a3a) !important;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  border-bottom: 0.53mm solid var(--free-canvas-accent, #1e2a3a);
+  border-bottom: 2px solid var(--free-canvas-accent, #1e2a3a) !important;
   margin: 0 0 1.06mm;
-  padding-bottom: 0.26mm;
+  padding-bottom: 1px;
 }
 
-/* Catégories sidebar (pas de filet pleine largeur comme les titres LANGUES/AUTRES) */
+/* Catégories sidebar (pas de filet — Stable .sidebar-category) */
 .free-canvas-page--tpl-classic .free-canvas-block__section-title--bold-sidebar-category,
 .free-canvas-page--tpl-classic .free-canvas-block__sidebar-category {
+  font-family: var(--free-canvas-font-heading) !important;
   font-size: 9.5pt !important;
+  font-weight: 700 !important;
+  color: var(--free-canvas-accent, #1e2a3a) !important;
   text-transform: none;
   letter-spacing: 0;
-  border-bottom: 0;
+  border-bottom: 0 !important;
   margin: 0 0 1.06mm;
   padding-bottom: 0;
 }

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -213,6 +213,7 @@
 
 .free-canvas-page--tpl-bold .free-canvas-block__contact--header-bar {
   text-align: center;
+  justify-content: center;
   margin: 0;
   color: rgba(255, 255, 255, 0.75);
 }
@@ -324,6 +325,7 @@
   margin: 0;
   line-height: 1.35;
   text-align: left !important;
+  justify-content: flex-start !important;
 }
 
 .free-canvas-page--tpl-minimal .free-canvas-block__contact--header-bar .free-canvas-block__contact-spacer {

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -287,9 +287,18 @@
 }
 
 .free-canvas-page--tpl-classic .free-canvas-block__photo--border-light,
+.free-canvas-page--tpl-classic .free-canvas-block__image-frame-inner.free-canvas-block__photo--border-light {
+  border-radius: 50%;
+  /* Stable : border 2px solid white — pas de box-shadow (clippé par overflow → arcs blancs). */
+  border: 2px solid #ffffff;
+  box-shadow: none;
+  box-sizing: border-box;
+}
+
 .free-canvas-page--tpl-classic .free-canvas-block__photo {
   border-radius: 50%;
-  box-shadow: 0 0 0 0.53mm #ffffff;
+  object-fit: cover;
+  object-position: center;
 }
 
 .free-canvas-page--tpl-classic .free-canvas-block__identity--inline-title,

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -443,6 +443,21 @@
   padding-bottom: 0.26mm;
 }
 
+/* Catégories sidebar (pas de filet pleine largeur comme les titres LANGUES/AUTRES) */
+.free-canvas-page--tpl-classic .free-canvas-block__section-title--bold-sidebar-category,
+.free-canvas-page--tpl-classic .free-canvas-block__sidebar-category {
+  font-size: 9.5pt !important;
+  text-transform: none;
+  letter-spacing: 0;
+  border-bottom: 0;
+  margin: 0 0 1.06mm;
+  padding-bottom: 0;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__pdf-fidelity-badge {
+  display: none;
+}
+
 /* ---------- Minimal (réplique mono-colonne — AXE-346) ---------- */
 .free-canvas-page--tpl-minimal {
   color: #1a1a1a;

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -276,13 +276,171 @@
   margin: 0 0 0.3mm;
 }
 
-/* ---------- Classique ---------- */
+/* ---------- Classique (réplique templates/classic — AXE-389) ---------- */
+.free-canvas-page--tpl-classic {
+  color: #1a1a1a;
+  font-family: Arial, sans-serif;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__inner {
+  padding: 0;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__photo--border-light,
+.free-canvas-page--tpl-classic .free-canvas-block__photo {
+  border-radius: 50%;
+  box-shadow: 0 0 0 0.53mm #ffffff;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__identity--inline-title,
+.free-canvas-page--tpl-classic .free-canvas-block__identity--classic-header {
+  color: #ffffff;
+  line-height: 1.2;
+  margin: 0;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__identity--inline-title .free-canvas-block__identity-name,
+.free-canvas-page--tpl-classic .free-canvas-block__identity--classic-header .free-canvas-block__identity-name {
+  font-family: var(--free-canvas-font-heading) !important;
+  font-size: 15pt !important;
+  font-weight: 700 !important;
+  color: #ffffff !important;
+  letter-spacing: 0;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__identity--inline-title .free-canvas-block__identity-sep {
+  font-weight: 400;
+  opacity: 0.7;
+  margin: 0 1.06mm;
+  color: #ffffff;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__identity--inline-title .free-canvas-block__identity-title,
+.free-canvas-page--tpl-classic .free-canvas-block__identity--inline-title .free-canvas-block__identity-title--accent {
+  font-family: var(--free-canvas-font-heading) !important;
+  font-size: 10pt !important;
+  font-weight: 600 !important;
+  opacity: 0.95;
+  color: #ffffff !important;
+  font-style: normal !important;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__inner--zone-header .free-canvas-block__resume {
+  font-family: Arial, sans-serif !important;
+  font-size: 9pt !important;
+  font-weight: 400 !important;
+  font-style: italic !important;
+  text-align: justify;
+  color: #ffffff !important;
+  line-height: 1.35;
+  margin: 0;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__contact--header-bar {
+  justify-content: center;
+  text-align: center;
+  color: #ffffff !important;
+  font-family: var(--free-canvas-font-heading) !important;
+  font-size: 9pt !important;
+  margin: 0;
+  line-height: 1.4;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__contact-icon {
+  color: rgba(255, 255, 255, 0.9);
+  margin-right: 0.53mm;
+  vertical-align: middle;
+}
+
 .free-canvas-page--tpl-classic .free-canvas-block__section-title--classic-main {
-  font-size: 9pt;
-  font-weight: 700;
-  color: var(--free-canvas-accent);
-  border-bottom: 0.35mm solid var(--free-canvas-accent);
+  font-family: var(--free-canvas-font-heading) !important;
+  font-size: 9.5pt !important;
+  font-weight: 700 !important;
+  color: var(--free-canvas-section-title, var(--free-canvas-accent, #1e2a3a)) !important;
+  border-bottom: 0.53mm solid var(--free-canvas-accent, #1e2a3a) !important;
+  padding-bottom: 0.26mm;
+  margin: 0 0 1.06mm !important;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__exp--classic,
+.free-canvas-page--tpl-classic .free-canvas-block__exp--bold {
+  margin-bottom: 1.59mm;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__exp--classic .free-canvas-block__exp-header,
+.free-canvas-page--tpl-classic .free-canvas-block__exp--bold .free-canvas-block__exp-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 2.5mm;
+  margin-bottom: 0.3mm;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__exp--classic .free-canvas-block__ats-label,
+.free-canvas-page--tpl-classic .free-canvas-block__exp--bold .free-canvas-block__ats-label {
+  font-weight: 400;
+  font-size: 0.9em;
+  color: #666666;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__exp--classic .free-canvas-block__exp-dates,
+.free-canvas-page--tpl-classic .free-canvas-block__exp--bold .free-canvas-block__exp-dates {
+  font-size: 8.5pt !important;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__exp--classic .free-canvas-block__exp-role,
+.free-canvas-page--tpl-classic .free-canvas-block__exp--bold .free-canvas-block__exp-role {
+  margin: 0 0 0.53mm;
+  font-size: 9pt !important;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__exp--classic .free-canvas-block__exp-clients,
+.free-canvas-page--tpl-classic .free-canvas-block__exp--bold .free-canvas-block__exp-clients {
+  font-style: italic;
+  font-size: 8.5pt;
+  margin: 1.06mm 0 0;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__formation--minimal .free-canvas-block__formation-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 2.5mm;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__formation--minimal .free-canvas-block__formation-diplome {
+  font-weight: 600;
+  font-size: 9pt !important;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__formation--minimal .free-canvas-block__formation-date {
+  font-size: 8.5pt !important;
+  white-space: nowrap;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__sidebar-item {
+  font-size: 8.5pt !important;
+  margin: 0 0 0.13mm;
+  line-height: 1.3;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block__section-title--bold-sidebar-section,
+.free-canvas-page--tpl-classic .free-canvas-block__section-title--bold-sidebar-category,
+.free-canvas-page--tpl-classic .free-canvas-block__section-title--bold-main,
+.free-canvas-page--tpl-classic .free-canvas-block__section-title--sidebar-category {
+  font-family: var(--free-canvas-font-heading) !important;
+  font-size: 9.5pt !important;
+  font-weight: 700 !important;
+  color: var(--free-canvas-accent, #1e2a3a) !important;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-bottom: 0.53mm solid var(--free-canvas-accent, #1e2a3a);
+  margin: 0 0 1.06mm;
+  padding-bottom: 0.26mm;
 }
 
 /* ---------- Minimal (réplique mono-colonne — AXE-346) ---------- */

--- a/frontend/src/styles/FreeCanvas.css
+++ b/frontend/src/styles/FreeCanvas.css
@@ -669,12 +669,24 @@
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
-  justify-content: center;
+  /* Défaut gauche — le centrage est opt-in (Élégant/Bold via --align-center). */
+  justify-content: flex-start;
   align-items: baseline;
   gap: 0;
   margin: 0;
   max-width: 100%;
   overflow: visible;
+  text-align: left;
+}
+
+.free-canvas-block__contact--header-bar.free-canvas-block__contact--align-center {
+  justify-content: center;
+  text-align: center;
+}
+
+.free-canvas-block__contact--header-bar.free-canvas-block__contact--align-right {
+  justify-content: flex-end;
+  text-align: right;
 }
 
 .free-canvas-block__contact--header-bar > span {

--- a/frontend/tests/unit/canvasCvImportAdapter.test.js
+++ b/frontend/tests/unit/canvasCvImportAdapter.test.js
@@ -418,7 +418,10 @@ test('classic preserveReplicaGeometry : contenu main reste page 1 (lanes sépar�
   assert.ok(page0.some((b) => b.type === 'shape:rect'), 'fonds couleurs sur page 1');
   const contact = page0.find((b) => b.type === 'contact');
   const experiences = page0.find((b) => b.type === 'experiences');
-  assert.ok(experiences.y > contact.y, 'main sous le header');
+  assert.ok(
+    experiences.y >= contact.y + contact.h - 0.05,
+    'main sous le header (pas de chevauchement contact)',
+  );
 });
 
 test('classic sidebar : cascade resserre les blocs (pas de trous après shrink)', () => {
@@ -455,7 +458,10 @@ test('classic sidebar : cascade resserre les blocs (pas de trous après shrink)'
   for (let i = 1; i < side.length; i += 1) {
     const prev = side[i - 1];
     const gap = side[i].y - (prev.y + prev.h);
-    assert.ok(gap < 1.5, `trou sidebar ${prev.type}→${side[i].type}: ${gap.toFixed(1)}mm`);
+    assert.ok(
+      gap >= -0.05 && gap < 1.5,
+      `gap sidebar ${prev.type}→${side[i].type}: ${gap.toFixed(1)}mm`,
+    );
   }
 });
 

--- a/frontend/tests/unit/canvasCvImportAdapter.test.js
+++ b/frontend/tests/unit/canvasCvImportAdapter.test.js
@@ -421,6 +421,44 @@ test('classic preserveReplicaGeometry : contenu main reste page 1 (lanes sépar�
   assert.ok(experiences.y > contact.y, 'main sous le header');
 });
 
+test('classic sidebar : cascade resserre les blocs (pas de trous après shrink)', () => {
+  const cv = {
+    prenom: 'L',
+    nom: 'V',
+    titre_professionnel: 'PO',
+    telephone: '06',
+    email: 'a@b.fr',
+    resume: 'Résumé.',
+    experiences: [{ entreprise: 'A', poste: 'B', bullet_points: ['x'] }],
+    formations: [{ etablissement: 'E', diplome: 'D', date: '2023' }],
+    projets: [{ nom: 'P', description: 'D' }],
+    competences: {
+      techniques: ['Python', 'Lire'],
+      logiciels: ['Excel', 'Claude'],
+      autres: ['Permis B'],
+      langues: [
+        { langue: 'Français', niveau: 'Natif' },
+        { langue: 'Japonais', niveau: 'C2' },
+      ],
+    },
+    certifications: [{ nom: 'Cert', organisme: 'AXEL', date: '2026' }],
+    photo_url: 'https://example.com/p.jpg',
+  };
+  const { layout } = adaptCanvasLayoutForCv(cv, createCanvasLayoutForTemplate({ id: 'classic' }), {
+    preserveReplicaGeometry: true,
+    templateId: 'classic',
+  });
+  const side = layout.pages[0].blocks
+    .filter((b) => b.style?.zone === 'sidebar-light')
+    .sort((a, b) => (Number(a.y) || 0) - (Number(b.y) || 0));
+  assert.ok(side.length >= 4, `sidebar trop courte: ${side.length}`);
+  for (let i = 1; i < side.length; i += 1) {
+    const prev = side[i - 1];
+    const gap = side[i].y - (prev.y + prev.h);
+    assert.ok(gap < 1.5, `trou sidebar ${prev.type}→${side[i].type}: ${gap.toFixed(1)}mm`);
+  }
+});
+
 test('minimal : contact sous identity sans overlap (hauteur nom+titre)', () => {
   const blocks = createCanvasLayoutForTemplate({ id: 'minimal' }).pages[0].blocks;
   const identity = blocks.find((b) => b.type === 'identity');

--- a/frontend/tests/unit/canvasCvImportAdapter.test.js
+++ b/frontend/tests/unit/canvasCvImportAdapter.test.js
@@ -385,6 +385,49 @@ test('elegant preserveReplicaGeometry : photo au-dessus du nom, pas de restack A
   assert.ok(experiences.y + experiences.h <= formations.y + 0.05, 'pas de chevauchement exp/formation');
 });
 
+test('classic preserveReplicaGeometry : contenu main reste page 1 (lanes séparées)', () => {
+  const cv = {
+    prenom: 'Louis',
+    nom: 'Vedovato',
+    titre_professionnel: 'Product Owner',
+    telephone: '06',
+    email: 'a@b.fr',
+    resume: 'Résumé professionnel court pour le header Classic.',
+    experiences: [
+      {
+        entreprise: 'A',
+        poste: 'B',
+        date_debut: '2022',
+        date_fin: "Aujourd'hui",
+        lieu: 'Paris',
+        bullet_points: ['Un', 'Deux'],
+      },
+    ],
+    formations: [{ etablissement: 'ESSEC', diplome: 'BBA', date: '2023' }],
+    projets: [{ nom: 'CRM', description: 'Desc' }],
+    competences: { techniques: ['Python'], logiciels: ['Notion'] },
+    photo_url: 'https://example.com/p.jpg',
+  };
+  const { layout } = adaptCanvasLayoutForCv(cv, createCanvasLayoutForTemplate({ id: 'classic' }), {
+    preserveReplicaGeometry: true,
+    templateId: 'classic',
+  });
+  assert.equal(layout.pages.length, 1, 'pas de pagination parasite sidebar/main');
+  const page0 = layout.pages[0].blocks;
+  assert.ok(page0.some((b) => b.type === 'experiences'), 'expériences sur page 1');
+  assert.ok(page0.some((b) => b.type === 'shape:rect'), 'fonds couleurs sur page 1');
+  const contact = page0.find((b) => b.type === 'contact');
+  const experiences = page0.find((b) => b.type === 'experiences');
+  assert.ok(experiences.y > contact.y, 'main sous le header');
+});
+
+test('minimal : contact sous identity sans overlap (hauteur nom+titre)', () => {
+  const blocks = createCanvasLayoutForTemplate({ id: 'minimal' }).pages[0].blocks;
+  const identity = blocks.find((b) => b.type === 'identity');
+  const contact = blocks.find((b) => b.type === 'contact');
+  assert.ok(contact.y >= identity.y + identity.h + 1, `gap trop serré: id.h=${identity.h} contact.y=${contact.y}`);
+});
+
 test('adaptCanvasLayoutForCv : freeform sans replica_cascade ne cascade pas', () => {
   const freeformNoCascade = {
     version: 3,

--- a/frontend/tests/unit/canvasTemplateSpecs.test.js
+++ b/frontend/tests/unit/canvasTemplateSpecs.test.js
@@ -85,6 +85,7 @@ test('minimal réplique Stable : contact inline ·, titres Title Case, exp ATS',
   assert.equal(identity.style?.lock_geometry, true);
   assert.equal(contact.style?.lock_geometry, true);
   assert.equal(contact.style?.contact_layout, 'header-bar');
+  assert.equal(contact.style?.align, 'left', 'Minimal : contact à gauche (pas center Élégant)');
   assert.equal(contact.style?.contact_separator, ' · ');
   assert.equal(contact.style?.contact_icons, false);
   assert.deepEqual(contact.bind, ['telephone', 'email', 'linkedin']);

--- a/frontend/tests/unit/canvasTemplateSpecs.test.js
+++ b/frontend/tests/unit/canvasTemplateSpecs.test.js
@@ -163,3 +163,38 @@ test('elegant réplique Stable : header centré + photo, chips, freeform', () =>
   assert.equal(getTemplateCanvasFidelity('elegant')?.fidelityCss, 'rich');
   assert.equal(getTemplateCanvasFidelity('elegant')?.readiness, 'near-replica');
 });
+
+test('classic réplique Stable : header sombre + résumé + sidebar droite', () => {
+  const blocks = buildTemplateBlocks({ id: 'classic' });
+  const photo = blocks.find((b) => b.type === 'photo');
+  const identity = blocks.find((b) => b.type === 'identity');
+  const contact = blocks.find((b) => b.type === 'contact');
+  const resume = blocks.find((b) => b.type === 'resume');
+  const experiences = blocks.find((b) => b.type === 'experiences');
+  const projets = blocks.find((b) => b.type === 'projets');
+  const sidebarSkills = blocks.filter((b) => b.type === 'skills' && b.style?.zone === 'sidebar-light');
+
+  assert.ok(photo && identity && contact && resume);
+  assert.equal(photo.style?.zone, 'header');
+  assert.equal(identity.style?.header_layout, 'inline-title');
+  assert.equal(identity.style?.zone, 'header');
+  assert.equal(resume.style?.zone, 'header');
+  assert.equal(resume.style?.show_section_title, false);
+  assert.ok(resume.y > identity.y, 'résumé sous identity dans le header');
+  assert.equal(contact.style?.align, 'center');
+  assert.equal(contact.style?.contact_icons, true);
+  assert.ok(contact.y > resume.y, 'contact sous résumé');
+
+  assert.equal(experiences.style?.exp_style, 'classic');
+  assert.equal(experiences.style?.title_style, 'classic-main');
+  assert.ok(projets, 'projets en main (pas profil)');
+  assert.ok(!blocks.some((b) => b.type === 'resume' && b.style?.zone === 'main'), 'pas de Profil en main');
+  assert.ok(sidebarSkills.length >= 1, 'compétences en sidebar');
+  assert.ok(sidebarSkills.every((b) => b.x > 100), 'sidebar à droite');
+
+  const layout = createCanvasLayoutForTemplate({ id: 'classic' });
+  assert.equal(layout.freeform, true);
+  assert.equal(layout.replica_cascade, true);
+  assert.equal(getTemplateCanvasFidelity('classic')?.fidelityCss, 'rich');
+  assert.equal(getTemplateCanvasFidelity('classic')?.readiness, 'near-replica');
+});


### PR DESCRIPTION
## Summary
- Réplique Stable→Beta du template **Classic** ([AXE-389](https://linear.app/axel-project/issue/AXE-389) / #176)
- Inclut aussi le fix contact Minimal à gauche (align header-bar) — supersède #175 si mergeé ici
- Housekeeping doc matrice Minimal/Élégant/Classic

## Test plan
- [ ] Apply Classic Stable→Beta ≈ preview (header sombre, résumé dans header, sidebar droite)
- [ ] Minimal : contact toujours à gauche
- [ ] Élégant : contact centré
- [ ] Checklist visuelle avant merge


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout d’un rendu « Classic » quasi fidèle, avec en-tête sombre, résumé et contacts centrés, contenu principal et compétences en colonne latérale.
  * Prise en charge de l’alignement gauche, centré ou droit des contacts dans l’en-tête.
  * Possibilité de masquer le titre de section du résumé.
  * Amélioration de l’adaptation automatique des blocs et de la préservation de la mise en page sur une page.

* **Améliorations**
  * Ajustement des styles des modèles Classic, Minimal et Bold.
  * Espacements et hauteurs de sections mieux harmonisés pour les contenus variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->