### PR TITLE
Feat: réplique canvas Beta Creative (Stable twin)

### DIFF
--- a/docs/template-canvas-fidelity.md
+++ b/docs/template-canvas-fidelity.md
@@ -30,7 +30,7 @@ Le template virtuel `beta` (`betaCanvasTemplate.js`) n’est **pas** une twin HT
 | `minimal` | single-column | near-replica | **rich** | Checklist visuelle OK (PR #170) |
 | `classic` | sidebar-right | near-replica | **rich** | Checklist visuelle + densité PDF (AXE-389 / PR #177) |
 | `modern` | sidebar-left | near-replica | **rich** | Checklist visuelle + densité PDF (AXE-391) |
-| `creative` | sidebar-left | projection | medium | Titres creative-main |
+| `creative` | sidebar-left | near-replica | **rich** | Checklist visuelle + densité PDF (AXE-393) |
 | `elegant` | single-column | near-replica | **rich** | Checklist visuelle OK (PR #174 / AXE-388) |
 | `executive` | sidebar-right | near-replica | **rich** | Checklist visuelle + densité PDF (AXE-392) |
 | `bold` | sidebar-right | **near-replica** | rich | Checklist visuelle (AXE-390) |
@@ -75,6 +75,12 @@ Source de vérité code : `TEMPLATE_CANVAS_FIDELITY` + `STABLE_CANVAS_TEMPLATE_I
 2. **CSS** `templates/executive/template.css` — header `#0f172a` + barre 3px `#b8860b`, photo 60px, sidebar `#f8f6f0`, Georgia titres
 3. **Canvas** `buildTemplateBlocks('executive')` + twin CSS + `exp_style: executive` + `freeform` / `replica_cascade`
 
+### Creative — couches Stable à calquer (AXE-393)
+
+1. **HTML** `templates/creative/template.html` — sidebar gauche (photo, identité, CONTACT, compétences…), main PROFIL → EXP → FORMATION → PROJETS
+2. **CSS** `templates/creative/template.css` — sidebar 200px `#6366f1`, titres accent `#f59e0b`, photo 80px `border: 3px solid accent`, bullets `▸`
+3. **Canvas** `buildTemplateBlocks('creative')` + twin CSS + `exp_style: creative` + `title_style: creative-main|creative-sidebar` + `freeform` / `replica_cascade`
+
 ## Critères de « réplique native »
 
 Pour un id catalogue :
@@ -92,8 +98,9 @@ Pour un id catalogue :
 4. ~~Classic~~ (AXE-389 / PR #177) — near-replica ; checklist visuelle + densité PDF à valider
 5. ~~Bold / Impact~~ (AXE-390 / PR #179) — near-replica
 6. ~~Modern~~ (AXE-391 / PR #181) — near-replica
-7. **Executive** (AXE-392) — sidebar-right + header band near-replica
-8. Option ultérieure : Creative ; assets `default_layout.json`
+7. ~~Executive~~ (AXE-392 / PR #183) — near-replica
+8. **Creative** (AXE-393) — dernier twin sidebar-left
+9. Option ultérieure : assets `default_layout.json` ; close AXE-346 après checklist Creative
 
 ## Alignement contact header-bar
 

--- a/docs/template-canvas-fidelity.md
+++ b/docs/template-canvas-fidelity.md
@@ -78,7 +78,7 @@ Source de vérité code : `TEMPLATE_CANVAS_FIDELITY` + `STABLE_CANVAS_TEMPLATE_I
 ### Creative — couches Stable à calquer (AXE-393)
 
 1. **HTML** `templates/creative/template.html` — sidebar gauche (photo, identité, CONTACT, compétences…), main PROFIL → EXP → FORMATION → PROJETS
-2. **CSS** `templates/creative/template.css` — sidebar 200px `#6366f1`, titres accent `#f59e0b`, photo 80px `border: 3px solid accent`, bullets `▸`
+2. **CSS** `templates/creative/template.css` — sidebar 200px `#6366f1`, accent `#f59e0b` (photo / filets / labels sidebar / bullets ▸) ; titres main Beta = indigo sidebar (brand), filet ambre
 3. **Canvas** `buildTemplateBlocks('creative')` + twin CSS + `exp_style: creative` + `title_style: creative-main|creative-sidebar` + `freeform` / `replica_cascade`
 
 ## Critères de « réplique native »

--- a/frontend/src/components/editor/FreeCanvasBlock.jsx
+++ b/frontend/src/components/editor/FreeCanvasBlock.jsx
@@ -353,20 +353,22 @@ function SemanticBlockBody({ block, cv, editing = false }) {
         || style.exp_style === 'elegant'
         || style.exp_style === 'classic'
         || style.exp_style === 'modern'
-        || style.exp_style === 'executive';
+        || style.exp_style === 'executive'
+        || style.exp_style === 'creative';
       const elegantExp = style.exp_style === 'elegant';
       const minimalExp = style.exp_style === 'minimal';
       const classicExp = style.exp_style === 'classic';
       const impactExp = style.exp_style === 'bold';
       const modernExp = style.exp_style === 'modern';
       const executiveExp = style.exp_style === 'executive';
+      const creativeExp = style.exp_style === 'creative';
       const atsLabels = boldExp || minimalExp;
-      const hyphenDates = minimalExp || elegantExp || impactExp || modernExp || executiveExp;
-      const dashBullets = minimalExp || elegantExp || classicExp || impactExp || modernExp || executiveExp;
-      const clientsAfterBullets = classicExp || impactExp || modernExp || executiveExp;
-      const secteurInline = impactExp || modernExp || executiveExp;
+      const hyphenDates = minimalExp || elegantExp || impactExp || modernExp || executiveExp || creativeExp;
+      const dashBullets = minimalExp || elegantExp || classicExp || impactExp || modernExp || executiveExp || creativeExp;
+      const clientsAfterBullets = classicExp || impactExp || modernExp || executiveExp || creativeExp;
+      const secteurInline = impactExp || modernExp || executiveExp || creativeExp;
       return (
-        <div className={`free-canvas-block__section-list${boldExp ? ' free-canvas-block__section-list--bold-exp' : ''}${minimalExp ? ' free-canvas-block__section-list--minimal-exp' : ''}${elegantExp ? ' free-canvas-block__section-list--elegant-exp' : ''}${modernExp ? ' free-canvas-block__section-list--modern-exp' : ''}${executiveExp ? ' free-canvas-block__section-list--executive-exp' : ''}`}>
+        <div className={`free-canvas-block__section-list${boldExp ? ' free-canvas-block__section-list--bold-exp' : ''}${minimalExp ? ' free-canvas-block__section-list--minimal-exp' : ''}${elegantExp ? ' free-canvas-block__section-list--elegant-exp' : ''}${modernExp ? ' free-canvas-block__section-list--modern-exp' : ''}${executiveExp ? ' free-canvas-block__section-list--executive-exp' : ''}${creativeExp ? ' free-canvas-block__section-list--creative-exp' : ''}`}>
           <SectionHeading
             label={style.section_label || SECTION_LABELS.experiences}
             titleStyle={style.title_style}
@@ -448,7 +450,7 @@ function SemanticBlockBody({ block, cv, editing = false }) {
             return (
               <div
                 key={exp.id || i}
-                className={`free-canvas-block__exp${format === 'compact' ? ' free-canvas-block__exp--compact' : ''}${boldExp ? ' free-canvas-block__exp--bold' : ''}${minimalExp ? ' free-canvas-block__exp--minimal' : ''}${elegantExp ? ' free-canvas-block__exp--elegant' : ''}${classicExp ? ' free-canvas-block__exp--classic' : ''}${modernExp ? ' free-canvas-block__exp--modern' : ''}${executiveExp ? ' free-canvas-block__exp--executive' : ''}`}
+                className={`free-canvas-block__exp${format === 'compact' ? ' free-canvas-block__exp--compact' : ''}${boldExp ? ' free-canvas-block__exp--bold' : ''}${minimalExp ? ' free-canvas-block__exp--minimal' : ''}${elegantExp ? ' free-canvas-block__exp--elegant' : ''}${classicExp ? ' free-canvas-block__exp--classic' : ''}${modernExp ? ' free-canvas-block__exp--modern' : ''}${executiveExp ? ' free-canvas-block__exp--executive' : ''}${creativeExp ? ' free-canvas-block__exp--creative' : ''}`}
               >
                 {minimalExp ? (
                   <>

--- a/frontend/src/lib/canvasTemplateSpecs.js
+++ b/frontend/src/lib/canvasTemplateSpecs.js
@@ -136,8 +136,8 @@ export function parseCanvasTheme(template, optionValues = null) {
   };
   const defaults = {
     modern: { color_header: '#2d3748', color_sidebar: '#2d3748', color_accent: '#3182ce', color_section_title: '#3182ce', font: 'Inter' },
-    // Stable : --cv-color-section-title = accent (#f59e0b), pas la sidebar indigo.
-    creative: { color_header: '#6366f1', color_sidebar: '#6366f1', color_accent: '#f59e0b', color_section_title: '#f59e0b', font: 'Plus Jakarta Sans' },
+    // Titres main = indigo sidebar (comme twin historique) ; accent ambre = filets / photo / labels.
+    creative: { color_header: '#6366f1', color_sidebar: '#6366f1', color_accent: '#f59e0b', color_section_title: '#6366f1', font: 'Plus Jakarta Sans' },
     executive: { color_header: '#0f172a', color_sidebar: '#f8f6f0', color_accent: '#b8860b', color_section_title: '#0f172a', font: 'Georgia' },
     bold: { color_header: '#1e293b', color_sidebar: '#f1f5f9', color_accent: '#dc2626', color_section_title: '#1e293b', font: 'Plus Jakarta Sans' },
     classic: { color_header: '#1e2a3a', color_sidebar: '#f4f4f2', color_accent: '#1e2a3a', color_section_title: '#1e2a3a', font: 'Plus Jakarta Sans' },
@@ -172,9 +172,8 @@ export function parseCanvasTheme(template, optionValues = null) {
         const val = resolveOpt('accent_color', o.default);
         if (val) {
           theme.color_accent = val;
-          // Bold / Executive Stable : titres corps restent slate ; accent = filets/dates seulement.
-          // Creative Stable : titres main = accent (ambre).
-          if (id !== 'bold' && id !== 'executive') {
+          // Bold / Executive : titres slate. Creative : titres = sidebar indigo (pas accent ambre).
+          if (id !== 'creative' && id !== 'bold' && id !== 'executive') {
             theme.color_section_title = val;
           }
         }
@@ -189,7 +188,11 @@ export function parseCanvasTheme(template, optionValues = null) {
       }
       if (o?.key === 'sidebar_color') {
         const val = resolveOpt('sidebar_color', o.default);
-        if (val) theme.color_sidebar = val;
+        if (val) {
+          theme.color_sidebar = val;
+          // Creative : titres main calés sur la sidebar (indigo brand).
+          if (id === 'creative') theme.color_section_title = val;
+        }
       }
       if (o?.key === 'font') {
         const val = resolveOpt('font', o.default);
@@ -205,7 +208,7 @@ export function parseCanvasTheme(template, optionValues = null) {
     // Template catalogue sans schema options (id seul) : appliquer les valeurs live.
     if (live.accent_color) {
       theme.color_accent = live.accent_color;
-      if (id !== 'bold' && id !== 'executive') {
+      if (id !== 'creative' && id !== 'bold' && id !== 'executive') {
         theme.color_section_title = live.accent_color;
       }
     }
@@ -213,7 +216,10 @@ export function parseCanvasTheme(template, optionValues = null) {
       theme.color_header = live.header_color;
       if (id === 'executive') theme.color_section_title = live.header_color;
     }
-    if (live.sidebar_color) theme.color_sidebar = live.sidebar_color;
+    if (live.sidebar_color) {
+      theme.color_sidebar = live.sidebar_color;
+      if (id === 'creative') theme.color_section_title = live.sidebar_color;
+    }
     if (live.font) {
       theme.font_heading = fontStackFromTemplateOption(live.font);
       theme.font_body = id === 'executive' || id === 'minimal' || id === 'elegant'
@@ -221,6 +227,8 @@ export function parseCanvasTheme(template, optionValues = null) {
         : theme.font_heading;
     }
   }
+  // Creative : titres main = sidebar (Stable preview / twin historique), accent = filets uniquement.
+  if (id === 'creative') theme.color_section_title = theme.color_sidebar;
   return theme;
 }
 

--- a/frontend/src/lib/canvasTemplateSpecs.js
+++ b/frontend/src/lib/canvasTemplateSpecs.js
@@ -57,9 +57,9 @@ export const TEMPLATE_CANVAS_FIDELITY = Object.freeze({
   creative: {
     name: 'Créatif',
     layoutFamily: 'sidebar-left',
-    readiness: 'projection',
-    fidelityCss: 'medium',
-    gaps: ['Titres creative-main et bordures photo à valider visuellement'],
+    readiness: 'near-replica',
+    fidelityCss: 'rich',
+    gaps: ['Checklist visuelle Stable↔Beta (AXE-393)', 'Densité PDF compacte à valider'],
   },
   elegant: {
     name: 'Élégant',
@@ -136,7 +136,8 @@ export function parseCanvasTheme(template, optionValues = null) {
   };
   const defaults = {
     modern: { color_header: '#2d3748', color_sidebar: '#2d3748', color_accent: '#3182ce', color_section_title: '#3182ce', font: 'Inter' },
-    creative: { color_header: '#6366f1', color_sidebar: '#6366f1', color_accent: '#f59e0b', color_section_title: '#6366f1', font: 'Plus Jakarta Sans' },
+    // Stable : --cv-color-section-title = accent (#f59e0b), pas la sidebar indigo.
+    creative: { color_header: '#6366f1', color_sidebar: '#6366f1', color_accent: '#f59e0b', color_section_title: '#f59e0b', font: 'Plus Jakarta Sans' },
     executive: { color_header: '#0f172a', color_sidebar: '#f8f6f0', color_accent: '#b8860b', color_section_title: '#0f172a', font: 'Georgia' },
     bold: { color_header: '#1e293b', color_sidebar: '#f1f5f9', color_accent: '#dc2626', color_section_title: '#1e293b', font: 'Plus Jakarta Sans' },
     classic: { color_header: '#1e2a3a', color_sidebar: '#f4f4f2', color_accent: '#1e2a3a', color_section_title: '#1e2a3a', font: 'Plus Jakarta Sans' },
@@ -172,7 +173,8 @@ export function parseCanvasTheme(template, optionValues = null) {
         if (val) {
           theme.color_accent = val;
           // Bold / Executive Stable : titres corps restent slate ; accent = filets/dates seulement.
-          if (id !== 'creative' && id !== 'bold' && id !== 'executive') {
+          // Creative Stable : titres main = accent (ambre).
+          if (id !== 'bold' && id !== 'executive') {
             theme.color_section_title = val;
           }
         }
@@ -203,7 +205,7 @@ export function parseCanvasTheme(template, optionValues = null) {
     // Template catalogue sans schema options (id seul) : appliquer les valeurs live.
     if (live.accent_color) {
       theme.color_accent = live.accent_color;
-      if (id !== 'creative' && id !== 'bold' && id !== 'executive') {
+      if (id !== 'bold' && id !== 'executive') {
         theme.color_section_title = live.accent_color;
       }
     }
@@ -219,7 +221,6 @@ export function parseCanvasTheme(template, optionValues = null) {
         : theme.font_heading;
     }
   }
-  if (id === 'creative') theme.color_section_title = theme.color_sidebar;
   return theme;
 }
 
@@ -278,32 +279,6 @@ function rightSidebarMetrics() {
     MAIN_W: PAGE_WIDTH_MM - SB - px(36),
     SB_INSET: px(12),
   };
-}
-
-/** Blocs compétences + outils (reflow ajuste les y). */
-function sidebarCompetenceBlocks(x, w, startY, style, z, labels = {}) {
-  return [
-    {
-      type: 'skills',
-      bind: 'competences.techniques',
-      x,
-      y: startY,
-      w,
-      h: 30,
-      z,
-      style: { ...style, section_label: labels.tech || 'COMPÉTENCES', list_format: 'list' },
-    },
-    {
-      type: 'skills',
-      bind: 'competences.logiciels',
-      x,
-      y: startY + 34,
-      w,
-      h: 26,
-      z,
-      style: { ...style, section_label: labels.tools || 'OUTILS', list_format: 'list' },
-    },
-  ];
 }
 
 /** Sidebar type Executive / Classic / Bold (sous-titres catégorie). */
@@ -374,11 +349,7 @@ function sidebarCompetenceBlocksDetailed(x, w, startY, style, z) {
 export function buildTemplateBlocks(template, optionValues = null) {
   const id = template?.id;
   const t = parseCanvasTheme(template, optionValues);
-  const { SB, MAIN_L, MAIN_R, SB_R, H } = LAYOUT;
-  const sx = SIDE_PAD_X;
-  const sy = SIDE_PAD_Y;
-  const mx = MAIN_L.x + MAIN_PAD_X;
-  const mw = MAIN_L.w - MAIN_PAD_X * 2;
+  const { H } = LAYOUT;
   switch (id) {
     case 'modern': {
       // Réplique templates/modern : sidebar gauche (photo, identité, contact, skills…),
@@ -545,21 +516,172 @@ export function buildTemplateBlocks(template, optionValues = null) {
       ];
     }
 
-    case 'creative':
+    case 'creative': {
+      // Réplique templates/creative : sidebar gauche indigo (photo bordure accent,
+      // identité centrée + divider, CONTACT/COMPÉTENCES/OUTILS/CERTIFS/LANGUES/AUTRES),
+      // main PROFIL → EXP → FORMATION → PROJETS ; titres section = accent ambre.
+      const { SB, SX, SY, MAIN_X, MAIN_W, MAIN_Y } = leftSidebarMetrics();
+      const PHOTO = px(80);
+      const photoX = (SB - PHOTO) / 2;
+      const identityY = SY + PHOTO + px(10);
+      const identityH = px(42);
+      const contactY = identityY + identityH + px(10);
+      const sideW = SB - SX * 2;
+      const sideLock = { lock_geometry: true };
+      const sideCol = (extra = {}) => ({
+        ...sideCreative(),
+        title_style: 'creative-sidebar',
+        font_family: t.font_heading,
+        align: 'left',
+        ...extra,
+      });
+      const mainCol = (extra = {}) => ({
+        ...main(),
+        title_style: 'creative-main',
+        font_family: t.font_heading,
+        ...extra,
+      });
       return [
         bg(0, 0, SB, H, t.color_sidebar, 0),
-        { type: 'photo', x: SB / 2 - 11, y: sy, w: 22, h: 22, z: 2, style: { shape: 'circle', zone: 'sidebar', photo_border: 'accent' } },
-        { type: 'identity', bind: ['prenom', 'nom', 'titre_professionnel'], x: sx, y: sy + 24, w: SB - sx * 2, h: 24, z: 2, style: { ...sideCreative(), font_size: 14, identity_divider: true, font_style: 'italic' } },
-        { type: 'contact', bind: ['email', 'telephone', 'linkedin'], x: sx, y: sy + 50, w: SB - sx * 2, h: 22, z: 2, style: { ...sideCreative(), section_label: 'CONTACT', contact_divider: true } },
-        ...sidebarCompetenceBlocks(sx, SB - sx * 2, sy + 76, sideCreative(), 2, { tools: 'OUTILS' }),
-        { type: 'languages', x: sx, y: sy + 112, w: SB - sx * 2, h: 18, z: 2, style: { ...sideCreative(), section_label: 'LANGUES', list_format: 'list' } },
-        { type: 'certifications', bind: 'certifications', x: sx, y: sy + 132, w: SB - sx * 2, h: 22, z: 2, style: { ...sideCreative(), section_label: 'CERTIFICATIONS', list_format: 'list' } },
-        { type: 'skills', bind: 'competences.autres', x: sx, y: sy + 156, w: SB - sx * 2, h: 22, z: 2, style: { ...sideCreative(), section_label: 'AUTRES', list_format: 'list' } },
-        { type: 'resume', bind: 'resume', x: mx, y: MAIN_PAD_Y, w: mw, h: 22, z: 1, style: { ...main(), section_label: 'PROFIL', title_style: 'creative-main', font_style: 'italic' } },
-        { type: 'experiences', bind: 'experiences', x: mx, y: MAIN_PAD_Y + 26, w: mw, h: 130, z: 1, style: { ...main(), section_label: 'EXPÉRIENCE PROFESSIONNELLE', title_style: 'creative-main' } },
-        { type: 'formations', bind: 'formations', x: mx, y: MAIN_PAD_Y + 160, w: mw, h: 30, z: 1, style: { ...main(), section_label: 'FORMATION', title_style: 'creative-main' } },
-        { type: 'projets', bind: 'projets', x: mx, y: MAIN_PAD_Y + 194, w: mw, h: 26, z: 1, style: { ...main(), section_label: 'PROJETS', title_style: 'creative-main' } },
+        {
+          type: 'photo',
+          x: photoX,
+          y: SY,
+          w: PHOTO,
+          h: PHOTO,
+          z: 2,
+          style: { shape: 'circle', zone: 'sidebar', photo_border: 'accent', align: 'center', ...sideLock },
+        },
+        {
+          type: 'identity',
+          bind: ['prenom', 'nom', 'titre_professionnel'],
+          x: SX,
+          y: identityY,
+          w: sideW,
+          h: identityH,
+          z: 2,
+          style: {
+            ...sideCol(),
+            align: 'center',
+            identity_divider: true,
+            identity_layout: 'creative-sidebar',
+            ...sideLock,
+          },
+        },
+        {
+          type: 'contact',
+          bind: ['telephone', 'email', 'linkedin'],
+          x: SX,
+          y: contactY,
+          w: sideW,
+          h: px(48),
+          z: 2,
+          style: { ...sideCol(), section_label: 'CONTACT', contact_divider: true },
+        },
+        {
+          type: 'skills',
+          bind: 'competences.techniques',
+          x: SX,
+          y: contactY + px(52),
+          w: sideW,
+          h: px(40),
+          z: 2,
+          style: { ...sideCol(), section_label: 'COMPÉTENCES' },
+        },
+        {
+          type: 'skills',
+          bind: 'competences.logiciels',
+          x: SX,
+          y: contactY + px(96),
+          w: sideW,
+          h: px(34),
+          z: 2,
+          style: { ...sideCol(), section_label: 'OUTILS' },
+        },
+        {
+          type: 'certifications',
+          bind: 'certifications',
+          x: SX,
+          y: contactY + px(134),
+          w: sideW,
+          h: px(28),
+          z: 2,
+          style: { ...sideCol(), section_label: 'CERTIFICATIONS' },
+        },
+        {
+          type: 'languages',
+          x: SX,
+          y: contactY + px(166),
+          w: sideW,
+          h: px(24),
+          z: 2,
+          style: { ...sideCol(), section_label: 'LANGUES' },
+        },
+        {
+          type: 'skills',
+          bind: 'competences.autres',
+          x: SX,
+          y: contactY + px(194),
+          w: sideW,
+          h: px(28),
+          z: 2,
+          style: { ...sideCol(), section_label: 'AUTRES' },
+        },
+        {
+          type: 'resume',
+          bind: 'resume',
+          x: MAIN_X,
+          y: MAIN_Y,
+          w: MAIN_W,
+          h: px(36),
+          z: 1,
+          style: {
+            ...mainCol(),
+            section_label: 'PROFIL',
+            font_style: 'italic',
+            align: 'justify',
+          },
+        },
+        {
+          type: 'experiences',
+          bind: 'experiences',
+          x: MAIN_X,
+          y: MAIN_Y + px(42),
+          w: MAIN_W,
+          h: px(160),
+          z: 1,
+          style: {
+            ...mainCol(),
+            section_label: 'EXPÉRIENCE PROFESSIONNELLE',
+            exp_style: 'creative',
+          },
+        },
+        {
+          type: 'formations',
+          bind: 'formations',
+          x: MAIN_X,
+          y: MAIN_Y + px(208),
+          w: MAIN_W,
+          h: px(36),
+          z: 1,
+          style: {
+            ...mainCol(),
+            section_label: 'FORMATION',
+            formation_style: 'minimal',
+          },
+        },
+        {
+          type: 'projets',
+          bind: 'projets',
+          x: MAIN_X,
+          y: MAIN_Y + px(250),
+          w: MAIN_W,
+          h: px(28),
+          z: 1,
+          style: { ...mainCol(), section_label: 'PROJETS' },
+        },
       ];
+    }
 
     case 'executive': {
       // Réplique templates/executive : header sombre + barre accent 3px, photo 60px,

--- a/frontend/src/lib/layoutTemplatePresets.js
+++ b/frontend/src/lib/layoutTemplatePresets.js
@@ -24,6 +24,7 @@ export function createCanvasLayoutForTemplate(template, optionValues = null) {
     || template.id === 'bold'
     || template.id === 'modern'
     || template.id === 'executive'
+    || template.id === 'creative'
   ) {
     layout.freeform = true;
     layout.replica_cascade = true;

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -184,36 +184,197 @@
   display: none;
 }
 
-/* ---------- Créatif ---------- */
+/* ---------- Créatif (réplique templates/creative — AXE-393) ---------- */
 .free-canvas-page--tpl-creative {
   font-family: 'Plus Jakarta Sans', Arial, sans-serif;
+  color: #1a1a1a;
 }
 
-.free-canvas-page--tpl-creative .free-canvas-block__photo--border-accent {
-  box-shadow: 0 0 0 0.8mm var(--free-canvas-accent);
+.free-canvas-page--tpl-creative .free-canvas-block__inner {
+  padding: 0;
+}
+
+.free-canvas-page--tpl-creative .free-canvas-block__photo--border-accent,
+.free-canvas-page--tpl-creative .free-canvas-block__image-frame-inner.free-canvas-block__photo--border-accent {
   border-radius: 50%;
+  /* Stable : border 3px solid accent — pas de box-shadow (clippé → arcs). */
+  border: 3px solid var(--free-canvas-accent, #f59e0b);
+  box-shadow: none;
+  box-sizing: border-box;
 }
 
-.free-canvas-page--tpl-creative .free-canvas-block__section-title--sidebar,
-.free-canvas-page--tpl-creative .free-canvas-block__section-title--sidebar-creative {
-  font-size: 8.5pt;
-  color: var(--free-canvas-accent);
-  text-transform: uppercase;
+.free-canvas-page--tpl-creative .free-canvas-block__photo {
+  border-radius: 50%;
+  object-fit: cover;
+  object-position: center;
+}
+
+.free-canvas-page--tpl-creative .free-canvas-block__identity--creative-sidebar,
+.free-canvas-page--tpl-creative .free-canvas-block__identity--divider {
+  text-align: center;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  padding-bottom: 2.5mm;
+  margin: 0 0 2mm;
+}
+
+.free-canvas-page--tpl-creative .free-canvas-block__identity--creative-sidebar .free-canvas-block__identity-name,
+.free-canvas-page--tpl-creative .free-canvas-block__inner--zone-sidebar .free-canvas-block__identity-name {
+  font-family: var(--free-canvas-font-heading, 'Plus Jakarta Sans', Arial, sans-serif) !important;
+  font-size: 14pt !important;
+  font-weight: 700 !important;
+  color: #ffffff !important;
+  border-bottom: none;
+  padding-bottom: 0;
+  margin: 0;
+  line-height: 1.2;
+}
+
+.free-canvas-page--tpl-creative .free-canvas-block__identity--creative-sidebar .free-canvas-block__identity-title,
+.free-canvas-page--tpl-creative .free-canvas-block__inner--zone-sidebar .free-canvas-block__identity-title {
+  font-size: 9pt !important;
+  font-weight: 400 !important;
+  color: rgba(255, 255, 255, 0.9) !important;
+  font-style: italic !important;
+  opacity: 1 !important;
+  margin: 1mm 0 0;
+}
+
+.free-canvas-page--tpl-creative .free-canvas-block__section-title--creative-sidebar,
+.free-canvas-page--tpl-creative .free-canvas-block__section-title--sidebar-creative,
+.free-canvas-page--tpl-creative .free-canvas-block__section-title--sidebar {
+  font-family: var(--free-canvas-font-heading, 'Plus Jakarta Sans', Arial, sans-serif) !important;
+  font-size: 8.5pt !important;
+  font-weight: 700 !important;
   letter-spacing: 0.08em;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.28);
+  color: var(--free-canvas-accent, #f59e0b) !important;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.28) !important;
+  text-transform: uppercase;
+  margin: 0 0 1.5mm;
+  padding-bottom: 0.5mm;
 }
 
 .free-canvas-page--tpl-creative .free-canvas-block__contact--divider {
-  padding: 2mm 0;
+  padding: 0 0 2.5mm;
+  margin: 0 0 1mm;
   border-bottom: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 .free-canvas-page--tpl-creative .free-canvas-block__section-title--creative-main {
-  font-size: 10pt;
-  color: var(--free-canvas-sidebar);
-  text-transform: uppercase;
-  border-bottom: 0.5mm solid var(--free-canvas-accent);
+  font-family: var(--free-canvas-font-heading, 'Plus Jakarta Sans', Arial, sans-serif) !important;
+  font-size: 9.5pt !important;
+  font-weight: 700 !important;
+  color: var(--free-canvas-section-title, var(--free-canvas-accent, #f59e0b)) !important;
+  border-bottom: 2px solid var(--free-canvas-accent, #f59e0b) !important;
   letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin: 0 0 2mm;
+  padding-bottom: 0.8mm;
+}
+
+.free-canvas-page--tpl-creative .free-canvas-block__resume {
+  font-style: italic !important;
+  text-align: justify;
+  color: #555555 !important;
+  font-size: 9pt !important;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.free-canvas-page--tpl-creative .free-canvas-block__sidebar-item,
+.free-canvas-page--tpl-creative .free-canvas-block__inner--zone-sidebar .free-canvas-block__contact p,
+.free-canvas-page--tpl-creative .free-canvas-block__inner--zone-sidebar li {
+  font-size: 8pt !important;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.92) !important;
+  margin: 0 0 0.5mm;
+}
+
+.free-canvas-page--tpl-creative .free-canvas-block__exp--creative {
+  margin-bottom: 1.8mm;
+}
+
+.free-canvas-page--tpl-creative .free-canvas-block__exp--creative .free-canvas-block__exp-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 2.5mm;
+  margin-bottom: 0.4mm;
+}
+
+.free-canvas-page--tpl-creative .free-canvas-block__exp--creative .free-canvas-block__ats-label {
+  font-size: 0.9em;
+  color: #999999;
+  font-weight: 400;
+}
+
+.free-canvas-page--tpl-creative .free-canvas-block__exp--creative .free-canvas-block__exp-dates {
+  font-weight: 600 !important;
+  font-size: 8.5pt !important;
+  color: var(--free-canvas-sidebar, #6366f1) !important;
+  white-space: nowrap;
+}
+
+.free-canvas-page--tpl-creative .free-canvas-block__exp--creative .free-canvas-block__exp-entreprise strong {
+  color: #1a1a1a !important;
+  font-weight: 700 !important;
+}
+
+.free-canvas-page--tpl-creative .free-canvas-block__exp--creative .free-canvas-block__exp-role {
+  font-size: 9pt !important;
+  color: #666666 !important;
+  margin: 0.3mm 0 0.8mm;
+}
+
+.free-canvas-page--tpl-creative .free-canvas-block__exp-clients {
+  font-style: italic;
+  font-size: 8pt;
+  color: #888888;
+  margin: 0.8mm 0 0;
+}
+
+.free-canvas-page--tpl-creative .free-canvas-block__bullets--dash {
+  list-style: none;
+  margin: 0.4mm 0 0;
+  padding: 0;
+}
+
+.free-canvas-page--tpl-creative .free-canvas-block__bullets--dash li {
+  position: relative;
+  padding-left: 2.8mm;
+  margin: 0 0 0.3mm;
+  font-size: 8.5pt;
+  line-height: 1.4;
+}
+
+.free-canvas-page--tpl-creative .free-canvas-block__bullets--dash li::before {
+  content: '▸';
+  position: absolute;
+  left: 0;
+  color: var(--free-canvas-accent, #f59e0b);
+  font-size: 8pt;
+}
+
+.free-canvas-page--tpl-creative .free-canvas-block__formation--minimal .free-canvas-block__formation-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 2.5mm;
+}
+
+.free-canvas-page--tpl-creative .free-canvas-block__formation--minimal .free-canvas-block__formation-diplome {
+  font-weight: 600;
+  color: #1a1a1a !important;
+}
+
+.free-canvas-page--tpl-creative .free-canvas-block__formation--minimal .free-canvas-block__formation-date {
+  font-size: 8.5pt;
+  font-weight: 600;
+  color: var(--free-canvas-sidebar, #6366f1) !important;
+  white-space: nowrap;
+}
+
+.free-canvas-page--tpl-creative .free-canvas-block__pdf-fidelity-badge {
+  display: none;
 }
 
 /* ---------- Executive (réplique templates/executive — AXE-392) ---------- */

--- a/frontend/src/styles/CanvasTemplateFidelity.css
+++ b/frontend/src/styles/CanvasTemplateFidelity.css
@@ -263,7 +263,8 @@
   font-family: var(--free-canvas-font-heading, 'Plus Jakarta Sans', Arial, sans-serif) !important;
   font-size: 9.5pt !important;
   font-weight: 700 !important;
-  color: var(--free-canvas-section-title, var(--free-canvas-accent, #f59e0b)) !important;
+  /* Indigo sidebar (brand) — accent ambre réservé au filet / bullets / photo. */
+  color: var(--free-canvas-section-title, var(--free-canvas-sidebar, #6366f1)) !important;
   border-bottom: 2px solid var(--free-canvas-accent, #f59e0b) !important;
   letter-spacing: 0.04em;
   text-transform: uppercase;

--- a/frontend/tests/unit/canvasTemplateSpecs.test.js
+++ b/frontend/tests/unit/canvasTemplateSpecs.test.js
@@ -325,7 +325,7 @@ test('creative réplique Stable : sidebar indigo + accent ambre + freeform', () 
   assert.match(theme.font_heading, /Plus Jakarta Sans/);
   assert.equal(theme.color_sidebar, '#6366f1');
   assert.equal(theme.color_accent, '#f59e0b');
-  assert.equal(theme.color_section_title, '#f59e0b', 'titres = accent Stable');
+  assert.equal(theme.color_section_title, '#6366f1', 'titres main = sidebar indigo');
 
   const live = parseCanvasTheme(
     {
@@ -335,10 +335,11 @@ test('creative réplique Stable : sidebar indigo + accent ambre + freeform', () 
         { key: 'accent_color', type: 'color', default: '#f59e0b' },
       ],
     },
-    { accent_color: '#e11d48' },
+    { accent_color: '#e11d48', sidebar_color: '#4f46e5' },
   );
   assert.equal(live.color_accent, '#e11d48');
-  assert.equal(live.color_section_title, '#e11d48', 'titres suivent accent live');
+  assert.equal(live.color_sidebar, '#4f46e5');
+  assert.equal(live.color_section_title, '#4f46e5', 'titres suivent sidebar, pas accent');
 
   const layout = createCanvasLayoutForTemplate({ id: 'creative' });
   assert.equal(layout.freeform, true);

--- a/frontend/tests/unit/canvasTemplateSpecs.test.js
+++ b/frontend/tests/unit/canvasTemplateSpecs.test.js
@@ -277,6 +277,76 @@ test('modern réplique Stable : sidebar gauche + main PROFIL/EXP/FORMATION', () 
   assert.equal(getTemplateCanvasFidelity('modern')?.fidelityCss, 'rich');
 });
 
+test('creative réplique Stable : sidebar indigo + accent ambre + freeform', () => {
+  const blocks = buildTemplateBlocks({ id: 'creative' });
+  const photo = blocks.find((b) => b.type === 'photo');
+  const identity = blocks.find((b) => b.type === 'identity');
+  const contact = blocks.find((b) => b.type === 'contact');
+  const resume = blocks.find((b) => b.type === 'resume');
+  const experiences = blocks.find((b) => b.type === 'experiences');
+  const formations = blocks.find((b) => b.type === 'formations');
+  const projets = blocks.find((b) => b.type === 'projets');
+  const sidebarSkills = blocks.filter((b) => b.type === 'skills' && b.style?.zone === 'sidebar');
+  const shapes = blocks.filter((b) => b.type === 'shape:rect');
+
+  assert.ok(photo && identity && contact && resume && experiences);
+  assert.equal(photo.style?.zone, 'sidebar');
+  assert.equal(photo.style?.photo_border, 'accent');
+  assert.equal(photo.style?.lock_geometry, true);
+  assert.ok(photo.w > 18 && photo.w < 24, 'photo ~80px');
+
+  assert.equal(identity.style?.zone, 'sidebar');
+  assert.equal(identity.style?.align, 'center');
+  assert.equal(identity.style?.identity_layout, 'creative-sidebar');
+  assert.equal(identity.style?.identity_divider, true);
+  assert.equal(identity.style?.lock_geometry, true);
+
+  assert.equal(contact.style?.section_label, 'CONTACT');
+  assert.equal(contact.style?.title_style, 'creative-sidebar');
+  assert.equal(contact.style?.contact_divider, true);
+  assert.deepEqual(contact.bind, ['telephone', 'email', 'linkedin']);
+  assert.ok(contact.x < 60, 'contact en sidebar gauche');
+
+  assert.equal(resume.style?.zone, 'main');
+  assert.equal(resume.style?.section_label, 'PROFIL');
+  assert.equal(resume.style?.title_style, 'creative-main');
+  assert.equal(resume.style?.font_style, 'italic');
+  assert.ok(resume.x > 50, 'profil en main');
+
+  assert.equal(experiences.style?.exp_style, 'creative');
+  assert.equal(experiences.style?.title_style, 'creative-main');
+  assert.equal(formations.style?.formation_style, 'minimal');
+  assert.ok(projets, 'projets en main');
+  assert.ok(sidebarSkills.length >= 3, 'COMPÉTENCES / OUTILS / AUTRES');
+  assert.ok(sidebarSkills.every((b) => b.x < 60), 'skills sidebar gauche');
+  assert.equal(shapes.length, 1, 'bandeau sidebar uniquement');
+
+  const theme = parseCanvasTheme({ id: 'creative' });
+  assert.match(theme.font_heading, /Plus Jakarta Sans/);
+  assert.equal(theme.color_sidebar, '#6366f1');
+  assert.equal(theme.color_accent, '#f59e0b');
+  assert.equal(theme.color_section_title, '#f59e0b', 'titres = accent Stable');
+
+  const live = parseCanvasTheme(
+    {
+      id: 'creative',
+      options: [
+        { key: 'sidebar_color', type: 'color', default: '#6366f1' },
+        { key: 'accent_color', type: 'color', default: '#f59e0b' },
+      ],
+    },
+    { accent_color: '#e11d48' },
+  );
+  assert.equal(live.color_accent, '#e11d48');
+  assert.equal(live.color_section_title, '#e11d48', 'titres suivent accent live');
+
+  const layout = createCanvasLayoutForTemplate({ id: 'creative' });
+  assert.equal(layout.freeform, true);
+  assert.equal(layout.replica_cascade, true);
+  assert.equal(getTemplateCanvasFidelity('creative')?.readiness, 'near-replica');
+  assert.equal(getTemplateCanvasFidelity('creative')?.fidelityCss, 'rich');
+});
+
 test('parseCanvasTheme applique template_options live (Modern)', () => {
   const template = {
     id: 'modern',


### PR DESCRIPTION
## Summary
- Near-replica canvas Beta du template **Creative** (`templates/creative/`) : sidebar gauche `#6366f1`, photo bordure accent `#f59e0b`, identité + CONTACT/skills, main PROFIL/EXP/FORMATION/PROJETS
- Twin CSS rich + `exp_style: creative` (bullets ▸) + `freeform` / `replica_cascade`
- Titres de section = accent (Stable `--cv-color-section-title`), pas la sidebar indigo
- Dernier `projection` du catalogue AXE-346 → `near-replica`

Fixes AXE-393
Closes #184

## Test plan
- [ ] Apply Creative Stable→Beta : sidebar indigo, photo cercle accent, titres ambre
- [ ] Comparer visuellement preview Stable vs canvas Beta (page 1)
- [ ] Changer accent_color live → titres + filets suivent
- [ ] Pas de régression Minimal / Élégant / Classic / Bold / Modern / Executive
- [ ] `npm run test:unit` (canvasTemplateSpecs) vert


Made with [Cursor](https://cursor.com)