### PR TITLE
Feat: réplique canvas Beta Executive (Stable twin)

### DIFF
--- a/docs/template-canvas-fidelity.md
+++ b/docs/template-canvas-fidelity.md
@@ -32,7 +32,7 @@ Le template virtuel `beta` (`betaCanvasTemplate.js`) n’est **pas** une twin HT
 | `modern` | sidebar-left | near-replica | **rich** | Checklist visuelle + densité PDF (AXE-391) |
 | `creative` | sidebar-left | projection | medium | Titres creative-main |
 | `elegant` | single-column | near-replica | **rich** | Checklist visuelle OK (PR #174 / AXE-388) |
-| `executive` | sidebar-right | projection | medium | Header band |
+| `executive` | sidebar-right | near-replica | **rich** | Checklist visuelle + densité PDF (AXE-392) |
 | `bold` | sidebar-right | **near-replica** | rich | Checklist visuelle (AXE-390) |
 
 Source de vérité code : `TEMPLATE_CANVAS_FIDELITY` + `STABLE_CANVAS_TEMPLATE_IDS`.
@@ -69,6 +69,12 @@ Source de vérité code : `TEMPLATE_CANVAS_FIDELITY` + `STABLE_CANVAS_TEMPLATE_I
 2. **CSS** `templates/modern/template.css` — sidebar 200px `#2d3748`, titres main underline accent `#3182ce`, photo 80px `border: 3px solid rgba(255,255,255,0.3)` (pas de box-shadow)
 3. **Canvas** `buildTemplateBlocks('modern')` + twin CSS + `exp_style: modern` + `title_style: modern-main|modern-sidebar` + `freeform` / `replica_cascade`
 
+### Executive — couches Stable à calquer (AXE-392)
+
+1. **HTML** `templates/executive/template.html` — header sombre (photo + nom/titre inline, résumé, contact icônes), main EXP/FORMATION/PROJETS, sidebar droite
+2. **CSS** `templates/executive/template.css` — header `#0f172a` + barre 3px `#b8860b`, photo 60px, sidebar `#f8f6f0`, Georgia titres
+3. **Canvas** `buildTemplateBlocks('executive')` + twin CSS + `exp_style: executive` + `freeform` / `replica_cascade`
+
 ## Critères de « réplique native »
 
 Pour un id catalogue :
@@ -85,8 +91,9 @@ Pour un id catalogue :
 3. ~~Élégant~~ (AXE-388 / PR #174) — near-replica
 4. ~~Classic~~ (AXE-389 / PR #177) — near-replica ; checklist visuelle + densité PDF à valider
 5. ~~Bold / Impact~~ (AXE-390 / PR #179) — near-replica
-6. **Modern** (AXE-391) — sidebar-left near-replica
-7. Option ultérieure : Creative / Executive ; assets `default_layout.json`
+6. ~~Modern~~ (AXE-391 / PR #181) — near-replica
+7. **Executive** (AXE-392) — sidebar-right + header band near-replica
+8. Option ultérieure : Creative ; assets `default_layout.json`
 
 ## Alignement contact header-bar
 

--- a/frontend/src/components/editor/FreeCanvasBlock.jsx
+++ b/frontend/src/components/editor/FreeCanvasBlock.jsx
@@ -352,19 +352,21 @@ function SemanticBlockBody({ block, cv, editing = false }) {
       const boldExp = style.exp_style === 'bold'
         || style.exp_style === 'elegant'
         || style.exp_style === 'classic'
-        || style.exp_style === 'modern';
+        || style.exp_style === 'modern'
+        || style.exp_style === 'executive';
       const elegantExp = style.exp_style === 'elegant';
       const minimalExp = style.exp_style === 'minimal';
       const classicExp = style.exp_style === 'classic';
       const impactExp = style.exp_style === 'bold';
       const modernExp = style.exp_style === 'modern';
+      const executiveExp = style.exp_style === 'executive';
       const atsLabels = boldExp || minimalExp;
-      const hyphenDates = minimalExp || elegantExp || impactExp || modernExp;
-      const dashBullets = minimalExp || elegantExp || classicExp || impactExp || modernExp;
-      const clientsAfterBullets = classicExp || impactExp || modernExp;
-      const secteurInline = impactExp || modernExp;
+      const hyphenDates = minimalExp || elegantExp || impactExp || modernExp || executiveExp;
+      const dashBullets = minimalExp || elegantExp || classicExp || impactExp || modernExp || executiveExp;
+      const clientsAfterBullets = classicExp || impactExp || modernExp || executiveExp;
+      const secteurInline = impactExp || modernExp || executiveExp;
       return (
-        <div className={`free-canvas-block__section-list${boldExp ? ' free-canvas-block__section-list--bold-exp' : ''}${minimalExp ? ' free-canvas-block__section-list--minimal-exp' : ''}${elegantExp ? ' free-canvas-block__section-list--elegant-exp' : ''}${modernExp ? ' free-canvas-block__section-list--modern-exp' : ''}`}>
+        <div className={`free-canvas-block__section-list${boldExp ? ' free-canvas-block__section-list--bold-exp' : ''}${minimalExp ? ' free-canvas-block__section-list--minimal-exp' : ''}${elegantExp ? ' free-canvas-block__section-list--elegant-exp' : ''}${modernExp ? ' free-canvas-block__section-list--modern-exp' : ''}${executiveExp ? ' free-canvas-block__section-list--executive-exp' : ''}`}>
           <SectionHeading
             label={style.section_label || SECTION_LABELS.experiences}
             titleStyle={style.title_style}
@@ -446,7 +448,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
             return (
               <div
                 key={exp.id || i}
-                className={`free-canvas-block__exp${format === 'compact' ? ' free-canvas-block__exp--compact' : ''}${boldExp ? ' free-canvas-block__exp--bold' : ''}${minimalExp ? ' free-canvas-block__exp--minimal' : ''}${elegantExp ? ' free-canvas-block__exp--elegant' : ''}${classicExp ? ' free-canvas-block__exp--classic' : ''}${modernExp ? ' free-canvas-block__exp--modern' : ''}`}
+                className={`free-canvas-block__exp${format === 'compact' ? ' free-canvas-block__exp--compact' : ''}${boldExp ? ' free-canvas-block__exp--bold' : ''}${minimalExp ? ' free-canvas-block__exp--minimal' : ''}${elegantExp ? ' free-canvas-block__exp--elegant' : ''}${classicExp ? ' free-canvas-block__exp--classic' : ''}${modernExp ? ' free-canvas-block__exp--modern' : ''}${executiveExp ? ' free-canvas-block__exp--executive' : ''}`}
               >
                 {minimalExp ? (
                   <>

--- a/frontend/src/lib/canvasTemplateSpecs.js
+++ b/frontend/src/lib/canvasTemplateSpecs.js
@@ -71,9 +71,9 @@ export const TEMPLATE_CANVAS_FIDELITY = Object.freeze({
   executive: {
     name: 'Executive',
     layoutFamily: 'sidebar-right',
-    readiness: 'projection',
-    fidelityCss: 'medium',
-    gaps: ['Bandeau header + barre accent vs CSS Stable'],
+    readiness: 'near-replica',
+    fidelityCss: 'rich',
+    gaps: ['Checklist visuelle Stable↔Beta (AXE-392)', 'Densité PDF compacte à valider'],
   },
   bold: {
     name: 'Impact',
@@ -567,29 +567,210 @@ export function buildTemplateBlocks(template, optionValues = null) {
       ];
 
     case 'executive': {
-      const { SB_X, PAD, MAIN_W, SB_INSET } = rightSidebarMetrics();
-      const headerH = 50;
-      const bodyY = headerH + 1.2;
+      // Réplique templates/executive : header sombre + barre accent 3px, photo 60px,
+      // identity inline, résumé sans titre, contact icônes centré ; main EXP/FORMATION/PROJETS ;
+      // sidebar droite crème + filet accent.
+      const { SB, SB_X, PAD, MAIN_W, SB_INSET } = rightSidebarMetrics();
+      const PHOTO_TOP = px(18);
+      const PHOTO_H = px(60);
+      const GAP = px(8);
+      const RESUME_H = px(36);
+      const CONTACT_H = px(14);
+      const headerPadBottom = px(14);
+      const ACCENT_BAR = px(3);
+      const headerH = PHOTO_TOP + PHOTO_H + GAP + RESUME_H + GAP + CONTACT_H + headerPadBottom;
+      const bodyY = headerH + ACCENT_BAR;
+      const resumeY = PHOTO_TOP + PHOTO_H + GAP;
+      const contactY = resumeY + RESUME_H + GAP;
       const bodyH = H - bodyY;
-      const sideCol = (extra = {}) => ({
-        ...sideLight(),
-        title_color: t.color_accent,
-        list_format: 'list',
+      const headerLock = { lock_geometry: true };
+      const hdr = (extra = {}) => ({
+        zone: 'header',
+        color: '#ffffff',
+        font_family: t.font_heading,
+        ...headerLock,
         ...extra,
       });
+      const mainCol = (extra = {}) => ({
+        zone: 'main',
+        font_size: 9.5,
+        color: '#1a1a1a',
+        font_family: t.font_heading,
+        ...extra,
+      });
+      const sideCol = (extra = {}) => ({
+        zone: 'sidebar-light',
+        font_size: 8.5,
+        color: '#333333',
+        list_format: 'list',
+        font_family: t.font_heading,
+        ...extra,
+      });
+      const photoX = px(22);
+      const identityX = photoX + PHOTO_H + px(16);
       return [
         bg(0, 0, PAGE_WIDTH_MM, headerH, t.color_header, 0),
-        bar(0, headerH, PAGE_WIDTH_MM, 1.2, t.color_accent, 1),
+        bar(0, headerH, PAGE_WIDTH_MM, ACCENT_BAR, t.color_accent, 1),
         bg(SB_X, bodyY, SB, bodyH, t.color_sidebar, 0),
-        bar(SB_X, bodyY, 0.5, bodyH, t.color_accent, 2),
-        { type: 'photo', x: 8, y: 6, w: 16, h: 16, z: 5, style: { shape: 'circle', zone: 'header', photo_border: 'accent' } },
-        { type: 'identity', bind: ['prenom', 'nom', 'titre_professionnel'], x: 28, y: 6, w: PAGE_WIDTH_MM - SB - 36, h: 14, z: 5, style: { ...header(), font_size: 18, font_family: t.font_heading, align: 'left' } },
-        { type: 'resume', bind: 'resume', x: 28, y: 22, w: PAGE_WIDTH_MM - SB - 36, h: 12, z: 5, style: { ...header(), font_style: 'italic', align: 'justify', font_size: 9 } },
-        { type: 'contact', bind: ['email', 'telephone', 'linkedin'], x: 8, y: 36, w: PAGE_WIDTH_MM - SB - 16, h: 10, z: 5, style: { ...header(), contact_layout: 'header-bar', font_size: 8.5, contact_icons: true } },
-        { type: 'experiences', bind: 'experiences', x: PAD, y: bodyY + 4, w: MAIN_W, h: 118, z: 2, style: { ...main(), section_label: 'EXPÉRIENCE PROFESSIONNELLE', title_style: 'executive-main', font_family: t.font_heading, exp_style: 'bold' } },
-        { type: 'formations', bind: 'formations', x: PAD, y: bodyY + 126, w: MAIN_W, h: 30, z: 2, style: { ...main(), section_label: 'FORMATION', title_style: 'executive-main', font_family: t.font_heading } },
-        { type: 'projets', bind: 'projets', x: PAD, y: bodyY + 160, w: MAIN_W, h: 26, z: 2, style: { ...main(), section_label: 'PROJETS', title_style: 'executive-main', font_family: t.font_heading } },
-        ...sidebarCompetenceBlocksDetailed(SB_X + SB_INSET, SB - SB_INSET * 2, bodyY + 8, sideCol(), 3),
+        bar(SB_X, bodyY, px(1.5), bodyH, t.color_accent, 2),
+        {
+          type: 'photo',
+          x: photoX,
+          y: PHOTO_TOP,
+          w: PHOTO_H,
+          h: PHOTO_H,
+          z: 5,
+          style: { shape: 'circle', zone: 'header', photo_border: 'accent', ...headerLock },
+        },
+        {
+          type: 'identity',
+          bind: ['prenom', 'nom', 'titre_professionnel'],
+          x: identityX,
+          y: PHOTO_TOP,
+          w: PAGE_WIDTH_MM - identityX - px(22),
+          h: PHOTO_H,
+          z: 5,
+          style: {
+            ...hdr(),
+            header_layout: 'inline-title',
+            identity_layout: 'executive-header',
+          },
+        },
+        {
+          type: 'resume',
+          bind: 'resume',
+          x: photoX,
+          y: resumeY,
+          w: PAGE_WIDTH_MM - px(44),
+          h: RESUME_H,
+          z: 5,
+          style: {
+            ...hdr(),
+            align: 'justify',
+            font_size: 9,
+            color: 'rgba(255,255,255,0.9)',
+            show_section_title: false,
+          },
+        },
+        {
+          type: 'contact',
+          bind: ['telephone', 'email', 'linkedin'],
+          x: photoX,
+          y: contactY,
+          w: PAGE_WIDTH_MM - px(44),
+          h: CONTACT_H,
+          z: 5,
+          style: {
+            ...hdr(),
+            align: 'center',
+            contact_layout: 'header-bar',
+            font_size: 8.5,
+            contact_icons: true,
+            contact_separator: ' ',
+          },
+        },
+        {
+          type: 'experiences',
+          bind: 'experiences',
+          x: PAD,
+          y: bodyY + px(10),
+          w: MAIN_W,
+          h: px(160),
+          z: 2,
+          style: {
+            ...mainCol(),
+            section_label: 'EXPÉRIENCE PROFESSIONNELLE',
+            title_style: 'executive-main',
+            exp_style: 'executive',
+          },
+        },
+        {
+          type: 'formations',
+          bind: 'formations',
+          x: PAD,
+          y: bodyY + px(176),
+          w: MAIN_W,
+          h: px(36),
+          z: 2,
+          style: {
+            ...mainCol(),
+            section_label: 'FORMATION',
+            title_style: 'executive-main',
+            formation_style: 'minimal',
+          },
+        },
+        {
+          type: 'projets',
+          bind: 'projets',
+          x: PAD,
+          y: bodyY + px(218),
+          w: MAIN_W,
+          h: px(28),
+          z: 2,
+          style: { ...mainCol(), section_label: 'PROJETS', title_style: 'executive-main' },
+        },
+        {
+          type: 'skills',
+          bind: 'competences.techniques',
+          x: SB_X + SB_INSET,
+          y: bodyY + px(18),
+          w: SB - SB_INSET * 2,
+          h: px(52),
+          z: 3,
+          style: {
+            ...sideCol(),
+            section_label: 'COMPÉTENCES',
+            sidebar_category: 'Compétences techniques',
+            title_style: 'executive-sidebar-section',
+          },
+        },
+        {
+          type: 'skills',
+          bind: 'competences.logiciels',
+          x: SB_X + SB_INSET,
+          y: bodyY + px(72),
+          w: SB - SB_INSET * 2,
+          h: px(40),
+          z: 3,
+          style: {
+            ...sideCol(),
+            sidebar_category: 'Logiciels & outils',
+            title_style: 'executive-sidebar-category',
+          },
+        },
+        {
+          type: 'certifications',
+          bind: 'certifications',
+          x: SB_X + SB_INSET,
+          y: bodyY + px(114),
+          w: SB - SB_INSET * 2,
+          h: px(28),
+          z: 3,
+          style: {
+            ...sideCol(),
+            sidebar_category: 'Certifications',
+            title_style: 'executive-sidebar-category',
+          },
+        },
+        {
+          type: 'languages',
+          x: SB_X + SB_INSET,
+          y: bodyY + px(146),
+          w: SB - SB_INSET * 2,
+          h: px(22),
+          z: 3,
+          style: { ...sideCol(), section_label: 'LANGUES', title_style: 'executive-main' },
+        },
+        {
+          type: 'skills',
+          bind: 'competences.autres',
+          x: SB_X + SB_INSET,
+          y: bodyY + px(170),
+          w: SB - SB_INSET * 2,
+          h: px(30),
+          z: 3,
+          style: { ...sideCol(), section_label: 'AUTRES', title_style: 'executive-main' },
+        },
       ];
     }
 

--- a/frontend/src/lib/canvasTemplateSpecs.js
+++ b/frontend/src/lib/canvasTemplateSpecs.js
@@ -241,22 +241,6 @@ const main = (extra = {}) => ({
   ...extra,
 });
 
-const header = (extra = {}) => ({
-  zone: 'header',
-  color: '#ffffff',
-  ...extra,
-});
-
-const sideLight = (extra = {}) => ({
-  zone: 'sidebar-light',
-  font_size: 8.5,
-  color: '#333333',
-  show_section_title: true,
-  title_style: 'sidebar-category',
-  list_format: 'list',
-  ...extra,
-});
-
 const px = (n) => (n * 25.4) / 96;
 
 /** Layout colonne gauche type Modern / Creative (sidebar 200px). */

--- a/frontend/src/lib/canvasTemplateSpecs.js
+++ b/frontend/src/lib/canvasTemplateSpecs.js
@@ -171,13 +171,19 @@ export function parseCanvasTheme(template, optionValues = null) {
         const val = resolveOpt('accent_color', o.default);
         if (val) {
           theme.color_accent = val;
-          // Bold Stable : titres corps restent slate ; accent = filets/dates seulement.
-          if (id !== 'creative' && id !== 'bold') theme.color_section_title = val;
+          // Bold / Executive Stable : titres corps restent slate ; accent = filets/dates seulement.
+          if (id !== 'creative' && id !== 'bold' && id !== 'executive') {
+            theme.color_section_title = val;
+          }
         }
       }
       if (o?.key === 'header_color') {
         const val = resolveOpt('header_color', o.default);
-        if (val) theme.color_header = val;
+        if (val) {
+          theme.color_header = val;
+          // Executive : titres de section calés sur l’en-tête (Stable #0f172a).
+          if (id === 'executive') theme.color_section_title = val;
+        }
       }
       if (o?.key === 'sidebar_color') {
         const val = resolveOpt('sidebar_color', o.default);
@@ -197,9 +203,14 @@ export function parseCanvasTheme(template, optionValues = null) {
     // Template catalogue sans schema options (id seul) : appliquer les valeurs live.
     if (live.accent_color) {
       theme.color_accent = live.accent_color;
-      if (id !== 'creative' && id !== 'bold') theme.color_section_title = live.accent_color;
+      if (id !== 'creative' && id !== 'bold' && id !== 'executive') {
+        theme.color_section_title = live.accent_color;
+      }
     }
-    if (live.header_color) theme.color_header = live.header_color;
+    if (live.header_color) {
+      theme.color_header = live.header_color;
+      if (id === 'executive') theme.color_section_title = live.header_color;
+    }
     if (live.sidebar_color) theme.color_sidebar = live.sidebar_color;
     if (live.font) {
       theme.font_heading = fontStackFromTemplateOption(live.font);
@@ -579,7 +590,7 @@ export function buildTemplateBlocks(template, optionValues = null) {
         zone: 'main',
         font_size: 9.5,
         color: '#1a1a1a',
-        font_family: t.font_heading,
+        // Corps Inter (page) ; Georgia uniquement via twin CSS sur les titres.
         ...extra,
       });
       const sideCol = (extra = {}) => ({
@@ -587,7 +598,6 @@ export function buildTemplateBlocks(template, optionValues = null) {
         font_size: 8.5,
         color: '#333333',
         list_format: 'list',
-        font_family: t.font_heading,
         ...extra,
       });
       const photoX = px(22);

--- a/frontend/src/lib/canvasTemplateSpecs.js
+++ b/frontend/src/lib/canvasTemplateSpecs.js
@@ -1018,9 +1018,10 @@ export function buildTemplateBlocks(template, optionValues = null) {
           type: 'identity',
           bind: ['prenom', 'nom', 'titre_professionnel'],
           x: px(16) + PHOTO_H + px(12),
-          y: PHOTO_TOP + px(4),
+          // Même bande que la photo + flex center (Stable .header-top-row align-items:center).
+          y: PHOTO_TOP,
           w: PAGE_WIDTH_MM - px(16) - PHOTO_H - px(12) - px(16),
-          h: PHOTO_H - px(8),
+          h: PHOTO_H,
           z: 5,
           style: {
             ...hdr(),

--- a/frontend/src/lib/layoutTemplatePresets.js
+++ b/frontend/src/lib/layoutTemplatePresets.js
@@ -23,6 +23,7 @@ export function createCanvasLayoutForTemplate(template, optionValues = null) {
     || template.id === 'classic'
     || template.id === 'bold'
     || template.id === 'modern'
+    || template.id === 'executive'
   ) {
     layout.freeform = true;
     layout.replica_cascade = true;

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -306,10 +306,12 @@
   margin-right: 3px;
 }
 
-.free-canvas-page--tpl-executive .free-canvas-block__section-title--executive-main {
+.free-canvas-page--tpl-executive .free-canvas-block__section-title--executive-main,
+.free-canvas-page--tpl-executive .free-canvas-block__inner--zone-main .free-canvas-block__section-title {
   font-family: var(--free-canvas-font-heading, Georgia, 'Times New Roman', serif) !important;
   font-size: 10pt !important;
   font-weight: 700 !important;
+  /* Stable --cv-color-section-title (#0f172a), pas l’accent or */
   color: var(--free-canvas-section-title, #0f172a) !important;
   border-bottom: 1.5px solid var(--free-canvas-accent, #b8860b) !important;
   text-transform: uppercase;
@@ -318,7 +320,9 @@
   padding-bottom: 0.5mm;
 }
 
-.free-canvas-page--tpl-executive .free-canvas-block__section-title--executive-sidebar-section {
+.free-canvas-page--tpl-executive .free-canvas-block__section-title--executive-sidebar-section,
+.free-canvas-page--tpl-executive .free-canvas-block__inner--zone-sidebar-light .free-canvas-block__section-title--executive-sidebar-section,
+.free-canvas-page--tpl-executive .free-canvas-block__inner--zone-sidebar-light .free-canvas-block__section-title:not(.free-canvas-block__section-title--executive-sidebar-category) {
   font-family: var(--free-canvas-font-heading, Georgia, 'Times New Roman', serif) !important;
   font-size: 10pt !important;
   font-weight: 700 !important;
@@ -399,15 +403,17 @@
   position: relative;
   padding-left: 2.8mm;
   margin: 0 0 0.4mm;
-  font-size: 8.5pt;
+  font-size: 9pt;
   line-height: 1.4;
-  color: #333333;
+  /* Stable : var(--cv-color-body) → #1a1a1a */
+  color: #1a1a1a;
 }
 
 .free-canvas-page--tpl-executive .free-canvas-block__bullets--dash li::before {
   content: '-';
   position: absolute;
   left: 0;
+  color: #1a1a1a;
 }
 
 .free-canvas-page--tpl-executive .free-canvas-block__formation--minimal .free-canvas-block__formation-header {
@@ -429,11 +435,38 @@
   white-space: nowrap;
 }
 
+.free-canvas-page--tpl-executive .free-canvas-block__formation--minimal .free-canvas-block__formation-mention {
+  font-style: italic;
+  color: #555555 !important;
+  margin: 0;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__section-list strong {
+  color: #1a1a1a !important;
+  font-weight: 700;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block[data-block-type='projets'] .free-canvas-block__section-list p {
+  font-size: 8.5pt;
+  color: #555555;
+  line-height: 1.4;
+  margin: 0 0 1mm;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block[data-block-type='projets'] .free-canvas-block__section-list p strong {
+  font-size: 9.5pt;
+  color: #1a1a1a !important;
+}
+
 .free-canvas-page--tpl-executive .free-canvas-block__sidebar-item {
   font-size: 8.5pt !important;
   color: #333333 !important;
   line-height: 1.4;
   margin: 0 0 0.3mm;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__inner--zone-sidebar-light {
+  color: #1a1a1a;
 }
 
 .free-canvas-page--tpl-executive .free-canvas-block__pdf-fidelity-badge {

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -757,6 +757,22 @@
   margin: 0;
 }
 
+/* Stable .header-top-row { align-items: center } — centrer le nom vs photo. */
+.free-canvas-page--tpl-classic .free-canvas-block[data-block-type='identity'] .free-canvas-block__inner--zone-header {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: flex-start;
+  height: 100% !important;
+  min-height: 100% !important;
+  max-height: 100% !important;
+  overflow: hidden !important;
+}
+
+.free-canvas-page--tpl-classic .free-canvas-block[data-block-type='identity'] .free-canvas-block__identity--inline-title {
+  width: 100%;
+  margin: 0;
+}
+
 .free-canvas-page--tpl-classic .free-canvas-block__identity--inline-title .free-canvas-block__identity-name,
 .free-canvas-page--tpl-classic .free-canvas-block__identity--classic-header .free-canvas-block__identity-name {
   font-family: var(--free-canvas-font-heading) !important;

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -216,49 +216,228 @@
   letter-spacing: 0.04em;
 }
 
-/* ---------- Executive ---------- */
-.free-canvas-page--tpl-executive .free-canvas-block__inner--zone-main {
+/* ---------- Executive (réplique templates/executive — AXE-392) ---------- */
+.free-canvas-page--tpl-executive {
   font-family: Inter, Arial, sans-serif;
+  color: #1a1a1a;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__inner {
+  padding: 0;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__photo--border-accent,
+.free-canvas-page--tpl-executive .free-canvas-block__image-frame-inner.free-canvas-block__photo--border-accent {
+  border-radius: 50%;
+  /* Stable : border 2.5px accent — pas de box-shadow (clippé → arcs). */
+  border: 2.5px solid var(--free-canvas-accent, #b8860b);
+  box-shadow: none;
+  box-sizing: border-box;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__photo {
+  border-radius: 50%;
+  object-fit: cover;
+  object-position: center;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__identity--inline-title,
+.free-canvas-page--tpl-executive .free-canvas-block__identity--executive-header {
+  color: #ffffff;
+  line-height: 1.15;
+  margin: 0;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__identity--inline-title .free-canvas-block__identity-name,
+.free-canvas-page--tpl-executive .free-canvas-block__identity--executive-header .free-canvas-block__identity-name {
+  font-family: var(--free-canvas-font-heading, Georgia, 'Times New Roman', serif) !important;
+  font-size: 18pt !important;
+  font-weight: 700 !important;
+  letter-spacing: 0.02em;
+  color: #ffffff !important;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__identity--inline-title .free-canvas-block__identity-sep {
+  font-weight: 400 !important;
+  opacity: 0.5;
+  margin: 0 1.5mm;
+  color: #ffffff !important;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__identity--inline-title .free-canvas-block__identity-title,
+.free-canvas-page--tpl-executive .free-canvas-block__identity--inline-title .free-canvas-block__identity-title--accent {
+  font-family: var(--free-canvas-font-heading, Georgia, 'Times New Roman', serif) !important;
+  font-size: 10.5pt !important;
+  font-weight: 400 !important;
+  font-style: italic !important;
+  opacity: 0.9 !important;
+  color: #ffffff !important;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block[data-block-type='identity'] .free-canvas-block__inner--zone-header {
+  display: flex;
+  align-items: center;
+  overflow: hidden !important;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__inner--zone-header .free-canvas-block__resume {
+  color: rgba(255, 255, 255, 0.9) !important;
+  font-size: 9pt !important;
+  font-style: italic !important;
+  text-align: justify;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__contact--header-bar {
+  text-align: center;
+  justify-content: center;
+  margin: 0;
+  color: rgba(255, 255, 255, 0.85) !important;
+  font-size: 8.5pt !important;
+  letter-spacing: 0.03em;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__contact--header-bar .free-canvas-block__contact-icon {
+  color: var(--free-canvas-accent, #b8860b) !important;
+  vertical-align: middle;
+  width: 0.9em;
+  height: 0.9em;
+  margin-right: 3px;
 }
 
 .free-canvas-page--tpl-executive .free-canvas-block__section-title--executive-main {
-  font-family: var(--free-canvas-font-heading);
-  font-size: 10pt;
-  font-weight: 700;
-  color: var(--free-canvas-section-title, #0f172a);
-  border-bottom: 0.4mm solid var(--free-canvas-accent);
+  font-family: var(--free-canvas-font-heading, Georgia, 'Times New Roman', serif) !important;
+  font-size: 10pt !important;
+  font-weight: 700 !important;
+  color: var(--free-canvas-section-title, #0f172a) !important;
+  border-bottom: 1.5px solid var(--free-canvas-accent, #b8860b) !important;
   text-transform: uppercase;
   letter-spacing: 0.06em;
+  margin: 0 0 1.5mm;
+  padding-bottom: 0.5mm;
 }
 
-.free-canvas-page--tpl-executive .free-canvas-block__section-title--sidebar-category {
-  font-family: var(--free-canvas-font-heading);
-  font-size: 9pt;
-  font-weight: 700;
-  color: var(--free-canvas-accent);
+.free-canvas-page--tpl-executive .free-canvas-block__section-title--executive-sidebar-section {
+  font-family: var(--free-canvas-font-heading, Georgia, 'Times New Roman', serif) !important;
+  font-size: 10pt !important;
+  font-weight: 700 !important;
+  color: var(--free-canvas-section-title, #0f172a) !important;
+  border-bottom: 1.5px solid var(--free-canvas-accent, #b8860b) !important;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin: 0 0 2mm;
+  padding-bottom: 0.5mm;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__sidebar-category,
+.free-canvas-page--tpl-executive .free-canvas-block__sidebar-category--executive-sidebar-category,
+.free-canvas-page--tpl-executive .free-canvas-block__section-title--executive-sidebar-category {
+  font-family: var(--free-canvas-font-heading, Georgia, 'Times New Roman', serif) !important;
+  font-size: 9pt !important;
+  font-weight: 700 !important;
+  color: var(--free-canvas-accent, #b8860b) !important;
   letter-spacing: 0.04em;
-  border: none;
+  border: none !important;
   text-transform: none;
+  margin: 0 0 1mm;
 }
 
-.free-canvas-page--tpl-executive .free-canvas-block__exp-dates {
-  color: var(--free-canvas-accent);
-  font-weight: 600;
+.free-canvas-page--tpl-executive .free-canvas-block__exp--executive {
+  margin-bottom: 2mm;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__exp--executive .free-canvas-block__exp-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 3mm;
+  margin-bottom: 0.5mm;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__exp--executive .free-canvas-block__ats-label {
+  font-size: 0.9em;
+  color: #999999;
+  font-weight: 400;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__exp--executive .free-canvas-block__exp-entreprise strong {
+  color: #1a1a1a !important;
+  font-weight: 700 !important;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__exp--executive .free-canvas-block__exp-dates {
+  color: var(--free-canvas-accent, #b8860b) !important;
+  font-weight: 600 !important;
+  font-size: 8.5pt !important;
+  white-space: nowrap;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__exp--executive .free-canvas-block__exp-role {
+  font-size: 9pt !important;
+  font-style: italic !important;
+  color: #555555 !important;
+  margin: 0 0 0.8mm;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__exp-clients {
+  font-style: italic;
+  font-size: 8pt;
+  color: #777777;
+  margin: 1mm 0 0;
+  padding-top: 0.8mm;
+  border-top: 1px solid #eeeeee;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__bullets--dash {
+  list-style: none;
+  margin: 0.4mm 0 0;
+  padding: 0;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__bullets--dash li {
+  position: relative;
+  padding-left: 2.8mm;
+  margin: 0 0 0.4mm;
   font-size: 8.5pt;
+  line-height: 1.4;
+  color: #333333;
 }
 
-.free-canvas-page--tpl-executive .free-canvas-block__exp-role {
-  font-style: italic;
-  color: #555;
+.free-canvas-page--tpl-executive .free-canvas-block__bullets--dash li::before {
+  content: '-';
+  position: absolute;
+  left: 0;
 }
 
-.free-canvas-page--tpl-executive .free-canvas-block__inner--zone-header .free-canvas-block__identity-title {
-  font-style: italic;
-  opacity: 0.9;
+.free-canvas-page--tpl-executive .free-canvas-block__formation--minimal .free-canvas-block__formation-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 3mm;
 }
 
-.free-canvas-page--tpl-executive .free-canvas-block__contact--icons .free-canvas-block__contact-icon {
-  color: var(--free-canvas-accent);
+.free-canvas-page--tpl-executive .free-canvas-block__formation--minimal .free-canvas-block__formation-diplome {
+  font-weight: 700;
+  color: #1a1a1a !important;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__formation--minimal .free-canvas-block__formation-date {
+  font-size: 8.5pt;
+  font-weight: 600;
+  color: var(--free-canvas-accent, #b8860b) !important;
+  white-space: nowrap;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__sidebar-item {
+  font-size: 8.5pt !important;
+  color: #333333 !important;
+  line-height: 1.4;
+  margin: 0 0 0.3mm;
+}
+
+.free-canvas-page--tpl-executive .free-canvas-block__pdf-fidelity-badge {
+  display: none;
 }
 
 /* ---------- Impact (bold) ---------- */

--- a/frontend/tests/unit/canvasTemplateSpecs.test.js
+++ b/frontend/tests/unit/canvasTemplateSpecs.test.js
@@ -382,6 +382,8 @@ test('classic réplique Stable : header sombre + résumé + sidebar droite', () 
   assert.equal(photo.style?.zone, 'header');
   assert.equal(identity.style?.header_layout, 'inline-title');
   assert.equal(identity.style?.zone, 'header');
+  assert.equal(identity.y, photo.y, 'identity alignée verticalement avec la photo');
+  assert.equal(identity.h, photo.h, 'identity même hauteur que la photo (centrage flex)');
   assert.equal(resume.style?.zone, 'header');
   assert.equal(resume.style?.show_section_title, false);
   assert.ok(resume.y > identity.y, 'résumé sous identity dans le header');

--- a/frontend/tests/unit/canvasTemplateSpecs.test.js
+++ b/frontend/tests/unit/canvasTemplateSpecs.test.js
@@ -305,6 +305,7 @@ test('executive réplique Stable : header band + sidebar droite + freeform', () 
   const resume = blocks.find((b) => b.type === 'resume');
   const experiences = blocks.find((b) => b.type === 'experiences');
   const formations = blocks.find((b) => b.type === 'formations');
+  const projets = blocks.find((b) => b.type === 'projets');
   const shapes = blocks.filter((b) => b.type === 'shape:rect');
   const sidebarSkills = blocks.filter((b) => b.type === 'skills' && b.style?.zone === 'sidebar-light');
 
@@ -329,12 +330,15 @@ test('executive réplique Stable : header band + sidebar droite + freeform', () 
   assert.equal(experiences.style?.exp_style, 'executive');
   assert.equal(experiences.style?.title_style, 'executive-main');
   assert.equal(formations.style?.formation_style, 'minimal');
+  assert.ok(projets, 'projets en main');
+  assert.equal(projets.style?.section_label, 'PROJETS');
   assert.ok(sidebarSkills.length >= 2, 'compétences sidebar');
   assert.ok(sidebarSkills.every((b) => b.x > 100), 'sidebar à droite');
   assert.ok(shapes.length >= 3, 'header + barre accent + sidebar');
 
   const theme = parseCanvasTheme({ id: 'executive' });
   assert.match(theme.font_heading, /Georgia/);
+  assert.match(theme.font_body, /Inter/);
   assert.equal(theme.color_header, '#0f172a');
   assert.equal(theme.color_sidebar, '#f8f6f0');
   assert.equal(theme.color_accent, '#b8860b');

--- a/frontend/tests/unit/canvasTemplateSpecs.test.js
+++ b/frontend/tests/unit/canvasTemplateSpecs.test.js
@@ -297,6 +297,56 @@ test('parseCanvasTheme applique template_options live (Modern)', () => {
   assert.equal(sidebarBg?.style?.color, '#1a365d');
 });
 
+test('executive réplique Stable : header band + sidebar droite + freeform', () => {
+  const blocks = buildTemplateBlocks({ id: 'executive' });
+  const photo = blocks.find((b) => b.type === 'photo');
+  const identity = blocks.find((b) => b.type === 'identity');
+  const contact = blocks.find((b) => b.type === 'contact');
+  const resume = blocks.find((b) => b.type === 'resume');
+  const experiences = blocks.find((b) => b.type === 'experiences');
+  const formations = blocks.find((b) => b.type === 'formations');
+  const shapes = blocks.filter((b) => b.type === 'shape:rect');
+  const sidebarSkills = blocks.filter((b) => b.type === 'skills' && b.style?.zone === 'sidebar-light');
+
+  assert.ok(photo && identity && contact && resume && experiences);
+  assert.equal(photo.style?.zone, 'header');
+  assert.equal(photo.style?.photo_border, 'accent');
+  assert.equal(photo.style?.lock_geometry, true);
+  assert.ok(photo.w > 14 && photo.w < 18, 'photo ~60px');
+
+  assert.equal(identity.style?.header_layout, 'inline-title');
+  assert.equal(identity.style?.lock_geometry, true);
+  assert.equal(resume.style?.show_section_title, false);
+  assert.equal(resume.style?.lock_geometry, true);
+  assert.ok(resume.y > identity.y, 'résumé sous identity');
+
+  assert.equal(contact.style?.contact_layout, 'header-bar');
+  assert.equal(contact.style?.align, 'center');
+  assert.equal(contact.style?.contact_icons, true);
+  assert.deepEqual(contact.bind, ['telephone', 'email', 'linkedin']);
+  assert.ok(contact.y > resume.y, 'contact sous résumé');
+
+  assert.equal(experiences.style?.exp_style, 'executive');
+  assert.equal(experiences.style?.title_style, 'executive-main');
+  assert.equal(formations.style?.formation_style, 'minimal');
+  assert.ok(sidebarSkills.length >= 2, 'compétences sidebar');
+  assert.ok(sidebarSkills.every((b) => b.x > 100), 'sidebar à droite');
+  assert.ok(shapes.length >= 3, 'header + barre accent + sidebar');
+
+  const theme = parseCanvasTheme({ id: 'executive' });
+  assert.match(theme.font_heading, /Georgia/);
+  assert.equal(theme.color_header, '#0f172a');
+  assert.equal(theme.color_sidebar, '#f8f6f0');
+  assert.equal(theme.color_accent, '#b8860b');
+  assert.equal(theme.color_section_title, '#0f172a');
+
+  const layout = createCanvasLayoutForTemplate({ id: 'executive' });
+  assert.equal(layout.freeform, true);
+  assert.equal(layout.replica_cascade, true);
+  assert.equal(getTemplateCanvasFidelity('executive')?.readiness, 'near-replica');
+  assert.equal(getTemplateCanvasFidelity('executive')?.fidelityCss, 'rich');
+});
+
 test('classic réplique Stable : header sombre + résumé + sidebar droite', () => {
   const blocks = buildTemplateBlocks({ id: 'classic' });
   const photo = blocks.find((b) => b.type === 'photo');

--- a/frontend/tests/unit/canvasTemplateSpecs.test.js
+++ b/frontend/tests/unit/canvasTemplateSpecs.test.js
@@ -347,6 +347,23 @@ test('executive réplique Stable : header band + sidebar droite + freeform', () 
   assert.equal(getTemplateCanvasFidelity('executive')?.fidelityCss, 'rich');
 });
 
+test('executive : accent or ne remplace pas les titres slate', () => {
+  const template = {
+    id: 'executive',
+    options: [
+      { key: 'header_color', type: 'color', default: '#0f172a' },
+      { key: 'accent_color', type: 'color', default: '#b8860b' },
+      { key: 'sidebar_color', type: 'color', default: '#f8f6f0' },
+    ],
+  };
+  const theme = parseCanvasTheme(template);
+  assert.equal(theme.color_accent, '#b8860b');
+  assert.equal(theme.color_section_title, '#0f172a', 'titres ≠ accent (Stable --cv-color-section-title)');
+  const live = parseCanvasTheme(template, { accent_color: '#d4a017', header_color: '#0f172a' });
+  assert.equal(live.color_accent, '#d4a017');
+  assert.equal(live.color_section_title, '#0f172a');
+});
+
 test('classic réplique Stable : header sombre + résumé + sidebar droite', () => {
   const blocks = buildTemplateBlocks({ id: 'classic' });
   const photo = blocks.find((b) => b.type === 'photo');


### PR DESCRIPTION
## Summary
- Réplique native canvas Beta du template **Executive** : header `#0f172a` + barre accent `#b8860b`, photo 60px, identity inline, résumé sans titre, contact icônes centré
- Sidebar droite crème + compétences catégorisées ; main EXP / FORMATION / PROJETS
- Twin CSS rich + `exp_style: executive` + `freeform` / `replica_cascade` + `lock_geometry` header

Fixes AXE-392
Closes #182

## Test plan
- [ ] Apply Stable→Beta Executive ≈ preview Stable
- [ ] Photo sans arcs (border accent, pas box-shadow)
- [ ] Cascade header figé (photo + identity alignés)
- [ ] Pas de régression Minimal / Élégant / Classic / Bold / Modern
- [ ] CI verte


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout d’une réplique haute fidélité du modèle de CV Executive.
  * Nouvelle mise en page avec en-tête sombre, photo, résumé, coordonnées centrées et barre latérale.
  * Prise en charge des libellés ATS, dates et puces au format Executive.
  * Les couleurs d’accent et des titres de section sont désormais personnalisables séparément.

* **Documentation**
  * Mise à jour de la feuille de route et des niveaux de fidélité des modèles.

* **Tests**
  * Ajout de tests couvrant la structure, le thème et les couleurs du modèle Executive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->