### PR TITLE
Feat: réplique canvas Beta Modern (Stable twin)

### DIFF
--- a/docs/template-canvas-fidelity.md
+++ b/docs/template-canvas-fidelity.md
@@ -29,7 +29,7 @@ Le template virtuel `beta` (`betaCanvasTemplate.js`) n’est **pas** une twin HT
 |----|---------|-----------|--------------|-----------------|
 | `minimal` | single-column | near-replica | **rich** | Checklist visuelle OK (PR #170) |
 | `classic` | sidebar-right | near-replica | **rich** | Checklist visuelle + densité PDF (AXE-389 / PR #177) |
-| `modern` | sidebar-left | projection | medium | Sidebar / accents |
+| `modern` | sidebar-left | near-replica | **rich** | Checklist visuelle + densité PDF (AXE-391) |
 | `creative` | sidebar-left | projection | medium | Titres creative-main |
 | `elegant` | single-column | near-replica | **rich** | Checklist visuelle OK (PR #174 / AXE-388) |
 | `executive` | sidebar-right | projection | medium | Header band |
@@ -63,6 +63,12 @@ Source de vérité code : `TEMPLATE_CANVAS_FIDELITY` + `STABLE_CANVAS_TEMPLATE_I
 2. **CSS** `templates/bold/template.css` — titres 800 + border-left accent, exp ATS, bullets `-`, formations flex + dates accent
 3. **Canvas** `buildTemplateBlocks('bold')` + twin CSS + `exp_style: bold` + `formation_style: minimal` + `freeform` / `replica_cascade`
 
+### Modern — couches Stable à calquer (AXE-391)
+
+1. **HTML** `templates/modern/template.html` — sidebar gauche (photo, identité, CONTACT, compétences…), main PROFIL → EXP → FORMATION → PROJETS
+2. **CSS** `templates/modern/template.css` — sidebar 200px `#2d3748`, titres main underline accent `#3182ce`, photo 80px
+3. **Canvas** `buildTemplateBlocks('modern')` + twin CSS + `exp_style: modern` + `title_style: modern-main|modern-sidebar` + `freeform` / `replica_cascade`
+
 ## Critères de « réplique native »
 
 Pour un id catalogue :
@@ -78,8 +84,9 @@ Pour un id catalogue :
 2. ~~Tranche Minimal~~ validée checklist visuelle
 3. ~~Élégant~~ (AXE-388 / PR #174) — near-replica
 4. ~~Classic~~ (AXE-389 / PR #177) — near-replica ; checklist visuelle + densité PDF à valider
-5. **Bold / Impact** (AXE-390) — polish near-replica (cascade + typo/exp)
-6. Option ultérieure : assets `default_layout.json` par template (voir `docs/editor-vision.md`)
+5. ~~Bold / Impact~~ (AXE-390 / PR #179) — near-replica
+6. **Modern** (AXE-391) — sidebar-left near-replica
+7. Option ultérieure : Creative / Executive ; assets `default_layout.json`
 
 ## Alignement contact header-bar
 

--- a/docs/template-canvas-fidelity.md
+++ b/docs/template-canvas-fidelity.md
@@ -66,7 +66,7 @@ Source de vérité code : `TEMPLATE_CANVAS_FIDELITY` + `STABLE_CANVAS_TEMPLATE_I
 ### Modern — couches Stable à calquer (AXE-391)
 
 1. **HTML** `templates/modern/template.html` — sidebar gauche (photo, identité, CONTACT, compétences…), main PROFIL → EXP → FORMATION → PROJETS
-2. **CSS** `templates/modern/template.css` — sidebar 200px `#2d3748`, titres main underline accent `#3182ce`, photo 80px
+2. **CSS** `templates/modern/template.css` — sidebar 200px `#2d3748`, titres main underline accent `#3182ce`, photo 80px `border: 3px solid rgba(255,255,255,0.3)` (pas de box-shadow)
 3. **Canvas** `buildTemplateBlocks('modern')` + twin CSS + `exp_style: modern` + `title_style: modern-main|modern-sidebar` + `freeform` / `replica_cascade`
 
 ## Critères de « réplique native »

--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -379,12 +379,14 @@ function CvEditorBeta({
   }, [refreshCanvasDrafts]);
 
   const buildTemplateCanvasLayout = useCallback((template) => {
-    let next = template ? createCanvasLayoutForTemplate(template) : createCanvasLayoutBlank();
+    let next = template
+      ? createCanvasLayoutForTemplate(template, templateOptions)
+      : createCanvasLayoutBlank();
     for (let pi = 0; pi < (next.pages?.length || 0); pi += 1) {
       next = reflowColumnBlocksOnPage(next, pi);
     }
     return next;
-  }, []);
+  }, [templateOptions]);
 
   const saveCurrentCanvasDraft = useCallback(() => {
     const currentLayout = layoutRef.current;
@@ -705,7 +707,10 @@ function CvEditorBeta({
     setDesignBridgeConfirming(true);
     setDesignBridgeError('');
     try {
-      const applied = applyStableDesignToCanvas(cv, template, { templatesList });
+      const applied = applyStableDesignToCanvas(cv, template, {
+        templatesList,
+        templateOptions,
+      });
       if (!applied.ok || !applied.layout) {
         setDesignBridgeError(
           applied.reason === 'no_canvas_spec'
@@ -722,7 +727,7 @@ function CvEditorBeta({
     } finally {
       setDesignBridgeConfirming(false);
     }
-  }, [cv, templateId, templatesList, onTemplateIdChange, openCanvasContext]);
+  }, [cv, templateId, templateOptions, templatesList, onTemplateIdChange, openCanvasContext]);
 
   const handleDismissDesignBridge = useCallback(() => {
     setDesignBridgeOffer(null);

--- a/frontend/src/components/editor/FreeCanvasBlock.jsx
+++ b/frontend/src/components/editor/FreeCanvasBlock.jsx
@@ -349,17 +349,22 @@ function SemanticBlockBody({ block, cv, editing = false }) {
     case 'experiences': {
       const items = resolveExperiences(cv, limit);
       if (items.length === 0) return <p className="free-canvas-block__placeholder">Expériences</p>;
-      const boldExp = style.exp_style === 'bold' || style.exp_style === 'elegant' || style.exp_style === 'classic';
+      const boldExp = style.exp_style === 'bold'
+        || style.exp_style === 'elegant'
+        || style.exp_style === 'classic'
+        || style.exp_style === 'modern';
       const elegantExp = style.exp_style === 'elegant';
       const minimalExp = style.exp_style === 'minimal';
       const classicExp = style.exp_style === 'classic';
       const impactExp = style.exp_style === 'bold';
+      const modernExp = style.exp_style === 'modern';
       const atsLabels = boldExp || minimalExp;
-      const hyphenDates = minimalExp || elegantExp || impactExp;
-      const dashBullets = minimalExp || elegantExp || classicExp || impactExp;
-      const clientsAfterBullets = classicExp || impactExp;
+      const hyphenDates = minimalExp || elegantExp || impactExp || modernExp;
+      const dashBullets = minimalExp || elegantExp || classicExp || impactExp || modernExp;
+      const clientsAfterBullets = classicExp || impactExp || modernExp;
+      const secteurInline = impactExp || modernExp;
       return (
-        <div className={`free-canvas-block__section-list${boldExp ? ' free-canvas-block__section-list--bold-exp' : ''}${minimalExp ? ' free-canvas-block__section-list--minimal-exp' : ''}${elegantExp ? ' free-canvas-block__section-list--elegant-exp' : ''}`}>
+        <div className={`free-canvas-block__section-list${boldExp ? ' free-canvas-block__section-list--bold-exp' : ''}${minimalExp ? ' free-canvas-block__section-list--minimal-exp' : ''}${elegantExp ? ' free-canvas-block__section-list--elegant-exp' : ''}${modernExp ? ' free-canvas-block__section-list--modern-exp' : ''}`}>
           <SectionHeading
             label={style.section_label || SECTION_LABELS.experiences}
             titleStyle={style.title_style}
@@ -441,7 +446,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
             return (
               <div
                 key={exp.id || i}
-                className={`free-canvas-block__exp${format === 'compact' ? ' free-canvas-block__exp--compact' : ''}${boldExp ? ' free-canvas-block__exp--bold' : ''}${minimalExp ? ' free-canvas-block__exp--minimal' : ''}${elegantExp ? ' free-canvas-block__exp--elegant' : ''}${classicExp ? ' free-canvas-block__exp--classic' : ''}`}
+                className={`free-canvas-block__exp${format === 'compact' ? ' free-canvas-block__exp--compact' : ''}${boldExp ? ' free-canvas-block__exp--bold' : ''}${minimalExp ? ' free-canvas-block__exp--minimal' : ''}${elegantExp ? ' free-canvas-block__exp--elegant' : ''}${classicExp ? ' free-canvas-block__exp--classic' : ''}${modernExp ? ' free-canvas-block__exp--modern' : ''}`}
               >
                 {minimalExp ? (
                   <>
@@ -477,7 +482,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
                       <p className="free-canvas-block__exp-role">
                         {atsLabels ? <span className="free-canvas-block__ats-label">Fonction : </span> : null}
                         {posteNode}
-                        {impactExp && (editing || (exp.secteur || '').trim()) ? (
+                        {secteurInline && (editing || (exp.secteur || '').trim()) ? (
                           <>
                             {' - '}
                             {editing ? (

--- a/frontend/src/lib/canvasCvImportAdapter.js
+++ b/frontend/src/lib/canvasCvImportAdapter.js
@@ -1045,7 +1045,10 @@ export function adaptCanvasLayoutForCv(cv, layout, {
  * Pipeline complet : template → layout → adaptation au CV importé.
  */
 export function buildAdaptedCanvasLayoutForCv(cv, template, options = {}) {
-  const base = createCanvasLayoutForTemplate(template);
+  const base = createCanvasLayoutForTemplate(
+    template,
+    options.optionValues || options.templateOptions || null,
+  );
   const templateId = template?.id || options.templateId || '';
   const preserveReplicaGeometry = Boolean(
     options.preserveReplicaGeometry

--- a/frontend/src/lib/canvasTemplateSpecs.js
+++ b/frontend/src/lib/canvasTemplateSpecs.js
@@ -118,8 +118,11 @@ function bar(x, y, w, h, color, z = 1) {
   return { type: 'shape:rect', x, y, w, h, z, style: { color } };
 }
 
-/** @param {object} template */
-export function parseCanvasTheme(template) {
+/**
+ * @param {object} template
+ * @param {Record<string, unknown>|null|undefined} [optionValues] valeurs live (Stable template_options)
+ */
+export function parseCanvasTheme(template, optionValues = null) {
   const id = template?.id || 'classic';
   const theme = {
     template_id: id,
@@ -155,23 +158,55 @@ export function parseCanvasTheme(template) {
       : theme.font_heading;
   }
 
+  const live = optionValues && typeof optionValues === 'object' ? optionValues : null;
+  const resolveOpt = (key, fallback) => {
+    if (live && live[key] != null && String(live[key]).trim() !== '') return live[key];
+    return fallback;
+  };
+
   const opts = template?.options;
   if (Array.isArray(opts)) {
     opts.forEach((o) => {
-      if (o?.key === 'accent_color' && o.default) {
-        theme.color_accent = o.default;
-        // Bold Stable : titres corps restent slate ; accent = filets/dates seulement.
-        if (id !== 'creative' && id !== 'bold') theme.color_section_title = o.default;
+      if (o?.key === 'accent_color') {
+        const val = resolveOpt('accent_color', o.default);
+        if (val) {
+          theme.color_accent = val;
+          // Bold Stable : titres corps restent slate ; accent = filets/dates seulement.
+          if (id !== 'creative' && id !== 'bold') theme.color_section_title = val;
+        }
       }
-      if (o?.key === 'header_color' && o.default) theme.color_header = o.default;
-      if (o?.key === 'sidebar_color' && o.default) theme.color_sidebar = o.default;
-      if (o?.key === 'font' && o.default) {
-        theme.font_heading = fontStackFromTemplateOption(o.default);
-        theme.font_body = id === 'executive' || id === 'minimal' || id === 'elegant'
-          ? 'Inter, sans-serif'
-          : theme.font_heading;
+      if (o?.key === 'header_color') {
+        const val = resolveOpt('header_color', o.default);
+        if (val) theme.color_header = val;
+      }
+      if (o?.key === 'sidebar_color') {
+        const val = resolveOpt('sidebar_color', o.default);
+        if (val) theme.color_sidebar = val;
+      }
+      if (o?.key === 'font') {
+        const val = resolveOpt('font', o.default);
+        if (val) {
+          theme.font_heading = fontStackFromTemplateOption(val);
+          theme.font_body = id === 'executive' || id === 'minimal' || id === 'elegant'
+            ? 'Inter, sans-serif'
+            : theme.font_heading;
+        }
       }
     });
+  } else if (live) {
+    // Template catalogue sans schema options (id seul) : appliquer les valeurs live.
+    if (live.accent_color) {
+      theme.color_accent = live.accent_color;
+      if (id !== 'creative' && id !== 'bold') theme.color_section_title = live.accent_color;
+    }
+    if (live.header_color) theme.color_header = live.header_color;
+    if (live.sidebar_color) theme.color_sidebar = live.sidebar_color;
+    if (live.font) {
+      theme.font_heading = fontStackFromTemplateOption(live.font);
+      theme.font_body = id === 'executive' || id === 'minimal' || id === 'elegant'
+        ? 'Inter, sans-serif'
+        : theme.font_heading;
+    }
   }
   if (id === 'creative') theme.color_section_title = theme.color_sidebar;
   return theme;
@@ -337,9 +372,13 @@ function sidebarCompetenceBlocksDetailed(x, w, startY, style, z) {
   ];
 }
 
-export function buildTemplateBlocks(template) {
+/**
+ * @param {object} template
+ * @param {Record<string, unknown>|null|undefined} [optionValues]
+ */
+export function buildTemplateBlocks(template, optionValues = null) {
   const id = template?.id;
-  const t = parseCanvasTheme(template);
+  const t = parseCanvasTheme(template, optionValues);
   const { SB, MAIN_L, MAIN_R, SB_R, H } = LAYOUT;
   const sx = SIDE_PAD_X;
   const sy = SIDE_PAD_Y;

--- a/frontend/src/lib/canvasTemplateSpecs.js
+++ b/frontend/src/lib/canvasTemplateSpecs.js
@@ -50,9 +50,9 @@ export const TEMPLATE_CANVAS_FIDELITY = Object.freeze({
   modern: {
     name: 'Moderne',
     layoutFamily: 'sidebar-left',
-    readiness: 'projection',
-    fidelityCss: 'medium',
-    gaps: ['Détails sidebar (outils/langues) et accents underline à peaufiner'],
+    readiness: 'near-replica',
+    fidelityCss: 'rich',
+    gaps: ['Checklist visuelle Stable↔Beta (AXE-391)', 'Densité PDF compacte à valider'],
   },
   creative: {
     name: 'Créatif',
@@ -224,6 +224,20 @@ const sideLight = (extra = {}) => ({
 
 const px = (n) => (n * 25.4) / 96;
 
+/** Layout colonne gauche type Modern / Creative (sidebar 200px). */
+function leftSidebarMetrics() {
+  const SB = px(200);
+  return {
+    SB,
+    SB_X: 0,
+    SX: px(14),
+    SY: px(20),
+    MAIN_X: SB + px(18),
+    MAIN_W: PAGE_WIDTH_MM - SB - px(36),
+    MAIN_Y: px(16),
+  };
+}
+
 /** Layout colonne droite type Impact / Executive (sidebar 200px). */
 function rightSidebarMetrics() {
   const SB = px(200);
@@ -332,21 +346,170 @@ export function buildTemplateBlocks(template) {
   const mx = MAIN_L.x + MAIN_PAD_X;
   const mw = MAIN_L.w - MAIN_PAD_X * 2;
   switch (id) {
-    case 'modern':
+    case 'modern': {
+      // Réplique templates/modern : sidebar gauche (photo, identité, contact, skills…),
+      // main droite PROFIL → EXP → FORMATION → PROJETS.
+      const { SB, SX, SY, MAIN_X, MAIN_W, MAIN_Y } = leftSidebarMetrics();
+      const PHOTO = px(80);
+      const photoX = (SB - PHOTO) / 2;
+      const identityY = SY + PHOTO + px(10);
+      const identityH = px(40);
+      const contactY = identityY + identityH + px(10);
+      const sideW = SB - SX * 2;
+      const sideLock = { lock_geometry: true };
+      const sideCol = (extra = {}) => ({
+        ...side(),
+        title_style: 'modern-sidebar',
+        font_family: t.font_heading,
+        ...extra,
+      });
+      const mainCol = (extra = {}) => ({
+        ...main(),
+        title_style: 'modern-main',
+        font_family: t.font_heading,
+        ...extra,
+      });
       return [
         bg(0, 0, SB, H, t.color_sidebar, 0),
-        { type: 'photo', x: SB / 2 - 11, y: sy, w: 22, h: 22, z: 2, style: { shape: 'circle', zone: 'sidebar', photo_border: 'light' } },
-        { type: 'identity', bind: ['prenom', 'nom', 'titre_professionnel'], x: sx, y: sy + 24, w: SB - sx * 2, h: 22, z: 2, style: { ...side(), font_size: 13, identity_divider: true } },
-        { type: 'contact', bind: ['email', 'telephone', 'linkedin'], x: sx, y: sy + 48, w: SB - sx * 2, h: 26, z: 2, style: { ...side(), section_label: 'CONTACT' } },
-        ...sidebarCompetenceBlocks(sx, SB - sx * 2, sy + 76, side(), 2, { tools: 'OUTILS' }),
-        { type: 'languages', x: sx, y: sy + 112, w: SB - sx * 2, h: 20, z: 2, style: { ...side(), section_label: 'LANGUES', list_format: 'list' } },
-        { type: 'certifications', bind: 'certifications', x: sx, y: sy + 134, w: SB - sx * 2, h: 24, z: 2, style: { ...side(), section_label: 'CERTIFICATIONS', list_format: 'list' } },
-        { type: 'skills', bind: 'competences.autres', x: sx, y: sy + 160, w: SB - sx * 2, h: 22, z: 2, style: { ...side(), section_label: 'AUTRES', list_format: 'list' } },
-        { type: 'resume', bind: 'resume', x: mx, y: MAIN_PAD_Y, w: mw, h: 20, z: 1, style: { ...main(), section_label: 'PROFIL', font_style: 'italic', align: 'justify' } },
-        { type: 'experiences', bind: 'experiences', x: mx, y: MAIN_PAD_Y + 24, w: mw, h: 128, z: 1, style: { ...main(), section_label: 'EXPÉRIENCE PROFESSIONNELLE', title_style: 'underline-accent' } },
-        { type: 'formations', bind: 'formations', x: mx, y: MAIN_PAD_Y + 156, w: mw, h: 36, z: 1, style: { ...main(), section_label: 'FORMATION', title_style: 'underline-accent' } },
-        { type: 'projets', bind: 'projets', x: mx, y: MAIN_PAD_Y + 196, w: mw, h: 28, z: 1, style: { ...main(), section_label: 'PROJETS', title_style: 'underline-accent' } },
+        {
+          type: 'photo',
+          x: photoX,
+          y: SY,
+          w: PHOTO,
+          h: PHOTO,
+          z: 2,
+          style: { shape: 'circle', zone: 'sidebar', photo_border: 'light', align: 'center', ...sideLock },
+        },
+        {
+          type: 'identity',
+          bind: ['prenom', 'nom', 'titre_professionnel'],
+          x: SX,
+          y: identityY,
+          w: sideW,
+          h: identityH,
+          z: 2,
+          style: {
+            ...sideCol(),
+            align: 'center',
+            identity_divider: true,
+            identity_layout: 'modern-sidebar',
+            ...sideLock,
+          },
+        },
+        {
+          type: 'contact',
+          bind: ['telephone', 'email', 'linkedin'],
+          x: SX,
+          y: contactY,
+          w: sideW,
+          h: px(48),
+          z: 2,
+          style: { ...sideCol(), section_label: 'CONTACT', align: 'left' },
+        },
+        {
+          type: 'skills',
+          bind: 'competences.techniques',
+          x: SX,
+          y: contactY + px(52),
+          w: sideW,
+          h: px(40),
+          z: 2,
+          style: { ...sideCol(), section_label: 'COMPÉTENCES', align: 'left' },
+        },
+        {
+          type: 'skills',
+          bind: 'competences.logiciels',
+          x: SX,
+          y: contactY + px(96),
+          w: sideW,
+          h: px(34),
+          z: 2,
+          style: { ...sideCol(), section_label: 'OUTILS', align: 'left' },
+        },
+        {
+          type: 'certifications',
+          bind: 'certifications',
+          x: SX,
+          y: contactY + px(134),
+          w: sideW,
+          h: px(28),
+          z: 2,
+          style: { ...sideCol(), section_label: 'CERTIFICATIONS', align: 'left' },
+        },
+        {
+          type: 'languages',
+          x: SX,
+          y: contactY + px(166),
+          w: sideW,
+          h: px(24),
+          z: 2,
+          style: { ...sideCol(), section_label: 'LANGUES', align: 'left' },
+        },
+        {
+          type: 'skills',
+          bind: 'competences.autres',
+          x: SX,
+          y: contactY + px(194),
+          w: sideW,
+          h: px(28),
+          z: 2,
+          style: { ...sideCol(), section_label: 'AUTRES', align: 'left' },
+        },
+        {
+          type: 'resume',
+          bind: 'resume',
+          x: MAIN_X,
+          y: MAIN_Y,
+          w: MAIN_W,
+          h: px(36),
+          z: 1,
+          style: {
+            ...mainCol(),
+            section_label: 'PROFIL',
+            font_style: 'italic',
+            align: 'justify',
+          },
+        },
+        {
+          type: 'experiences',
+          bind: 'experiences',
+          x: MAIN_X,
+          y: MAIN_Y + px(42),
+          w: MAIN_W,
+          h: px(160),
+          z: 1,
+          style: {
+            ...mainCol(),
+            section_label: 'EXPÉRIENCE PROFESSIONNELLE',
+            exp_style: 'modern',
+          },
+        },
+        {
+          type: 'formations',
+          bind: 'formations',
+          x: MAIN_X,
+          y: MAIN_Y + px(208),
+          w: MAIN_W,
+          h: px(36),
+          z: 1,
+          style: {
+            ...mainCol(),
+            section_label: 'FORMATION',
+            formation_style: 'minimal',
+          },
+        },
+        {
+          type: 'projets',
+          bind: 'projets',
+          x: MAIN_X,
+          y: MAIN_Y + px(250),
+          w: MAIN_W,
+          h: px(28),
+          z: 1,
+          style: { ...mainCol(), section_label: 'PROJETS' },
+        },
       ];
+    }
 
     case 'creative':
       return [

--- a/frontend/src/lib/designModeBridge.js
+++ b/frontend/src/lib/designModeBridge.js
@@ -54,6 +54,7 @@ export function applyStableDesignToCanvas(cv, template, options = {}) {
     templatesList: options.templatesList,
     templateId: template.id,
     preserveReplicaGeometry: true,
+    optionValues: options.optionValues || options.templateOptions || null,
   });
   return {
     ok: true,

--- a/frontend/src/lib/layoutTemplatePresets.js
+++ b/frontend/src/lib/layoutTemplatePresets.js
@@ -4,13 +4,17 @@
 import { buildTemplateBlocks, parseCanvasTheme } from './canvasTemplateSpecs.js';
 import { createBlankLayoutV3, createStarterLayoutV3, sanitizeLayoutV3 } from './cvLayoutModelV3.js';
 
-export function createCanvasLayoutForTemplate(template) {
+/**
+ * @param {object} template
+ * @param {Record<string, unknown>|null|undefined} [optionValues] Stable template_options live
+ */
+export function createCanvasLayoutForTemplate(template, optionValues = null) {
   if (!template?.id) return createStarterLayoutV3();
-  const blocks = buildTemplateBlocks(template);
+  const blocks = buildTemplateBlocks(template, optionValues);
   if (!blocks.length) return createStarterLayoutV3();
   const layout = createStarterLayoutV3();
   layout.pages[0].blocks = blocks;
-  layout.theme = { ...layout.theme, ...parseCanvasTheme(template) };
+  layout.theme = { ...layout.theme, ...parseCanvasTheme(template, optionValues) };
   // Répliques mono-colonne : géométrie mm calquée Stable — ne pas ré-empiler au reflow ATS.
   // `replica_cascade` : autorise le reflow colonne après auto-height (sans toucher lock_geometry).
   if (

--- a/frontend/src/lib/layoutTemplatePresets.js
+++ b/frontend/src/lib/layoutTemplatePresets.js
@@ -18,6 +18,7 @@ export function createCanvasLayoutForTemplate(template) {
     || template.id === 'elegant'
     || template.id === 'classic'
     || template.id === 'bold'
+    || template.id === 'modern'
   ) {
     layout.freeform = true;
     layout.replica_cascade = true;

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -1,15 +1,13 @@
 /* Styles canvas calqués sur templates/*.css - actifs via .free-canvas-page--tpl-{id} */
 
-/* ---------- Moderne ---------- */
+/* ---------- Moderne (réplique templates/modern — AXE-391) ---------- */
 .free-canvas-page--tpl-modern {
   font-family: Inter, Arial, sans-serif;
+  color: #1a1a1a;
 }
 
-.free-canvas-page--tpl-modern .free-canvas-block__inner--zone-sidebar .free-canvas-block__identity-name {
-  font-size: 13pt;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-  padding-bottom: 2mm;
-  margin-bottom: 2mm;
+.free-canvas-page--tpl-modern .free-canvas-block__inner {
+  padding: 0;
 }
 
 .free-canvas-page--tpl-modern .free-canvas-block__photo--border-light {
@@ -17,31 +15,156 @@
   border-radius: 50%;
 }
 
-.free-canvas-page--tpl-modern .free-canvas-block__section-title--sidebar {
-  font-size: 8pt;
-  letter-spacing: 0.08em;
-  color: rgba(255, 255, 255, 0.94);
-  border-bottom: 1px solid rgba(186, 230, 253, 0.35);
-  text-transform: uppercase;
+.free-canvas-page--tpl-modern .free-canvas-block__identity--modern-sidebar,
+.free-canvas-page--tpl-modern .free-canvas-block__identity--divider {
+  text-align: center;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  padding-bottom: 2mm;
+  margin: 0 0 2mm;
 }
 
+.free-canvas-page--tpl-modern .free-canvas-block__identity--modern-sidebar .free-canvas-block__identity-name,
+.free-canvas-page--tpl-modern .free-canvas-block__inner--zone-sidebar .free-canvas-block__identity-name {
+  font-size: 13pt !important;
+  font-weight: 700 !important;
+  color: #ffffff !important;
+  border-bottom: none;
+  padding-bottom: 0;
+  margin: 0;
+  line-height: 1.2;
+}
+
+.free-canvas-page--tpl-modern .free-canvas-block__identity--modern-sidebar .free-canvas-block__identity-title,
+.free-canvas-page--tpl-modern .free-canvas-block__inner--zone-sidebar .free-canvas-block__identity-title {
+  font-size: 8.5pt !important;
+  font-weight: 400 !important;
+  color: rgba(255, 255, 255, 0.85) !important;
+  font-style: normal !important;
+  opacity: 1 !important;
+  margin: 1mm 0 0;
+}
+
+.free-canvas-page--tpl-modern .free-canvas-block__section-title--modern-sidebar,
+.free-canvas-page--tpl-modern .free-canvas-block__section-title--sidebar {
+  font-size: 8pt !important;
+  font-weight: 700 !important;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.94) !important;
+  border-bottom: 1px solid rgba(186, 230, 253, 0.35) !important;
+  text-transform: uppercase;
+  margin: 0 0 1.5mm;
+  padding-bottom: 1px;
+}
+
+.free-canvas-page--tpl-modern .free-canvas-block__section-title--modern-main,
 .free-canvas-page--tpl-modern .free-canvas-block__section-title--underline-accent {
-  font-size: 9.5pt;
-  color: var(--free-canvas-accent);
-  border-bottom: 0.5mm solid var(--free-canvas-accent);
+  font-size: 9.5pt !important;
+  font-weight: 700 !important;
+  color: var(--free-canvas-accent, #3182ce) !important;
+  border-bottom: 2px solid var(--free-canvas-accent, #3182ce) !important;
   letter-spacing: 0.04em;
   text-transform: none;
+  margin: 0 0 2mm;
+  padding-bottom: 1px;
 }
 
 .free-canvas-page--tpl-modern .free-canvas-block__resume {
-  font-style: italic;
+  font-style: italic !important;
   text-align: justify;
-  color: #444;
+  color: #1a1a1a !important;
+  font-size: 9pt !important;
+  line-height: 1.4;
+  margin: 0;
 }
 
-.free-canvas-page--tpl-modern .free-canvas-block__exp-dates {
-  font-weight: 700;
+.free-canvas-page--tpl-modern .free-canvas-block__sidebar-item,
+.free-canvas-page--tpl-modern .free-canvas-block__inner--zone-sidebar .free-canvas-block__contact p,
+.free-canvas-page--tpl-modern .free-canvas-block__inner--zone-sidebar li {
+  font-size: 8pt !important;
+  line-height: 1.35;
+  color: rgba(255, 255, 255, 0.92) !important;
+  margin: 0 0 0.4mm;
+}
+
+.free-canvas-page--tpl-modern .free-canvas-block__exp--modern {
+  margin-bottom: 2mm;
+}
+
+.free-canvas-page--tpl-modern .free-canvas-block__exp--modern .free-canvas-block__exp-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 2mm;
+  margin-bottom: 0.5mm;
+}
+
+.free-canvas-page--tpl-modern .free-canvas-block__exp--modern .free-canvas-block__ats-label {
+  font-size: 0.9em;
+  color: #666666;
+  font-weight: 400;
+}
+
+.free-canvas-page--tpl-modern .free-canvas-block__exp--modern .free-canvas-block__exp-dates {
+  font-weight: 700 !important;
+  font-size: 8.5pt !important;
+  color: #1a1a1a !important;
+  white-space: nowrap;
+}
+
+.free-canvas-page--tpl-modern .free-canvas-block__exp--modern .free-canvas-block__exp-role {
+  font-size: 8.5pt !important;
+  color: #555555 !important;
+  margin: 1px 0 3px;
+}
+
+.free-canvas-page--tpl-modern .free-canvas-block__exp-clients {
+  font-style: italic;
+  font-size: 8pt;
+  color: #777777;
+  margin: 2mm 0 0;
+  padding-top: 1mm;
+  border-top: 1px solid #e8e8e8;
+}
+
+.free-canvas-page--tpl-modern .free-canvas-block__bullets--dash {
+  list-style: none;
+  margin: 0.4mm 0 0;
+  padding: 0;
+}
+
+.free-canvas-page--tpl-modern .free-canvas-block__bullets--dash li {
+  position: relative;
+  padding-left: 2.8mm;
+  margin: 0 0 0.3mm;
   font-size: 8.5pt;
+  line-height: 1.4;
+}
+
+.free-canvas-page--tpl-modern .free-canvas-block__bullets--dash li::before {
+  content: '-';
+  position: absolute;
+  left: 0;
+}
+
+.free-canvas-page--tpl-modern .free-canvas-block__formation--minimal .free-canvas-block__formation-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 2.5mm;
+}
+
+.free-canvas-page--tpl-modern .free-canvas-block__formation--minimal .free-canvas-block__formation-diplome {
+  font-weight: 700;
+}
+
+.free-canvas-page--tpl-modern .free-canvas-block__formation--minimal .free-canvas-block__formation-date {
+  font-size: 8.5pt;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.free-canvas-page--tpl-modern .free-canvas-block__pdf-fidelity-badge {
+  display: none;
 }
 
 /* ---------- Créatif ---------- */

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -10,9 +10,19 @@
   padding: 0;
 }
 
-.free-canvas-page--tpl-modern .free-canvas-block__photo--border-light {
-  box-shadow: 0 0 0 0.8mm rgba(255, 255, 255, 0.3);
+.free-canvas-page--tpl-modern .free-canvas-block__photo--border-light,
+.free-canvas-page--tpl-modern .free-canvas-block__image-frame-inner.free-canvas-block__photo--border-light {
   border-radius: 50%;
+  /* Stable : border 3px solid rgba(255,255,255,0.3) — pas de box-shadow (clippé par overflow → arcs). */
+  border: 3px solid rgba(255, 255, 255, 0.3);
+  box-shadow: none;
+  box-sizing: border-box;
+}
+
+.free-canvas-page--tpl-modern .free-canvas-block__photo {
+  border-radius: 50%;
+  object-fit: cover;
+  object-position: center;
 }
 
 .free-canvas-page--tpl-modern .free-canvas-block__identity--modern-sidebar,
@@ -60,7 +70,7 @@
 .free-canvas-page--tpl-modern .free-canvas-block__section-title--underline-accent {
   font-size: 9.5pt !important;
   font-weight: 700 !important;
-  color: var(--free-canvas-accent, #3182ce) !important;
+  color: var(--free-canvas-section-title, var(--free-canvas-accent, #3182ce)) !important;
   border-bottom: 2px solid var(--free-canvas-accent, #3182ce) !important;
   letter-spacing: 0.04em;
   text-transform: none;
@@ -111,19 +121,24 @@
   white-space: nowrap;
 }
 
+.free-canvas-page--tpl-modern .free-canvas-block__exp--modern .free-canvas-block__exp-entreprise strong {
+  color: #1a1a1a !important;
+  font-weight: 700 !important;
+}
+
 .free-canvas-page--tpl-modern .free-canvas-block__exp--modern .free-canvas-block__exp-role {
   font-size: 8.5pt !important;
   color: #555555 !important;
-  margin: 1px 0 3px;
+  margin: 0 0 3px;
 }
 
 .free-canvas-page--tpl-modern .free-canvas-block__exp-clients {
   font-style: italic;
   font-size: 8pt;
-  color: #777777;
-  margin: 2mm 0 0;
-  padding-top: 1mm;
-  border-top: 1px solid #e8e8e8;
+  color: #555555;
+  margin: 1mm 0 0;
+  padding-top: 0.8mm;
+  border-top: 1px solid #eeeeee;
 }
 
 .free-canvas-page--tpl-modern .free-canvas-block__bullets--dash {
@@ -155,11 +170,13 @@
 
 .free-canvas-page--tpl-modern .free-canvas-block__formation--minimal .free-canvas-block__formation-diplome {
   font-weight: 700;
+  color: #1a1a1a !important;
 }
 
 .free-canvas-page--tpl-modern .free-canvas-block__formation--minimal .free-canvas-block__formation-date {
   font-size: 8.5pt;
   font-weight: 700;
+  color: #1a1a1a !important;
   white-space: nowrap;
 }
 

--- a/frontend/tests/unit/canvasTemplateSpecs.test.js
+++ b/frontend/tests/unit/canvasTemplateSpecs.test.js
@@ -207,6 +207,76 @@ test('elegant réplique Stable : header centré + photo, chips, freeform', () =>
   assert.equal(getTemplateCanvasFidelity('elegant')?.readiness, 'near-replica');
 });
 
+test('modern réplique Stable : sidebar gauche + main PROFIL/EXP/FORMATION', () => {
+  const blocks = buildTemplateBlocks({ id: 'modern' });
+  const photo = blocks.find((b) => b.type === 'photo');
+  const identity = blocks.find((b) => b.type === 'identity');
+  const contact = blocks.find((b) => b.type === 'contact');
+  const resume = blocks.find((b) => b.type === 'resume');
+  const experiences = blocks.find((b) => b.type === 'experiences');
+  const formations = blocks.find((b) => b.type === 'formations');
+  const projets = blocks.find((b) => b.type === 'projets');
+  const sidebarSkills = blocks.filter((b) => b.type === 'skills' && b.style?.zone === 'sidebar');
+  const shapes = blocks.filter((b) => b.type === 'shape:rect');
+
+  assert.ok(photo && identity && contact && resume && experiences);
+  assert.equal(photo.style?.zone, 'sidebar');
+  assert.equal(photo.style?.photo_border, 'light');
+  assert.equal(photo.style?.lock_geometry, true);
+  assert.ok(photo.w > 18 && photo.w < 24, 'photo ~80px');
+  assert.ok(photo.x > 0, 'photo centrée dans la sidebar');
+
+  assert.equal(identity.style?.zone, 'sidebar');
+  assert.equal(identity.style?.align, 'center');
+  assert.equal(identity.style?.identity_layout, 'modern-sidebar');
+  assert.equal(identity.style?.identity_divider, true);
+  assert.equal(identity.style?.lock_geometry, true);
+  assert.ok(identity.y > photo.y, 'identity sous photo');
+
+  assert.equal(contact.style?.section_label, 'CONTACT');
+  assert.equal(contact.style?.title_style, 'modern-sidebar');
+  assert.equal(contact.style?.align, 'left');
+  assert.deepEqual(contact.bind, ['telephone', 'email', 'linkedin']);
+  assert.ok(contact.y > identity.y, 'contact sous identity');
+  assert.ok(contact.x < 60, 'contact en sidebar gauche');
+
+  assert.equal(resume.style?.zone, 'main');
+  assert.equal(resume.style?.section_label, 'PROFIL');
+  assert.equal(resume.style?.title_style, 'modern-main');
+  assert.equal(resume.style?.font_style, 'italic');
+  assert.equal(resume.style?.align, 'justify');
+  assert.ok(resume.x > 50, 'profil en main (droite)');
+
+  assert.equal(experiences.style?.exp_style, 'modern');
+  assert.equal(experiences.style?.title_style, 'modern-main');
+  assert.equal(experiences.style?.section_label, 'EXPÉRIENCE PROFESSIONNELLE');
+  assert.equal(formations.style?.formation_style, 'minimal');
+  assert.equal(formations.style?.section_label, 'FORMATION');
+  assert.ok(projets, 'projets en main');
+  assert.equal(projets.style?.section_label, 'PROJETS');
+
+  assert.ok(sidebarSkills.length >= 3, 'COMPÉTENCES / OUTILS / AUTRES');
+  assert.ok(sidebarSkills.every((b) => b.x < 60), 'skills sidebar gauche');
+  assert.ok(
+    sidebarSkills.some((b) => b.style?.section_label === 'COMPÉTENCES'),
+    'label COMPÉTENCES',
+  );
+  assert.ok(sidebarSkills.some((b) => b.style?.section_label === 'OUTILS'), 'label OUTILS');
+  assert.equal(shapes.length, 1, 'bandeau sidebar uniquement');
+
+  const theme = parseCanvasTheme({ id: 'modern' });
+  assert.match(theme.font_heading, /Inter/);
+  assert.equal(theme.color_sidebar, '#2d3748');
+  assert.equal(theme.color_accent, '#3182ce');
+  assert.equal(theme.color_section_title, '#3182ce');
+
+  const layout = createCanvasLayoutForTemplate({ id: 'modern' });
+  assert.equal(layout.freeform, true);
+  assert.equal(layout.replica_cascade, true);
+  assert.equal(getTemplateCanvasFidelity('modern')?.readiness, 'near-replica');
+  assert.equal(getTemplateCanvasFidelity('modern')?.fidelityCss, 'rich');
+});
+
 test('classic réplique Stable : header sombre + résumé + sidebar droite', () => {
   const blocks = buildTemplateBlocks({ id: 'classic' });
   const photo = blocks.find((b) => b.type === 'photo');

--- a/frontend/tests/unit/canvasTemplateSpecs.test.js
+++ b/frontend/tests/unit/canvasTemplateSpecs.test.js
@@ -277,6 +277,26 @@ test('modern réplique Stable : sidebar gauche + main PROFIL/EXP/FORMATION', () 
   assert.equal(getTemplateCanvasFidelity('modern')?.fidelityCss, 'rich');
 });
 
+test('parseCanvasTheme applique template_options live (Modern)', () => {
+  const template = {
+    id: 'modern',
+    options: [
+      { key: 'sidebar_color', type: 'color', default: '#2d3748' },
+      { key: 'accent_color', type: 'color', default: '#3182ce' },
+    ],
+  };
+  const theme = parseCanvasTheme(template, {
+    sidebar_color: '#1a365d',
+    accent_color: '#e53e3e',
+  });
+  assert.equal(theme.color_sidebar, '#1a365d');
+  assert.equal(theme.color_accent, '#e53e3e');
+  assert.equal(theme.color_section_title, '#e53e3e');
+  const blocks = buildTemplateBlocks(template, { sidebar_color: '#1a365d' });
+  const sidebarBg = blocks.find((b) => b.type === 'shape:rect');
+  assert.equal(sidebarBg?.style?.color, '#1a365d');
+});
+
 test('classic réplique Stable : header sombre + résumé + sidebar droite', () => {
   const blocks = buildTemplateBlocks({ id: 'classic' });
   const photo = blocks.find((b) => b.type === 'photo');


### PR DESCRIPTION
## Summary
- Réplique native canvas Beta du template **Modern** (`templates/modern/`) : sidebar gauche 200px, identité + CONTACT/skills, main PROFIL → EXP → FORMATION → PROJETS
- Twin CSS rich + `exp_style: modern` + `freeform` / `replica_cascade` + `lock_geometry` photo/identité
- Matrice fidélité → near-replica ; tests structurels

Fixes AXE-391
Closes #180

## Test plan
- [ ] Apply Stable→Beta Modern : sidebar sombre `#2d3748`, accents `#3182ce`, photo 80px
- [ ] Checklist visuelle Stable preview ↔ canvas (titres underline, bullets `-`, formations flex)
- [ ] Cascade / auto-height sidebar sans écraser photo+identité
- [ ] Pas de régression Minimal / Élégant / Classic / Bold
- [ ] CI verte


Made with [Cursor](https://cursor.com)