### PR TITLE
Feat(templates): polish réplique canvas Bold / Impact (AXE-390)

### DIFF
--- a/docs/template-canvas-fidelity.md
+++ b/docs/template-canvas-fidelity.md
@@ -33,7 +33,7 @@ Le template virtuel `beta` (`betaCanvasTemplate.js`) n’est **pas** une twin HT
 | `creative` | sidebar-left | projection | medium | Titres creative-main |
 | `elegant` | single-column | near-replica | **rich** | Checklist visuelle OK (PR #174 / AXE-388) |
 | `executive` | sidebar-right | projection | medium | Header band |
-| `bold` | sidebar-right | **near-replica** | rich | Écarts typo/exp résiduels |
+| `bold` | sidebar-right | **near-replica** | rich | Checklist visuelle (AXE-390) |
 
 Source de vérité code : `TEMPLATE_CANVAS_FIDELITY` + `STABLE_CANVAS_TEMPLATE_IDS`.
 
@@ -57,6 +57,12 @@ Source de vérité code : `TEMPLATE_CANVAS_FIDELITY` + `STABLE_CANVAS_TEMPLATE_I
 2. **CSS** `templates/classic/template.css` — pad header `12/16`, photo 52px, sidebar 200px, titres uppercase + filet accent
 3. **Canvas** `buildTemplateBlocks('classic')` + twin CSS + `exp_style: classic` + `freeform` / `replica_cascade`
 
+### Bold / Impact — couches Stable à calquer (AXE-390)
+
+1. **HTML** `templates/bold/template.html` — header sombre + barre rouge 4px, photo 64px bordure accent, nom inline + titre accent, résumé justifié, contact uppercase centré
+2. **CSS** `templates/bold/template.css` — titres 800 + border-left accent, exp ATS, bullets `-`, formations flex + dates accent
+3. **Canvas** `buildTemplateBlocks('bold')` + twin CSS + `exp_style: bold` + `formation_style: minimal` + `freeform` / `replica_cascade`
+
 ## Critères de « réplique native »
 
 Pour un id catalogue :
@@ -72,7 +78,7 @@ Pour un id catalogue :
 2. ~~Tranche Minimal~~ validée checklist visuelle
 3. ~~Élégant~~ (AXE-388 / PR #174) — near-replica
 4. ~~Classic~~ (AXE-389 / PR #177) — near-replica ; checklist visuelle + densité PDF à valider
-5. Finir `bold` (écarts typo/exp résiduels)
+5. **Bold / Impact** (AXE-390) — polish near-replica (cascade + typo/exp)
 6. Option ultérieure : assets `default_layout.json` par template (voir `docs/editor-vision.md`)
 
 ## Alignement contact header-bar

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -1175,6 +1175,7 @@ function CvEditorBeta({
     for (const [blockId, newHmm] of pending.entries()) {
       const found = findBlock(next, blockId);
       if (!found?.block) continue;
+      if (found.block.style?.lock_geometry) continue;
       const cur = found.block.h ?? 0;
       if (Math.abs(newHmm - cur) < 0.4) continue;
       next = updateBlock(next, blockId, { h: newHmm });

--- a/frontend/src/components/editor/FreeCanvasBlock.jsx
+++ b/frontend/src/components/editor/FreeCanvasBlock.jsx
@@ -477,12 +477,12 @@ function SemanticBlockBody({ block, cv, editing = false }) {
                       <p className="free-canvas-block__exp-role">
                         {atsLabels ? <span className="free-canvas-block__ats-label">Fonction : </span> : null}
                         {posteNode}
-                        {impactExp && (exp.secteur || '').trim() ? (
+                        {impactExp && (editing || (exp.secteur || '').trim()) ? (
                           <>
                             {' - '}
                             {editing ? (
                               <CanvasEditableField path={`experiences.${idx}.secteur`} editing>
-                                {exp.secteur}
+                                {exp.secteur || 'Secteur'}
                               </CanvasEditableField>
                             ) : (
                               exp.secteur

--- a/frontend/src/components/editor/FreeCanvasBlock.jsx
+++ b/frontend/src/components/editor/FreeCanvasBlock.jsx
@@ -1001,7 +1001,10 @@ export default function FreeCanvasBlock({
   const h = validBlock ? block.h : 0;
   const z = validBlock ? block.z : 0;
   const blockStyle = validBlock ? block.style : undefined;
-  const autoHeight = validBlock && isAutoHeightBlockType(type);
+  // Répliques figées (Bold/Classic header) : garder h preset pour centrer vs photo.
+  const autoHeight = validBlock
+    && isAutoHeightBlockType(type)
+    && !blockStyle?.lock_geometry;
 
   const reportHeight = useCallback((newHmm) => {
     if (!autoHeight || typeof onBlockAutoHeight !== 'function' || !id) return;

--- a/frontend/src/components/editor/FreeCanvasBlock.jsx
+++ b/frontend/src/components/editor/FreeCanvasBlock.jsx
@@ -353,8 +353,11 @@ function SemanticBlockBody({ block, cv, editing = false }) {
       const elegantExp = style.exp_style === 'elegant';
       const minimalExp = style.exp_style === 'minimal';
       const classicExp = style.exp_style === 'classic';
+      const impactExp = style.exp_style === 'bold';
       const atsLabels = boldExp || minimalExp;
-      const hyphenDates = minimalExp || elegantExp;
+      const hyphenDates = minimalExp || elegantExp || impactExp;
+      const dashBullets = minimalExp || elegantExp || classicExp || impactExp;
+      const clientsAfterBullets = classicExp || impactExp;
       return (
         <div className={`free-canvas-block__section-list${boldExp ? ' free-canvas-block__section-list--bold-exp' : ''}${minimalExp ? ' free-canvas-block__section-list--minimal-exp' : ''}${elegantExp ? ' free-canvas-block__section-list--elegant-exp' : ''}`}>
           <SectionHeading
@@ -421,7 +424,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
               </p>
             ) : null;
             const bulletsNode = (
-              <ul className={`free-canvas-block__bullets${minimalExp || elegantExp || classicExp ? ' free-canvas-block__bullets--dash' : ''}`}>
+              <ul className={`free-canvas-block__bullets${dashBullets ? ' free-canvas-block__bullets--dash' : ''}`}>
                 {(exp.bullet_points || []).filter((b) => editing || (b || '').trim()).map((b, j) => (
                   <li key={j}>
                     {editing ? (
@@ -474,10 +477,22 @@ function SemanticBlockBody({ block, cv, editing = false }) {
                       <p className="free-canvas-block__exp-role">
                         {atsLabels ? <span className="free-canvas-block__ats-label">Fonction : </span> : null}
                         {posteNode}
+                        {impactExp && (exp.secteur || '').trim() ? (
+                          <>
+                            {' - '}
+                            {editing ? (
+                              <CanvasEditableField path={`experiences.${idx}.secteur`} editing>
+                                {exp.secteur}
+                              </CanvasEditableField>
+                            ) : (
+                              exp.secteur
+                            )}
+                          </>
+                        ) : null}
                       </p>
                     ) : null}
-                    {/* Stable Classic : bullets puis Clients (filet au-dessus) */}
-                    {classicExp ? (
+                    {/* Stable Bold/Classic : bullets puis Clients */}
+                    {clientsAfterBullets ? (
                       <>
                         {bulletsNode}
                         {clientsNode}

--- a/frontend/src/lib/canvasTemplateSpecs.js
+++ b/frontend/src/lib/canvasTemplateSpecs.js
@@ -80,7 +80,7 @@ export const TEMPLATE_CANVAS_FIDELITY = Object.freeze({
     layoutFamily: 'sidebar-right',
     readiness: 'near-replica',
     fidelityCss: 'rich',
-    gaps: ['Écarts résiduels typo/exp (meilleure base actuelle)'],
+    gaps: ['Checklist visuelle Stable↔Beta (AXE-390)'],
   },
 });
 
@@ -148,12 +148,20 @@ export function parseCanvasTheme(template) {
     color_section_title: defaults.color_section_title ?? theme.color_accent,
   });
 
+  if (defaults.font) {
+    theme.font_heading = fontStackFromTemplateOption(defaults.font);
+    theme.font_body = id === 'executive' || id === 'minimal' || id === 'elegant'
+      ? 'Inter, sans-serif'
+      : theme.font_heading;
+  }
+
   const opts = template?.options;
   if (Array.isArray(opts)) {
     opts.forEach((o) => {
       if (o?.key === 'accent_color' && o.default) {
         theme.color_accent = o.default;
-        if (id !== 'creative') theme.color_section_title = o.default;
+        // Bold Stable : titres corps restent slate ; accent = filets/dates seulement.
+        if (id !== 'creative' && id !== 'bold') theme.color_section_title = o.default;
       }
       if (o?.key === 'header_color' && o.default) theme.color_header = o.default;
       if (o?.key === 'sidebar_color' && o.default) theme.color_sidebar = o.default;
@@ -388,7 +396,8 @@ export function buildTemplateBlocks(template) {
       const PHOTO_TOP = px(20);
       const PHOTO_H = px(64);
       const GAP = px(10);
-      const RESUME_H = px(52);
+      // Hauteur initiale courte : replica_cascade ajuste au contenu (Stable = auto).
+      const RESUME_H = px(36);
       const CONTACT_H = px(14);
       const headerH = PHOTO_TOP + PHOTO_H + GAP + RESUME_H + GAP + CONTACT_H + px(16);
       const bodyY = headerH + px(4);
@@ -431,7 +440,7 @@ export function buildTemplateBlocks(template) {
           style: {
             ...hdr(),
             font_size: 20,
-            bold: true,
+            // Pas de `bold: true` (inline 700) — twin CSS force 800 Stable.
             header_layout: 'inline-title',
             title_accent: true,
           },
@@ -486,7 +495,12 @@ export function buildTemplateBlocks(template) {
           w: MAIN_W,
           h: px(38),
           z: 2,
-          style: { ...mainCol(), section_label: 'FORMATION', title_style: 'bold-main' },
+          style: {
+            ...mainCol(),
+            section_label: 'FORMATION',
+            title_style: 'bold-main',
+            formation_style: 'minimal',
+          },
         },
         {
           type: 'projets',

--- a/frontend/src/lib/canvasTemplateSpecs.js
+++ b/frontend/src/lib/canvasTemplateSpecs.js
@@ -396,18 +396,21 @@ export function buildTemplateBlocks(template) {
       const PHOTO_TOP = px(20);
       const PHOTO_H = px(64);
       const GAP = px(10);
-      // Hauteur initiale courte : replica_cascade ajuste au contenu (Stable = auto).
       const RESUME_H = px(36);
       const CONTACT_H = px(14);
-      const headerH = PHOTO_TOP + PHOTO_H + GAP + RESUME_H + GAP + CONTACT_H + px(16);
+      const headerPadBottom = px(16);
+      const headerH = PHOTO_TOP + PHOTO_H + GAP + RESUME_H + GAP + CONTACT_H + headerPadBottom;
       const bodyY = headerH + px(4);
       const resumeY = PHOTO_TOP + PHOTO_H + GAP;
       const contactY = resumeY + RESUME_H + GAP;
       const bodyH = H - bodyY;
+      // Header figé : sinon replica_cascade empile identity sous la photo (même lane).
+      const headerLock = { lock_geometry: true };
       const hdr = (extra = {}) => ({
         zone: 'header',
         color: '#ffffff',
         font_family: t.font_heading,
+        ...headerLock,
         ...extra,
       });
       const mainCol = (extra = {}) => ({
@@ -428,7 +431,15 @@ export function buildTemplateBlocks(template) {
         bg(0, 0, PAGE_WIDTH_MM, headerH, t.color_header, 0),
         bar(0, headerH, PAGE_WIDTH_MM, px(4), t.color_accent, 1),
         bg(SB_X, bodyY, SB, bodyH, t.color_sidebar, 0),
-        { type: 'photo', x: px(24), y: PHOTO_TOP, w: PHOTO_H, h: PHOTO_H, z: 5, style: { shape: 'circle', zone: 'header', photo_border: 'accent-thick' } },
+        {
+          type: 'photo',
+          x: px(24),
+          y: PHOTO_TOP,
+          w: PHOTO_H,
+          h: PHOTO_H,
+          z: 5,
+          style: { shape: 'circle', zone: 'header', photo_border: 'accent-thick', ...headerLock },
+        },
         {
           type: 'identity',
           bind: ['prenom', 'nom', 'titre_professionnel'],
@@ -453,11 +464,18 @@ export function buildTemplateBlocks(template) {
           w: PAGE_WIDTH_MM - px(48),
           h: RESUME_H,
           z: 5,
-          style: { ...hdr(), align: 'justify', font_size: 9, color: 'rgba(255,255,255,0.88)' },
+          style: {
+            ...hdr(),
+            align: 'justify',
+            font_size: 9,
+            color: 'rgba(255,255,255,0.88)',
+            // Stable : résumé dans le header, pas de titre « Profil »
+            show_section_title: false,
+          },
         },
         {
           type: 'contact',
-          bind: ['email', 'telephone', 'linkedin'],
+          bind: ['telephone', 'email', 'linkedin'],
           x: px(24),
           y: contactY,
           w: PAGE_WIDTH_MM - px(48),
@@ -470,6 +488,7 @@ export function buildTemplateBlocks(template) {
             font_size: 8.5,
             contact_icons: true,
             contact_uppercase: true,
+            contact_separator: ' ',
           },
         },
         {

--- a/frontend/src/lib/canvasTemplateSpecs.js
+++ b/frontend/src/lib/canvasTemplateSpecs.js
@@ -444,7 +444,7 @@ export function buildTemplateBlocks(template) {
           type: 'identity',
           bind: ['prenom', 'nom', 'titre_professionnel'],
           x: px(24) + PHOTO_H + px(16),
-          y: PHOTO_TOP + px(2),
+          y: PHOTO_TOP,
           w: PAGE_WIDTH_MM - px(24) - PHOTO_H - px(16) - px(24),
           h: PHOTO_H,
           z: 5,

--- a/frontend/src/lib/canvasTemplateSpecs.js
+++ b/frontend/src/lib/canvasTemplateSpecs.js
@@ -450,8 +450,8 @@ export function buildTemplateBlocks(template) {
           z: 5,
           style: {
             ...hdr(),
-            font_size: 20,
-            // Pas de `bold: true` (inline 700) — twin CSS force 800 Stable.
+            // Pas de font_size ici : sinon --typography force titre = 20pt (inherit !important).
+            // Tailles via twin CSS : nom 20pt / titre 11pt.
             header_layout: 'inline-title',
             title_accent: true,
           },

--- a/frontend/src/lib/layoutTemplatePresets.js
+++ b/frontend/src/lib/layoutTemplatePresets.js
@@ -13,7 +13,12 @@ export function createCanvasLayoutForTemplate(template) {
   layout.theme = { ...layout.theme, ...parseCanvasTheme(template) };
   // Répliques mono-colonne : géométrie mm calquée Stable — ne pas ré-empiler au reflow ATS.
   // `replica_cascade` : autorise le reflow colonne après auto-height (sans toucher lock_geometry).
-  if (template.id === 'minimal' || template.id === 'elegant' || template.id === 'classic') {
+  if (
+    template.id === 'minimal'
+    || template.id === 'elegant'
+    || template.id === 'classic'
+    || template.id === 'bold'
+  ) {
     layout.freeform = true;
     layout.replica_cascade = true;
   }

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -212,14 +212,18 @@
 }
 
 .free-canvas-page--tpl-bold .free-canvas-block[data-block-type='identity'] .free-canvas-block__inner--zone-header {
-  display: flex;
-  align-items: center;
+  display: flex !important;
+  align-items: center !important;
   justify-content: flex-start;
-  height: 100%;
+  height: 100% !important;
+  min-height: 100% !important;
+  max-height: 100% !important;
+  overflow: hidden !important;
 }
 
 .free-canvas-page--tpl-bold .free-canvas-block[data-block-type='identity'] .free-canvas-block__identity--inline-title {
   width: 100%;
+  margin: 0;
 }
 
 .free-canvas-page--tpl-bold .free-canvas-block__inner--zone-header .free-canvas-block__identity-title--accent {

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -138,74 +138,87 @@
 }
 
 .free-canvas-page--tpl-bold .free-canvas-block__section-title--bold-main {
-  font-size: 10pt;
-  font-weight: 800;
-  color: #1e293b;
+  font-size: 10pt !important;
+  font-weight: 800 !important;
+  color: #1e293b !important;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  border-left: 1.05mm solid var(--free-canvas-accent);
-  padding: 0.8mm 0 0.8mm 2.1mm;
-  margin: 0 0 1.6mm;
-  border-bottom: none;
+  border-left: 4px solid var(--free-canvas-accent);
+  padding: 3px 0 3px 8px;
+  margin: 0 0 6px;
+  border-bottom: none !important;
 }
 
 .free-canvas-page--tpl-bold .free-canvas-block__section-title--bold-sidebar-section {
-  font-size: 10pt;
-  font-weight: 800;
-  color: #1e293b;
+  font-size: 10pt !important;
+  font-weight: 800 !important;
+  color: #1e293b !important;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  border-left: 1.05mm solid var(--free-canvas-accent);
-  padding: 0.8mm 0 0.8mm 2.1mm;
-  margin: 0 0 2.1mm;
-  border-bottom: none;
+  border-left: 4px solid var(--free-canvas-accent);
+  padding: 3px 0 3px 8px;
+  margin: 0 0 8px;
+  border-bottom: none !important;
 }
 
 .free-canvas-page--tpl-bold .free-canvas-block__sidebar-category,
 .free-canvas-page--tpl-bold .free-canvas-block__sidebar-category--bold-sidebar-category {
-  font-size: 8.5pt;
-  font-weight: 800;
-  color: #1e293b;
+  font-size: 8.5pt !important;
+  font-weight: 800 !important;
+  color: #1e293b !important;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  border-left: 0.8mm solid var(--free-canvas-accent);
-  padding-left: 1.6mm;
-  margin: 0 0 1.3mm;
+  border-left: 3px solid var(--free-canvas-accent);
+  padding-left: 6px;
+  margin: 0 0 5px;
 }
 
 .free-canvas-page--tpl-bold .free-canvas-block__identity--inline-title {
   margin: 0;
-  font-size: 20pt;
-  font-weight: 800 !important;
   line-height: 1.1;
   letter-spacing: -0.01em;
-}
-
-.free-canvas-page--tpl-bold .free-canvas-block__identity--inline-title .free-canvas-block__identity-name {
-  display: inline;
-  white-space: nowrap;
-  font-weight: 800 !important;
-}
-
-.free-canvas-page--tpl-bold .free-canvas-block__identity--inline-title .free-canvas-block__identity-sep {
-  font-weight: 400;
-  opacity: 0.4;
-  margin: 0 1mm;
   color: #fff;
 }
 
-.free-canvas-page--tpl-bold .free-canvas-block__identity--inline-title .free-canvas-block__identity-title--accent {
-  font-size: 11pt;
-  font-weight: 600;
-  color: var(--free-canvas-accent) !important;
-  font-style: normal !important;
-  opacity: 1;
+/* Battre `.inner--typography … { font-size: inherit !important }` (sinon titre = 20pt). */
+.free-canvas-page--tpl-bold .free-canvas-block__identity--inline-title .free-canvas-block__identity-name {
   display: inline;
+  white-space: nowrap;
+  font-family: var(--free-canvas-font-heading, 'Plus Jakarta Sans', Arial, sans-serif) !important;
+  font-size: 20pt !important;
+  font-weight: 800 !important;
+  color: #ffffff !important;
+  letter-spacing: -0.01em;
+}
+
+.free-canvas-page--tpl-bold .free-canvas-block__identity--inline-title .free-canvas-block__identity-sep {
+  font-size: 20pt !important;
+  font-weight: 400 !important;
+  opacity: 0.4;
+  margin: 0 4px;
+  color: #ffffff !important;
+}
+
+.free-canvas-page--tpl-bold .free-canvas-block__identity--inline-title .free-canvas-block__identity-title,
+.free-canvas-page--tpl-bold .free-canvas-block__identity--inline-title .free-canvas-block__identity-title--accent {
+  font-family: var(--free-canvas-font-heading, 'Plus Jakarta Sans', Arial, sans-serif) !important;
+  font-size: 11pt !important;
+  font-weight: 600 !important;
+  color: var(--free-canvas-accent, #dc2626) !important;
+  font-style: normal !important;
+  opacity: 1 !important;
+  display: inline;
+  margin: 0 !important;
+}
+
+.free-canvas-page--tpl-bold .free-canvas-block[data-block-type='identity'] .free-canvas-block__inner--zone-header {
+  display: flex;
+  align-items: center;
 }
 
 .free-canvas-page--tpl-bold .free-canvas-block__inner--zone-header .free-canvas-block__identity-title--accent {
-  font-style: normal;
-  opacity: 1;
+  font-style: normal !important;
+  opacity: 1 !important;
 }
 
 .free-canvas-page--tpl-bold .free-canvas-block__photo--border-accent {
@@ -215,6 +228,8 @@
 .free-canvas-page--tpl-bold .free-canvas-block__inner--zone-header .free-canvas-block__resume {
   color: rgba(255, 255, 255, 0.88) !important;
   font-size: 9pt !important;
+  font-weight: 400 !important;
+  font-family: var(--free-canvas-font-heading, 'Plus Jakarta Sans', Arial, sans-serif) !important;
   line-height: 1.45;
   margin: 0;
   text-align: justify;
@@ -225,23 +240,30 @@
   justify-content: center;
   margin: 0;
   color: rgba(255, 255, 255, 0.75) !important;
-  gap: 2mm;
+  font-size: 8.5pt !important;
+  font-weight: 400 !important;
+  letter-spacing: 0.04em;
+  gap: 0;
 }
 
 .free-canvas-page--tpl-bold .free-canvas-block__contact--header-bar .free-canvas-block__contact-icon {
-  color: var(--free-canvas-accent);
+  color: var(--free-canvas-accent) !important;
   vertical-align: middle;
+  width: 0.9em;
+  height: 0.9em;
+  margin-right: 3px;
 }
 
 .free-canvas-page--tpl-bold .free-canvas-block__contact--header-bar .free-canvas-block__contact-spacer {
   white-space: pre;
-  margin: 0 1.5mm;
+  /* Stable .contact-spacer { margin: 0 8px } */
+  margin: 0 8px;
 }
 
 .free-canvas-page--tpl-bold .free-canvas-block__contact--uppercase {
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  font-size: 8.5pt;
+  font-size: 8.5pt !important;
 }
 
 .free-canvas-page--tpl-bold .free-canvas-block__pdf-fidelity-badge {
@@ -265,20 +287,21 @@
 }
 
 .free-canvas-page--tpl-bold .free-canvas-block__exp--bold .free-canvas-block__exp-entreprise strong {
-  color: #1e293b;
+  font-weight: 700 !important;
+  color: #1e293b !important;
 }
 
 .free-canvas-page--tpl-bold .free-canvas-block__exp-dates {
   color: var(--free-canvas-accent) !important;
-  font-weight: 700;
-  font-size: 8.5pt;
+  font-weight: 700 !important;
+  font-size: 8.5pt !important;
 }
 
 .free-canvas-page--tpl-bold .free-canvas-block__exp--bold .free-canvas-block__exp-role {
-  font-size: 9pt;
-  font-weight: 600;
-  color: #64748b;
-  margin: 0.3mm 0 0.8mm;
+  font-size: 9pt !important;
+  font-weight: 600 !important;
+  color: #64748b !important;
+  margin: 1px 0 3px;
 }
 
 .free-canvas-page--tpl-bold .free-canvas-block__exp-clients {

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -176,7 +176,7 @@
 .free-canvas-page--tpl-bold .free-canvas-block__identity--inline-title {
   margin: 0;
   font-size: 20pt;
-  font-weight: 800;
+  font-weight: 800 !important;
   line-height: 1.1;
   letter-spacing: -0.01em;
 }
@@ -184,6 +184,7 @@
 .free-canvas-page--tpl-bold .free-canvas-block__identity--inline-title .free-canvas-block__identity-name {
   display: inline;
   white-space: nowrap;
+  font-weight: 800 !important;
 }
 
 .free-canvas-page--tpl-bold .free-canvas-block__identity--inline-title .free-canvas-block__identity-sep {
@@ -274,6 +275,51 @@
   color: #475569;
   line-height: 1.45;
   margin: 0 0 0.3mm;
+}
+
+.free-canvas-page--tpl-bold .free-canvas-block__bullets--dash {
+  list-style: none;
+  margin: 0.4mm 0 0;
+  padding: 0;
+}
+
+.free-canvas-page--tpl-bold .free-canvas-block__bullets--dash li {
+  position: relative;
+  padding-left: 2.8mm;
+  margin: 0 0 0.3mm;
+  font-size: 8.5pt;
+  line-height: 1.4;
+  color: #1e293b;
+}
+
+.free-canvas-page--tpl-bold .free-canvas-block__bullets--dash li::before {
+  content: '-';
+  position: absolute;
+  left: 0;
+  color: #1e293b;
+}
+
+.free-canvas-page--tpl-bold .free-canvas-block__formation--minimal {
+  margin: 0 0 1.1mm;
+}
+
+.free-canvas-page--tpl-bold .free-canvas-block__formation--minimal .free-canvas-block__formation-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 2.5mm;
+}
+
+.free-canvas-page--tpl-bold .free-canvas-block__formation--minimal .free-canvas-block__formation-diplome {
+  font-weight: 700;
+  font-size: 9pt;
+}
+
+.free-canvas-page--tpl-bold .free-canvas-block__formation--minimal .free-canvas-block__formation-date {
+  font-size: 8.5pt;
+  font-weight: 700;
+  color: var(--free-canvas-accent);
+  white-space: nowrap;
 }
 
 /* ---------- Classique (réplique templates/classic — AXE-389) ---------- */

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -212,11 +212,20 @@
   border: 0.8mm solid var(--free-canvas-accent);
 }
 
+.free-canvas-page--tpl-bold .free-canvas-block__inner--zone-header .free-canvas-block__resume {
+  color: rgba(255, 255, 255, 0.88) !important;
+  font-size: 9pt !important;
+  line-height: 1.45;
+  margin: 0;
+  text-align: justify;
+}
+
 .free-canvas-page--tpl-bold .free-canvas-block__contact--header-bar {
   text-align: center;
   justify-content: center;
   margin: 0;
-  color: rgba(255, 255, 255, 0.75);
+  color: rgba(255, 255, 255, 0.75) !important;
+  gap: 2mm;
 }
 
 .free-canvas-page--tpl-bold .free-canvas-block__contact--header-bar .free-canvas-block__contact-icon {
@@ -224,10 +233,19 @@
   vertical-align: middle;
 }
 
+.free-canvas-page--tpl-bold .free-canvas-block__contact--header-bar .free-canvas-block__contact-spacer {
+  white-space: pre;
+  margin: 0 1.5mm;
+}
+
 .free-canvas-page--tpl-bold .free-canvas-block__contact--uppercase {
   text-transform: uppercase;
   letter-spacing: 0.04em;
   font-size: 8.5pt;
+}
+
+.free-canvas-page--tpl-bold .free-canvas-block__pdf-fidelity-badge {
+  display: none;
 }
 
 .free-canvas-page--tpl-bold .free-canvas-block__exp--bold {
@@ -251,7 +269,7 @@
 }
 
 .free-canvas-page--tpl-bold .free-canvas-block__exp-dates {
-  color: var(--free-canvas-accent);
+  color: var(--free-canvas-accent) !important;
   font-weight: 700;
   font-size: 8.5pt;
 }

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -214,6 +214,12 @@
 .free-canvas-page--tpl-bold .free-canvas-block[data-block-type='identity'] .free-canvas-block__inner--zone-header {
   display: flex;
   align-items: center;
+  justify-content: flex-start;
+  height: 100%;
+}
+
+.free-canvas-page--tpl-bold .free-canvas-block[data-block-type='identity'] .free-canvas-block__identity--inline-title {
+  width: 100%;
 }
 
 .free-canvas-page--tpl-bold .free-canvas-block__inner--zone-header .free-canvas-block__identity-title--accent {

--- a/frontend/tests/unit/canvasCvImportAdapter.test.js
+++ b/frontend/tests/unit/canvasCvImportAdapter.test.js
@@ -449,12 +449,17 @@ test('bold header : lock_geometry garde photo | identity | résumé | contact', 
   const contact = page0.find((b) => b.type === 'contact');
   assert.ok(photo && identity && resume && contact);
   assert.ok(
-    Math.abs(identity.y - photo.y) < 2,
-    'identity reste à côté de la photo (pas empilée dessous)',
+    Math.abs(identity.y - photo.y) < 0.05,
+    'identity même y que la photo',
+  );
+  assert.ok(
+    Math.abs(identity.h - photo.h) < 0.05,
+    'identity même hauteur que la photo (centrage vertical)',
   );
   assert.ok(resume.y >= photo.y + photo.h - 0.05, 'résumé sous la rangée photo');
   assert.ok(contact.y >= resume.y + resume.h - 0.05, 'contact sous résumé');
   assert.equal(resume.style?.show_section_title, false);
+  assert.equal(identity.style?.lock_geometry, true);
 });
 
 test('classic sidebar : cascade resserre les blocs (pas de trous après shrink)', () => {

--- a/frontend/tests/unit/canvasCvImportAdapter.test.js
+++ b/frontend/tests/unit/canvasCvImportAdapter.test.js
@@ -424,6 +424,39 @@ test('classic preserveReplicaGeometry : contenu main reste page 1 (lanes sépar�
   );
 });
 
+test('bold header : lock_geometry garde photo | identity | résumé | contact', () => {
+  const cv = {
+    prenom: 'Louis',
+    nom: 'Vedovato',
+    titre_professionnel: 'Product Owner - Michelin',
+    telephone: '06',
+    email: 'a@b.fr',
+    linkedin: 'louis.vedovato',
+    resume: 'Product owner chez Michelin pour mon alternance de 20 mois',
+    experiences: [{ entreprise: 'A', poste: 'B', bullet_points: ['x'] }],
+    formations: [{ etablissement: 'E', diplome: 'D', date: '2023' }],
+    competences: { techniques: ['Python'] },
+    photo_url: 'https://example.com/p.jpg',
+  };
+  const { layout } = adaptCanvasLayoutForCv(cv, createCanvasLayoutForTemplate({ id: 'bold' }), {
+    preserveReplicaGeometry: true,
+    templateId: 'bold',
+  });
+  const page0 = layout.pages[0].blocks;
+  const photo = page0.find((b) => b.type === 'photo');
+  const identity = page0.find((b) => b.type === 'identity');
+  const resume = page0.find((b) => b.type === 'resume');
+  const contact = page0.find((b) => b.type === 'contact');
+  assert.ok(photo && identity && resume && contact);
+  assert.ok(
+    Math.abs(identity.y - photo.y) < 2,
+    'identity reste à côté de la photo (pas empilée dessous)',
+  );
+  assert.ok(resume.y >= photo.y + photo.h - 0.05, 'résumé sous la rangée photo');
+  assert.ok(contact.y >= resume.y + resume.h - 0.05, 'contact sous résumé');
+  assert.equal(resume.style?.show_section_title, false);
+});
+
 test('classic sidebar : cascade resserre les blocs (pas de trous après shrink)', () => {
   const cv = {
     prenom: 'L',

--- a/frontend/tests/unit/canvasTemplateSpecs.test.js
+++ b/frontend/tests/unit/canvasTemplateSpecs.test.js
@@ -121,12 +121,20 @@ test('bold réplique Stable : header Impact + freeform + cascade', () => {
 
   assert.ok(photo && identity && contact && resume);
   assert.equal(photo.style?.photo_border, 'accent-thick');
+  assert.equal(photo.style?.lock_geometry, true);
   assert.equal(identity.style?.header_layout, 'inline-title');
   assert.equal(identity.style?.title_accent, true);
+  assert.equal(identity.style?.lock_geometry, true);
   assert.notEqual(identity.style?.bold, true, 'pas de bold inline 700 (twin CSS 800)');
+  assert.equal(resume.style?.show_section_title, false, 'pas de titre Profil dans le header');
+  assert.equal(resume.style?.lock_geometry, true);
   assert.equal(contact.style?.contact_layout, 'header-bar');
   assert.equal(contact.style?.align, 'center');
   assert.equal(contact.style?.contact_uppercase, true);
+  assert.equal(contact.style?.lock_geometry, true);
+  assert.deepEqual(contact.bind, ['telephone', 'email', 'linkedin']);
+  assert.ok(resume.y > identity.y, 'résumé sous identity');
+  assert.ok(contact.y > resume.y, 'contact sous résumé');
   assert.equal(experiences.style?.exp_style, 'bold');
   assert.equal(experiences.style?.title_style, 'bold-main');
   assert.equal(formations.style?.formation_style, 'minimal');

--- a/frontend/tests/unit/canvasTemplateSpecs.test.js
+++ b/frontend/tests/unit/canvasTemplateSpecs.test.js
@@ -109,6 +109,41 @@ test('minimal réplique Stable : contact inline ·, titres Title Case, exp ATS',
   assert.equal(layout.freeform, true, 'minimal freeform pour préserver la géométrie Stable');
 });
 
+test('bold réplique Stable : header Impact + freeform + cascade', () => {
+  const blocks = buildTemplateBlocks({ id: 'bold' });
+  const photo = blocks.find((b) => b.type === 'photo');
+  const identity = blocks.find((b) => b.type === 'identity');
+  const contact = blocks.find((b) => b.type === 'contact');
+  const resume = blocks.find((b) => b.type === 'resume');
+  const experiences = blocks.find((b) => b.type === 'experiences');
+  const formations = blocks.find((b) => b.type === 'formations');
+  const shapes = blocks.filter((b) => b.type === 'shape:rect');
+
+  assert.ok(photo && identity && contact && resume);
+  assert.equal(photo.style?.photo_border, 'accent-thick');
+  assert.equal(identity.style?.header_layout, 'inline-title');
+  assert.equal(identity.style?.title_accent, true);
+  assert.notEqual(identity.style?.bold, true, 'pas de bold inline 700 (twin CSS 800)');
+  assert.equal(contact.style?.contact_layout, 'header-bar');
+  assert.equal(contact.style?.align, 'center');
+  assert.equal(contact.style?.contact_uppercase, true);
+  assert.equal(experiences.style?.exp_style, 'bold');
+  assert.equal(experiences.style?.title_style, 'bold-main');
+  assert.equal(formations.style?.formation_style, 'minimal');
+  assert.ok(shapes.length >= 3, 'header + barre accent + sidebar');
+
+  const theme = parseCanvasTheme({ id: 'bold' });
+  assert.match(theme.font_heading, /Plus Jakarta Sans/);
+  assert.equal(theme.color_section_title, '#1e293b');
+  assert.equal(theme.color_accent, '#dc2626');
+
+  const layout = createCanvasLayoutForTemplate({ id: 'bold' });
+  assert.equal(layout.freeform, true);
+  assert.equal(layout.replica_cascade, true);
+  assert.equal(getTemplateCanvasFidelity('bold')?.readiness, 'near-replica');
+  assert.equal(getTemplateCanvasFidelity('bold')?.fidelityCss, 'rich');
+});
+
 test('bold reste le plus proche d’une réplique (near-replica)', () => {
   assert.equal(getTemplateCanvasFidelity('bold')?.readiness, 'near-replica');
   assert.equal(getTemplateCanvasFidelity('bold')?.fidelityCss, 'rich');


### PR DESCRIPTION
## Summary
- Polish near-replica **Bold / Impact** : `freeform` + `replica_cascade`, typo 800, bullets `-`, dates ` - `, formations flex, thème font + titres slate (pas rouge accent)
- Tests structurels + doc `template-canvas-fidelity.md`
- Fixes AXE-390 · Closes #178

## What changed
- `layoutTemplatePresets` : Bold en réplique cascade (comme Classic)
- `parseCanvasTheme` : font defaults ; Bold garde `color_section_title` slate
- `FreeCanvasBlock` : dash bullets, ordre bullets→Clients, secteur inline
- Twin CSS formation + bullets Impact

## Why
Écarts résiduels Stable↔Beta sur le twin déjà near-replica (suite AXE-346 après Classic).

## Validation
- [x] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks`
- [x] Unit tests canvasTemplateSpecs / canvasCvImportAdapter
- [ ] Checklist visuelle Apply Stable→Beta Bold vs preview Stable

## Risk and rollback
- Risque borné au template `bold` + CSS twin ; rollback = revert PR.
- Pas de changement chrome app DS (`--ds-*`).

## Test plan
- [ ] Apply design Stable Bold → Beta : header, barre rouge, sidebar, exp
- [ ] Résumé court : header pas trop haut (cascade)
- [ ] Pas de régression Minimal / Élégant / Classic


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Améliorations**
  - Le modèle **Impact (bold)** bénéficie d’une mise en page plus fidèle, notamment pour l’en-tête, les contacts, les expériences et les formations.
  - Les dates et listes utilisent désormais un format harmonisé avec des tirets.
  - L’affichage du secteur et l’ordre des informations clients ont été ajustés.
  - Le rendu à l’impression et en PDF est amélioré, avec une meilleure cohérence des dimensions, couleurs et espacements.

- **Corrections**
  - Les blocs à géométrie verrouillée ne sont plus redimensionnés automatiquement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->