### PR TITLE
feat(AXE-359): balisage data-attr de la landing (React + HTML)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -189,28 +189,28 @@ a.button,a.btn{text-decoration:none}
               <img src="/favicon.svg" alt="AxeL Job" class="landing-logo" />
               <span class="landing-brand">AxeL Job</span>
               <nav class="landing-nav" aria-label="Navigation principale">
-                <a href="#comment">Comment ça marche</a>
-                <a href="#tarifs">Tarifs</a>
-                <a href="#features">Fonctionnalités</a>
-                <a href="/ats">Qu'est-ce que l'ATS ?</a>
-                <a href="/faq">FAQ</a>
-                <a href="/modeles-cv">Modèles CV</a>
-                <a href="/guide-cv">Guide CV</a>
-                <a href="/login" class="button button-primary landing-cta-nav">Essayer gratuitement</a>
+                <a href="#comment" data-attr="nav-link-how" data-track="nav" data-zone="header" data-level="tertiary">Comment ça marche</a>
+                <a href="#tarifs" data-attr="nav-link-pricing" data-track="nav" data-zone="header" data-level="tertiary">Tarifs</a>
+                <a href="#features" data-attr="nav-link-features" data-track="nav" data-zone="header" data-level="tertiary">Fonctionnalités</a>
+                <a href="/ats" data-attr="nav-link-ats" data-track="nav" data-zone="header" data-level="tertiary">Qu'est-ce que l'ATS ?</a>
+                <a href="/faq" data-attr="nav-link-faq" data-track="nav" data-zone="header" data-level="tertiary">FAQ</a>
+                <a href="/modeles-cv" data-attr="nav-link-modeles" data-track="nav" data-zone="header" data-level="tertiary">Modèles CV</a>
+                <a href="/guide-cv" data-attr="nav-link-guide" data-track="nav" data-zone="header" data-level="tertiary">Guide CV</a>
+                <a href="/login" class="button button-primary landing-cta-nav" data-attr="nav-cta-signup" data-track="cta" data-zone="header" data-level="primary">Essayer gratuitement</a>
               </nav>
-              <a href="/login" class="landing-mobile-cta button button-primary">Commencer</a>
+              <a href="/login" class="landing-mobile-cta button button-primary" data-attr="nav-cta-start" data-track="cta" data-zone="header" data-level="primary">Commencer</a>
             </div>
           </div>
         </header>
         <main id="main-content">
-          <section class="landing-hero">
+          <section class="landing-hero" data-section="hero">
             <div class="landing-container">
               <div class="landing-hero-inner">
                 <div class="landing-hero-content">
-                  <h1 class="landing-hero-title">Passe les filtres automatiques. Décroche des entretiens en 1 clic.</h1>
+                  <h1 class="landing-hero-title" data-attr="home-hero-title" data-zone="hero" data-level="tertiary">Passe les filtres automatiques. Décroche des entretiens en 1 clic.</h1>
                   <p class="landing-hero-subtitle">L'IA analyse l'offre d'emploi et adapte instantanément ton CV pour passer les filtres (ATS) et taper dans l'œil des recruteurs.</p>
                   <div class="landing-hero-ctas">
-                    <a href="/login" class="button button-primary landing-cta-hero">Essayer gratuitement</a>
+                    <a href="/login" class="button button-primary landing-cta-hero" data-attr="home-hero-cta-signup" data-track="cta" data-zone="hero" data-level="primary">Essayer gratuitement</a>
                     <span class="landing-hero-hint">3 adaptations offertes</span>
                   </div>
                 </div>
@@ -243,7 +243,7 @@ a.button,a.btn{text-decoration:none}
               </div>
             </div>
           </section>
-          <section id="comment" class="landing-section">
+          <section id="comment" class="landing-section" data-section="how">
             <div class="landing-container">
               <h2 class="landing-section-title">Comment ça marche</h2>
               <div class="landing-steps">
@@ -268,12 +268,12 @@ a.button,a.btn{text-decoration:none}
               </div>
             </div>
           </section>
-          <section id="tarifs" class="landing-section">
+          <section id="tarifs" class="landing-section" data-section="pricing">
             <div class="landing-container">
               <h2 class="landing-section-title">Tarifs</h2>
               <p class="landing-section-subtitle">Commence gratuitement. Passe Pro quand tu en as besoin.</p>
               <div class="landing-pricing">
-                <div class="pricing-card">
+                <div class="pricing-card" data-attr="home-pricing-card-free" data-zone="pricing" data-level="tertiary">
                   <div class="pricing-card-header">
                     <h3 class="pricing-plan-name">Gratuit</h3>
                     <div class="pricing-price"><span class="pricing-amount">0€</span><span class="pricing-period">pour toujours</span></div>
@@ -284,10 +284,10 @@ a.button,a.btn{text-decoration:none}
                     <li><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>Suivi de candidatures</li>
                     <li><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>Export PDF</li>
                   </ul>
-                  <a href="/login" class="button button-secondary pricing-cta">Commencer gratuitement</a>
+                  <a href="/login" class="button button-secondary pricing-cta" data-attr="home-pricing-cta-free" data-track="cta" data-zone="pricing" data-level="secondary">Commencer gratuitement</a>
                 </div>
-                <div class="pricing-card pricing-card--pro">
-                  <div class="pricing-badge">Populaire</div>
+                <div class="pricing-card pricing-card--pro" data-attr="home-pricing-card-pro" data-zone="pricing" data-level="tertiary">
+                  <div class="pricing-badge" data-attr="home-pricing-badge-popular" data-zone="pricing" data-level="tertiary">Populaire</div>
                   <div class="pricing-card-header">
                     <h3 class="pricing-plan-name">Pro</h3>
                     <div class="pricing-price"><span class="pricing-amount">10€</span><span class="pricing-period">/ mois</span></div>
@@ -300,12 +300,12 @@ a.button,a.btn{text-decoration:none}
                     <li><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>Lettre de motivation IA</li>
                     <li><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>Support prioritaire</li>
                   </ul>
-                  <a href="/login?plan=pro" class="button button-primary pricing-cta">Passer Pro</a>
+                  <a href="/login?plan=pro" class="button button-primary pricing-cta" data-attr="home-pricing-cta-pro" data-track="cta" data-zone="pricing" data-level="primary">Passer Pro</a>
                 </div>
               </div>
             </div>
           </section>
-          <section id="features" class="landing-section">
+          <section id="features" class="landing-section" data-section="features">
             <div class="landing-container">
               <h2 class="landing-section-title">Fonctionnalités</h2>
               <div class="landing-features-grid">
@@ -324,14 +324,14 @@ a.button,a.btn{text-decoration:none}
               </div>
             </div>
           </section>
-          <section class="landing-section">
+          <section class="landing-section" data-section="why">
             <div class="landing-container">
               <h2 class="landing-section-title">Pourquoi AxeL Job ?</h2>
               <div class="landing-features-grid">
                 <div class="landing-feature-card">
                   <h3 class="landing-feature-title">Score ATS optimisé</h3>
                   <p class="landing-feature-desc">Chaque CV est analysé et adapté pour maximiser son passage dans les filtres automatiques des recruteurs.</p>
-                  <a href="/ats" class="landing-ats-link">Qu'est-ce que l'ATS ?</a>
+                  <a href="/ats" class="landing-ats-link" data-attr="home-why-link-ats" data-track="nav" data-zone="why" data-level="tertiary">Qu'est-ce que l'ATS ?</a>
                 </div>
                 <div class="landing-feature-card">
                   <h3 class="landing-feature-title">Gain de temps massif</h3>
@@ -344,11 +344,11 @@ a.button,a.btn{text-decoration:none}
               </div>
             </div>
           </section>
-          <section class="landing-cta-bottom">
+          <section class="landing-cta-bottom" data-section="final">
             <div class="landing-container">
               <h2>Prêt à décrocher le job de tes rêves ?</h2>
               <p>Crée ton compte gratuit et teste 3 adaptations de CV.</p>
-              <a href="/login" class="button button-primary landing-cta-hero">Essayer gratuitement</a>
+              <a href="/login" class="button button-primary landing-cta-hero" data-attr="home-final-cta-signup" data-track="cta" data-zone="final" data-level="primary">Essayer gratuitement</a>
             </div>
           </section>
         </main>

--- a/frontend/src/components/LandingPage.jsx
+++ b/frontend/src/components/LandingPage.jsx
@@ -60,6 +60,13 @@ const PRO_FEATURES = [
   'Support prioritaire',
 ];
 
+/** Catalogue AXE-358 / AXE-359. Un ID = un nœud. `trackType` omis sur les surfaces A/B non-clic. */
+function analyticsAttrs(id, zone, level, trackType) {
+  const attrs = { 'data-attr': id, 'data-zone': zone, 'data-level': level };
+  if (trackType) attrs['data-track'] = trackType;
+  return attrs;
+}
+
 function BurgerIcon({ open }) {
   return (
     <svg className="landing-burger-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" aria-hidden>
@@ -119,14 +126,14 @@ export default function LandingPage({ onCtaClick, onProClick }) {
             <img src="/favicon.svg" alt="AxeL Job" className="landing-logo" />
             <span className="landing-brand">AxeL Job</span>
             <nav className="landing-nav" aria-label="Navigation principale">
-              <a href="#comment">Comment ça marche</a>
-              <a href="#tarifs">Tarifs</a>
-              <a href="#features">Fonctionnalités</a>
-              <Link to="/ats">Qu&apos;est-ce que l&apos;ATS ?</Link>
-              <Link to="/faq">FAQ</Link>
-              <Link to="/modeles-cv">Modèles CV</Link>
-              <Link to="/guide-cv">Guide CV</Link>
-              <button type="button" className="button button-primary landing-cta-nav" onClick={onCtaClick}>
+              <a href="#comment" {...analyticsAttrs('nav-link-how', 'header', 'tertiary', 'nav')}>Comment ça marche</a>
+              <a href="#tarifs" {...analyticsAttrs('nav-link-pricing', 'header', 'tertiary', 'nav')}>Tarifs</a>
+              <a href="#features" {...analyticsAttrs('nav-link-features', 'header', 'tertiary', 'nav')}>Fonctionnalités</a>
+              <Link to="/ats" {...analyticsAttrs('nav-link-ats', 'header', 'tertiary', 'nav')}>Qu&apos;est-ce que l&apos;ATS ?</Link>
+              <Link to="/faq" {...analyticsAttrs('nav-link-faq', 'header', 'tertiary', 'nav')}>FAQ</Link>
+              <Link to="/modeles-cv" {...analyticsAttrs('nav-link-modeles', 'header', 'tertiary', 'nav')}>Modèles CV</Link>
+              <Link to="/guide-cv" {...analyticsAttrs('nav-link-guide', 'header', 'tertiary', 'nav')}>Guide CV</Link>
+              <button type="button" className="button button-primary landing-cta-nav" onClick={onCtaClick} {...analyticsAttrs('nav-cta-signup', 'header', 'primary', 'cta')}>
                 Essayer gratuitement
               </button>
             </nav>
@@ -138,10 +145,11 @@ export default function LandingPage({ onCtaClick, onProClick }) {
                 aria-expanded={menuOpen}
                 aria-controls={drawerId}
                 aria-label={menuOpen ? 'Fermer le menu' : 'Ouvrir le menu'}
+                {...analyticsAttrs('nav-burger', 'header', 'tertiary', 'nav')}
               >
                 <BurgerIcon open={menuOpen} />
               </button>
-              <button type="button" className="landing-mobile-cta button button-primary" onClick={onCtaClick}>
+              <button type="button" className="landing-mobile-cta button button-primary" onClick={onCtaClick} {...analyticsAttrs('nav-cta-start', 'header', 'primary', 'cta')}>
                 Commencer
               </button>
             </div>
@@ -193,7 +201,7 @@ export default function LandingPage({ onCtaClick, onProClick }) {
                 <li><Link to="/cgu" onClick={closeMenu}>CGU</Link></li>
               </ul>
               <div className="landing-nav-drawer-cta">
-                <button type="button" className="button button-primary" onClick={() => { closeMenu(); onCtaClick(); }}>
+                <button type="button" className="button button-primary" onClick={() => { closeMenu(); onCtaClick(); }} {...analyticsAttrs('nav-cta-drawer', 'drawer', 'primary', 'cta')}>
                   Essayer gratuitement
                 </button>
               </div>
@@ -203,18 +211,18 @@ export default function LandingPage({ onCtaClick, onProClick }) {
       )}
 
       <main id="main-content">
-      <section className="landing-hero">
+      <section className="landing-hero" data-section="hero">
         <div className="landing-container">
           <div className="landing-hero-inner">
             <div className="landing-hero-content">
-              <h1 className="landing-hero-title">
+              <h1 className="landing-hero-title" {...analyticsAttrs('home-hero-title', 'hero', 'tertiary')}>
                 Passe les filtres automatiques. Décroche des entretiens en 1 clic.
               </h1>
               <p className="landing-hero-subtitle">
                 {"L'IA analyse l'offre d'emploi et adapte instantanément ton CV pour passer les filtres (ATS) et taper dans l'œil des recruteurs."}
               </p>
               <div className="landing-hero-ctas">
-                <button type="button" className="button button-primary landing-cta-hero" onClick={onCtaClick}>
+                <button type="button" className="button button-primary landing-cta-hero" onClick={onCtaClick} {...analyticsAttrs('home-hero-cta-signup', 'hero', 'primary', 'cta')}>
                   Essayer gratuitement
                 </button>
                 <span className="landing-hero-hint">3 adaptations offertes</span>
@@ -250,7 +258,7 @@ export default function LandingPage({ onCtaClick, onProClick }) {
         </div>
       </section>
 
-      <section id="comment" className="landing-section">
+      <section id="comment" className="landing-section" data-section="how">
         <div className="landing-container">
           <h2 className="landing-section-title">Comment ça marche</h2>
           <div className="landing-steps">
@@ -282,12 +290,12 @@ export default function LandingPage({ onCtaClick, onProClick }) {
         </div>
       </section>
 
-      <section id="tarifs" className="landing-section">
+      <section id="tarifs" className="landing-section" data-section="pricing">
         <div className="landing-container">
           <h2 className="landing-section-title">Tarifs</h2>
           <p className="landing-section-subtitle">Commence gratuitement. Passe Pro quand tu en as besoin.</p>
           <div className="landing-pricing">
-            <div className="pricing-card">
+            <div className="pricing-card" {...analyticsAttrs('home-pricing-card-free', 'pricing', 'tertiary')}>
               <div className="pricing-card-header">
                 <h3 className="pricing-plan-name">Gratuit</h3>
                 <div className="pricing-price">
@@ -303,13 +311,13 @@ export default function LandingPage({ onCtaClick, onProClick }) {
                   </li>
                 ))}
               </ul>
-              <button type="button" className="button button-secondary pricing-cta" onClick={onCtaClick}>
+              <button type="button" className="button button-secondary pricing-cta" onClick={onCtaClick} {...analyticsAttrs('home-pricing-cta-free', 'pricing', 'secondary', 'cta')}>
                 Commencer gratuitement
               </button>
             </div>
 
-            <div className="pricing-card pricing-card--pro">
-              <div className="pricing-badge">Populaire</div>
+            <div className="pricing-card pricing-card--pro" {...analyticsAttrs('home-pricing-card-pro', 'pricing', 'tertiary')}>
+              <div className="pricing-badge" {...analyticsAttrs('home-pricing-badge-popular', 'pricing', 'tertiary')}>Populaire</div>
               <div className="pricing-card-header">
                 <h3 className="pricing-plan-name">Pro</h3>
                 <div className="pricing-price">
@@ -325,7 +333,7 @@ export default function LandingPage({ onCtaClick, onProClick }) {
                   </li>
                 ))}
               </ul>
-              <button type="button" className="button button-primary pricing-cta" onClick={onProClick || onCtaClick}>
+              <button type="button" className="button button-primary pricing-cta" onClick={onProClick || onCtaClick} {...analyticsAttrs('home-pricing-cta-pro', 'pricing', 'primary', 'cta')}>
                 Passer Pro
               </button>
             </div>
@@ -333,7 +341,7 @@ export default function LandingPage({ onCtaClick, onProClick }) {
         </div>
       </section>
 
-      <section id="features" className="landing-section">
+      <section id="features" className="landing-section" data-section="features">
         <div className="landing-container">
           <h2 className="landing-section-title">Fonctionnalités</h2>
           <div className="landing-features-grid">
@@ -347,7 +355,7 @@ export default function LandingPage({ onCtaClick, onProClick }) {
         </div>
       </section>
 
-      <section className="landing-section">
+      <section className="landing-section" data-section="why">
         <div className="landing-container">
           <h2 className="landing-section-title">Pourquoi AxeL Job ?</h2>
           <div className="landing-features-grid">
@@ -356,7 +364,7 @@ export default function LandingPage({ onCtaClick, onProClick }) {
                 <h3 className="landing-feature-title">{b.title}</h3>
                 <p className="landing-feature-desc">{b.desc}</p>
                 {b.linkToAts && (
-                  <Link to="/ats" className="landing-ats-link">Qu&apos;est-ce que l&apos;ATS ?</Link>
+                  <Link to="/ats" className="landing-ats-link" {...analyticsAttrs('home-why-link-ats', 'why', 'tertiary', 'nav')}>Qu&apos;est-ce que l&apos;ATS ?</Link>
                 )}
               </div>
             ))}
@@ -364,11 +372,11 @@ export default function LandingPage({ onCtaClick, onProClick }) {
         </div>
       </section>
 
-      <section className="landing-cta-bottom">
+      <section className="landing-cta-bottom" data-section="final">
         <div className="landing-container">
           <h2>Prêt à décrocher le job de tes rêves ?</h2>
           <p>Crée ton compte gratuit et teste 3 adaptations de CV.</p>
-          <button type="button" className="button button-primary landing-cta-hero" onClick={onCtaClick}>
+          <button type="button" className="button button-primary landing-cta-hero" onClick={onCtaClick} {...analyticsAttrs('home-final-cta-signup', 'final', 'primary', 'cta')}>
             Essayer gratuitement
           </button>
         </div>

--- a/frontend/tests/unit/landingDataAttr.test.js
+++ b/frontend/tests/unit/landingDataAttr.test.js
@@ -1,0 +1,83 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FRONTEND_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+
+/** IDs home-* + nav-* posés en miroir React / HTML (AXE-359). */
+const SHARED_IDS = [
+  'nav-link-how',
+  'nav-link-pricing',
+  'nav-link-features',
+  'nav-link-ats',
+  'nav-link-faq',
+  'nav-link-modeles',
+  'nav-link-guide',
+  'nav-cta-signup',
+  'nav-cta-start',
+  'home-hero-title',
+  'home-hero-cta-signup',
+  'home-pricing-card-free',
+  'home-pricing-cta-free',
+  'home-pricing-card-pro',
+  'home-pricing-badge-popular',
+  'home-pricing-cta-pro',
+  'home-why-link-ats',
+  'home-final-cta-signup',
+];
+
+/** Burger + CTA drawer : markup React only (HTML statique sans menu JS). */
+const REACT_ONLY_IDS = ['nav-burger', 'nav-cta-drawer'];
+
+const SECTIONS = ['hero', 'how', 'pricing', 'features', 'why', 'final'];
+
+function unique(ids) {
+  const dups = ids.filter((id, i) => ids.indexOf(id) !== i);
+  return dups;
+}
+
+function idsFromHtml(text) {
+  return [...text.matchAll(/\bdata-attr="([a-z0-9-]+)"/g)].map((m) => m[1]);
+}
+
+function idsFromJsx(text) {
+  return [...text.matchAll(/analyticsAttrs\('([a-z0-9-]+)'/g)].map((m) => m[1]);
+}
+
+function sectionsFrom(text) {
+  return [...text.matchAll(/\bdata-section="([a-z-]+)"/g)].map((m) => m[1]);
+}
+
+test('landing React et HTML statique portent les data-attr AXE-359 en miroir', async () => {
+  const jsx = await readFile(path.join(FRONTEND_ROOT, 'src/components/LandingPage.jsx'), 'utf8');
+  const html = await readFile(path.join(FRONTEND_ROOT, 'index.html'), 'utf8');
+  const css = await readFile(path.join(FRONTEND_ROOT, 'src/components/LandingPage.css'), 'utf8');
+
+  const jsxIds = idsFromJsx(jsx);
+  const htmlIds = idsFromHtml(html);
+
+  assert.deepEqual(unique(jsxIds), [], `doublons React: ${unique(jsxIds)}`);
+  assert.deepEqual(unique(htmlIds), [], `doublons HTML: ${unique(htmlIds)}`);
+
+  for (const id of SHARED_IDS) {
+    assert.ok(jsxIds.includes(id), `manque React: ${id}`);
+    assert.ok(htmlIds.includes(id), `manque HTML: ${id}`);
+  }
+  for (const id of REACT_ONLY_IDS) {
+    assert.ok(jsxIds.includes(id), `manque React: ${id}`);
+    assert.equal(htmlIds.includes(id), false, `ID React-only présent dans HTML: ${id}`);
+  }
+
+  assert.equal(jsxIds.includes('nav-logo'), false);
+  assert.equal(jsxIds.includes('nav-link-back'), false);
+  assert.ok(!jsxIds.some((id) => id.startsWith('footer-')), 'footer hors AXE-359');
+
+  for (const section of SECTIONS) {
+    assert.ok(sectionsFrom(jsx).includes(section), `data-section React: ${section}`);
+    assert.ok(sectionsFrom(html).includes(section), `data-section HTML: ${section}`);
+  }
+
+  assert.equal(css.includes('data-attr'), false, 'pas de data-attr dans le CSS landing');
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

- Pose les `data-attr` **home-*** et **nav-*** du catalogue figé (AXE-358) sur la landing, en miroir :
  - `frontend/src/components/LandingPage.jsx`
  - `frontend/index.html` (`.static-crawlable`)
- Attributs : `data-attr`, `data-track` (clics seulement), `data-zone`, `data-level`
- Sections : `data-section="hero|how|pricing|features|why|final"`
- 3 CTA burger distincts : `nav-cta-signup` / `nav-cta-start` / `nav-cta-drawer`
- Surfaces A/B : H1, cartes tarif, badge Populaire (sans `data-track` pour ne pas les traiter comme des clics)
- Test unitaire : miroir React/HTML, unicité, pas de `data-attr` dans le CSS landing

Hors ticket (volontaire) :
- Footer → AXE-360
- `nav-logo` (logo `<img>`, pas de clic inventé)
- `nav-link-back`
- Liens extra du drawer (C.8)
- Tracker / GA4 / PostHog

`nav-burger` et `nav-cta-drawer` n’existent que dans React : le HTML statique n’a pas de menu burger (pas de JS).

## Why

Sans identifiants stables, les CTA `/login` de la home sont indiscernables. Le HTML statique est remplacé par React dès que le JS tourne : il faut les deux arbres.

## Linear

Fixes AXE-359

## GitHub issue

Pas d’issue GitHub miroir (`gh` lecture seule ici).

## Validation

- [x] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks` OK
- [x] Test `landingDataAttr.test.js`
- [x] Frontend lint (pre-push)
- [x] No secrets committed
- [ ] Recette visuelle : inchangée (attributs seulement) — inspecter `/` dans le DOM

## Test plan

- [x] Grep : IDs partagés présents React + HTML, uniques
- [ ] Ouvrir `/` : header desktop / mobile / hero / tarifs / final portent les `data-attr` (pas besoin de créer un compte)
- [ ] Vérifier qu’aucun `data-attr` n’est dans `LandingPage.css`

## Risk and rollback

- Risk: faible — markup seulement, pas de changement visuel ni de navigation
- Rollback: revert le commit

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

