### PR TITLE
feat(AXE-361): tracker unique CTA/nav/plan/section derrière la CMP

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -152,6 +152,7 @@ a.button,a.btn{text-decoration:none}
     <link rel="stylesheet" href="/consent-banner.css" />
     <script src="/analytics-config.js"></script>
     <script src="/consent-gtm.js"></script>
+    <script type="module" src="/track.js"></script>
     <script>window.__APP_CSS__ = "__APP_CSS_FILENAME__";</script>
   </head>
   <body>

--- a/frontend/public/404.html
+++ b/frontend/public/404.html
@@ -16,6 +16,7 @@
   <link rel="stylesheet" href="/consent-banner.css" />
   <script src="/analytics-config.js"></script>
   <script src="/consent-gtm.js"></script>
+  <script type="module" src="/track.js"></script>
 </head>
 <body>
   <div class="content-page">

--- a/frontend/public/500.html
+++ b/frontend/public/500.html
@@ -16,6 +16,7 @@
   <link rel="stylesheet" href="/consent-banner.css" />
   <script src="/analytics-config.js"></script>
   <script src="/consent-gtm.js"></script>
+  <script type="module" src="/track.js"></script>
 </head>
 <body>
   <div class="content-page">

--- a/frontend/public/ats.html
+++ b/frontend/public/ats.html
@@ -31,6 +31,7 @@
   <link rel="stylesheet" href="/consent-banner.css" />
   <script src="/analytics-config.js"></script>
   <script src="/consent-gtm.js"></script>
+  <script type="module" src="/track.js"></script>
 </head>
 <body>
   <div id="root">

--- a/frontend/public/cgu.html
+++ b/frontend/public/cgu.html
@@ -31,6 +31,7 @@
   <link rel="stylesheet" href="/consent-banner.css" />
   <script src="/analytics-config.js"></script>
   <script src="/consent-gtm.js"></script>
+  <script type="module" src="/track.js"></script>
 </head>
 <body>
   <div id="root">

--- a/frontend/public/confidentialite.html
+++ b/frontend/public/confidentialite.html
@@ -31,6 +31,7 @@
   <link rel="stylesheet" href="/consent-banner.css" />
   <script src="/analytics-config.js"></script>
   <script src="/consent-gtm.js"></script>
+  <script type="module" src="/track.js"></script>
 </head>
 <body>
   <div id="root">

--- a/frontend/public/consent-gtm.js
+++ b/frontend/public/consent-gtm.js
@@ -76,6 +76,15 @@
       axel_analytics: analytics,
       axel_marketing: marketing,
     });
+    try {
+      window.dispatchEvent(
+        new CustomEvent('axel_consent_update', {
+          detail: { analytics: !!analytics, marketing: !!marketing },
+        }),
+      );
+    } catch (_) {
+      /* CustomEvent indisponible */
+    }
   }
 
   function applySaved(c) {

--- a/frontend/public/cv-adapte-chaque-offre.html
+++ b/frontend/public/cv-adapte-chaque-offre.html
@@ -31,6 +31,7 @@
   <link rel="stylesheet" href="/consent-banner.css" />
   <script src="/analytics-config.js"></script>
   <script src="/consent-gtm.js"></script>
+  <script type="module" src="/track.js"></script>
   <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"Article","headline":"Pourquoi adapter son CV à chaque offre d'emploi (et comment le faire efficacement)","description":"Données sur la personnalisation du CV, mots-clés ATS, coût en temps et gain avec l'IA.","publisher":{"@type":"Organization","name":"AxeL Job","url":"https://job.axelproject.fr"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://job.axelproject.fr/cv-adapte-chaque-offre"}}
   </script>

--- a/frontend/public/cv-par-metier.html
+++ b/frontend/public/cv-par-metier.html
@@ -31,6 +31,7 @@
   <link rel="stylesheet" href="/consent-banner.css" />
   <script src="/analytics-config.js"></script>
   <script src="/consent-gtm.js"></script>
+  <script type="module" src="/track.js"></script>
 </head>
 <body>
   <div id="root">

--- a/frontend/public/erreurs-cv.html
+++ b/frontend/public/erreurs-cv.html
@@ -31,6 +31,7 @@
   <link rel="stylesheet" href="/consent-banner.css" />
   <script src="/analytics-config.js"></script>
   <script src="/consent-gtm.js"></script>
+  <script type="module" src="/track.js"></script>
 </head>
 <body>
   <div id="root">

--- a/frontend/public/faq.html
+++ b/frontend/public/faq.html
@@ -31,6 +31,7 @@
   <link rel="stylesheet" href="/consent-banner.css" />
   <script src="/analytics-config.js"></script>
   <script src="/consent-gtm.js"></script>
+  <script type="module" src="/track.js"></script>
   <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"FAQPage","mainEntity":[
     {"@type":"Question","name":"Pourquoi mon CV ne passe pas si j'ai les bonnes compétences ?","acceptedAnswer":{"@type":"Answer","text":"Selon l'étude Harvard Business School Hidden Workers, 88 % des employeurs estiment perdre des candidats qualifiés non pas parce que l'ATS les rejette automatiquement, mais parce que les mots utilisés dans leur CV ne correspondent pas aux termes exacts configurés par le recruteur. Le CV est bien lu, mais le vocabulaire ne matche pas."}},

--- a/frontend/public/guide-cv.html
+++ b/frontend/public/guide-cv.html
@@ -31,6 +31,7 @@
   <link rel="stylesheet" href="/consent-banner.css" />
   <script src="/analytics-config.js"></script>
   <script src="/consent-gtm.js"></script>
+  <script type="module" src="/track.js"></script>
 </head>
 <body>
   <div id="root">

--- a/frontend/public/home.html
+++ b/frontend/public/home.html
@@ -33,6 +33,7 @@
   <link rel="stylesheet" href="/consent-banner.css" />
   <script src="/analytics-config.js"></script>
   <script src="/consent-gtm.js"></script>
+  <script type="module" src="/track.js"></script>
   <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"SoftwareApplication","name":"AxeL Job","url":"https://job.axelproject.fr","description":"Outil pour créer et optimiser son CV pour l'ATS. CV adapté à chaque offre d'emploi en un clic avec l'IA. Score ATS, personnalisation par annonce, suivi des candidatures, export PDF. Générateur de CV IA compatible ATS. Essai gratuit.","applicationCategory":"BusinessApplication","operatingSystem":"Web","offers":{"@type":"Offer","price":"0","priceCurrency":"EUR"},"featureList":"Adaptation du CV à chaque offre avec IA; Score ATS; Mots-clés et format compatible ATS; Suivi des candidatures; Export PDF"}
   </script>

--- a/frontend/public/login.html
+++ b/frontend/public/login.html
@@ -32,6 +32,7 @@
   <link rel="stylesheet" href="/consent-banner.css" />
   <script src="/analytics-config.js"></script>
   <script src="/consent-gtm.js"></script>
+  <script type="module" src="/track.js"></script>
   <style>.js-enabled #root .static-crawlable{display:none!important}</style>
 </head>
 <body>

--- a/frontend/public/mentions-legales.html
+++ b/frontend/public/mentions-legales.html
@@ -31,6 +31,7 @@
   <link rel="stylesheet" href="/consent-banner.css" />
   <script src="/analytics-config.js"></script>
   <script src="/consent-gtm.js"></script>
+  <script type="module" src="/track.js"></script>
 </head>
 <body>
   <div id="root">

--- a/frontend/public/modeles-cv.html
+++ b/frontend/public/modeles-cv.html
@@ -31,6 +31,7 @@
   <link rel="stylesheet" href="/consent-banner.css" />
   <script src="/analytics-config.js"></script>
   <script src="/consent-gtm.js"></script>
+  <script type="module" src="/track.js"></script>
 </head>
 <body>
   <div id="root">

--- a/frontend/public/track.js
+++ b/frontend/public/track.js
@@ -1,0 +1,280 @@
+/**
+ * AXE-361 — tracker marketing unique (CTA / nav / plan / section).
+ * Chargé en <script type="module"> à côté de la CMP. Aucun event avant
+ * consentement analytics (`axel_job_consent_v1` / `axel_consent_update`).
+ * Hors `/app/*`. Ne cible jamais une classe CSS.
+ */
+export const CONSENT_STORAGE_KEY = 'axel_job_consent_v1';
+export const SECTION_VIEWED_KEY = 'axel_section_viewed_v1';
+
+/** Destinations des CTA React sans href (catalogue AXE-358). */
+export const CTA_LINK_URLS = {
+  'nav-cta-signup': '/login',
+  'nav-cta-start': '/login',
+  'nav-cta-drawer': '/login',
+  'home-hero-cta-signup': '/login',
+  'home-pricing-cta-free': '/login',
+  'home-pricing-cta-pro': '/login?plan=pro',
+  'home-final-cta-signup': '/login',
+  'faq-cta-signup': '/login',
+  'ats-cta-signup': '/login',
+  'modeles-cta-signup': '/login',
+  'guide-cta-signup': '/login',
+  'erreurs-cta-signup': '/login',
+  'metier-cta-signup': '/login',
+  'adapte-cta-signup': '/login',
+  'error-cta-home': '/',
+  'error-cta-login': '/login',
+  'login-cta-google': '/login',
+  'login-cta-linkedin': '/login',
+  'login-cta-submit': '/login',
+};
+
+export const PLAN_BY_CTA = {
+  'home-pricing-cta-pro': { plan: 'pro', price: 10, zone: 'pricing' },
+  'home-pricing-cta-free': { plan: 'free', price: 0, zone: 'pricing' },
+};
+
+const EMAIL_RE = /[^\s@]+@[^\s@]+\.[^\s@]+/g;
+
+export function sanitizeCtaText(text) {
+  if (!text) return '';
+  let s = String(text).replace(/\s+/g, ' ').trim();
+  s = s.replace(EMAIL_RE, '');
+  s = s.replace(/\s+/g, ' ').trim();
+  if (s.length > 80) s = s.slice(0, 80);
+  return s;
+}
+
+export function hasAnalyticsConsent(raw) {
+  if (!raw) return false;
+  try {
+    const o = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    return !!(o && o.v === 1 && o.analytics);
+  } catch {
+    return false;
+  }
+}
+
+export function resolveLinkUrl(dataAttr, href) {
+  const h = (href || '').trim();
+  if (/^\s*javascript:/i.test(h)) return CTA_LINK_URLS[dataAttr] || '';
+  if (/^mailto:/i.test(h)) return 'mailto:';
+  if (h) return h;
+  return CTA_LINK_URLS[dataAttr] || '';
+}
+
+function hostFromHref(href) {
+  if (!href || !/^https?:\/\//i.test(href)) return '';
+  try {
+    return new URL(href).hostname;
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Parseur d’événement (testable sans DOM).
+ * @returns {{ name: string, params: Record<string, string|number> }[]}
+ */
+export function eventsFromClick({
+  dataAttr,
+  dataTrack,
+  dataZone,
+  dataLevel,
+  href,
+  text,
+  pageHost,
+}) {
+  const events = [];
+  if (!dataAttr) return events;
+  if (dataTrack === 'input') return events;
+
+  const linkUrl = resolveLinkUrl(dataAttr, href);
+
+  if (dataTrack === 'cta') {
+    if (!dataZone || !dataLevel) return events;
+    events.push({
+      name: 'cta_click',
+      params: {
+        cta_id: dataAttr,
+        cta_zone: dataZone,
+        cta_level: dataLevel,
+        cta_text: sanitizeCtaText(text),
+        link_url: linkUrl,
+      },
+    });
+    const plan = PLAN_BY_CTA[dataAttr];
+    if (plan) {
+      events.push({
+        name: 'select_plan',
+        params: { plan: plan.plan, price: plan.price, zone: plan.zone },
+      });
+    }
+  } else if (dataTrack === 'nav') {
+    events.push({
+      name: 'nav_click',
+      params: {
+        nav_id: dataAttr,
+        nav_type: dataZone || 'nav',
+        link_url: linkUrl,
+      },
+    });
+  }
+
+  const h = (href || '').trim();
+  if (/^mailto:/i.test(h)) {
+    events.push({ name: 'contact_click', params: { method: 'email' } });
+  } else if (h) {
+    const linkHost = hostFromHref(h);
+    if (linkHost && pageHost && linkHost !== pageHost) {
+      events.push({
+        name: 'outbound_click',
+        params: { link_domain: linkHost, link_url: h },
+      });
+    }
+  }
+
+  return events;
+}
+
+export function isMarketingPath(pathname) {
+  const p = pathname || '';
+  return p !== '/app' && p.indexOf('/app/') !== 0;
+}
+
+function readStoredConsent() {
+  try {
+    return localStorage.getItem(CONSENT_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function emit(name, params) {
+  if (!hasAnalyticsConsent(readStoredConsent())) return;
+  const payload = { event: name, ...params };
+  if (typeof window.gtag === 'function') {
+    window.gtag('event', name, params);
+  }
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push(payload);
+}
+
+function attrsFromEl(el) {
+  if (!el || !el.getAttribute) return null;
+  const dataAttr = el.getAttribute('data-attr');
+  if (!dataAttr) return null;
+  const href = el.getAttribute('href') || '';
+  return {
+    dataAttr,
+    dataTrack: el.getAttribute('data-track') || '',
+    dataZone: el.getAttribute('data-zone') || '',
+    dataLevel: el.getAttribute('data-level') || '',
+    href,
+    text: el.textContent || '',
+    pageHost: (window.location && window.location.hostname) || '',
+  };
+}
+
+function onDocumentClick(e) {
+  if (!isMarketingPath(window.location.pathname)) return;
+  const t = e.target;
+  if (!t || !t.closest) return;
+  const el = t.closest('[data-attr]');
+  if (!el) return;
+  const input = attrsFromEl(el);
+  if (!input) return;
+  const events = eventsFromClick(input);
+  for (const ev of events) emit(ev.name, ev.params);
+}
+
+function loadSeenSections() {
+  try {
+    const raw = sessionStorage.getItem(SECTION_VIEWED_KEY);
+    const arr = raw ? JSON.parse(raw) : [];
+    return new Set(Array.isArray(arr) ? arr : []);
+  } catch {
+    return new Set();
+  }
+}
+
+function persistSeen(seen) {
+  try {
+    sessionStorage.setItem(SECTION_VIEWED_KEY, JSON.stringify([...seen]));
+  } catch {
+    /* private mode */
+  }
+}
+
+let sectionObserver = null;
+const observedEls = new WeakSet();
+let seenSections = loadSeenSections();
+let mutationObs = null;
+let clickBound = false;
+
+function ensureObserver() {
+  if (sectionObserver || typeof IntersectionObserver === 'undefined') return;
+  sectionObserver = new IntersectionObserver(
+    (entries) => {
+      if (!hasAnalyticsConsent(readStoredConsent())) return;
+      for (const entry of entries) {
+        if (entry.intersectionRatio < 0.5) continue;
+        const id = entry.target.getAttribute('data-section');
+        if (!id || seenSections.has(id)) continue;
+        seenSections.add(id);
+        persistSeen(seenSections);
+        sectionObserver.unobserve(entry.target);
+        emit('section_view', { section_id: id });
+      }
+    },
+    { threshold: 0.5 },
+  );
+}
+
+function observeNewSections() {
+  if (!isMarketingPath(window.location.pathname)) return;
+  if (!hasAnalyticsConsent(readStoredConsent())) return;
+  ensureObserver();
+  if (!sectionObserver) return;
+  const nodes = document.querySelectorAll('[data-section]');
+  for (const el of nodes) {
+    const id = el.getAttribute('data-section');
+    if (!id || seenSections.has(id) || observedEls.has(el)) continue;
+    observedEls.add(el);
+    sectionObserver.observe(el);
+  }
+}
+
+function startMutationWatch() {
+  if (mutationObs || typeof MutationObserver === 'undefined') return;
+  mutationObs = new MutationObserver(() => {
+    observeNewSections();
+  });
+  mutationObs.observe(document.documentElement, { childList: true, subtree: true });
+}
+
+function onConsent(analyticsGranted) {
+  if (!analyticsGranted) return;
+  observeNewSections();
+}
+
+function boot() {
+  if (clickBound) return;
+  clickBound = true;
+  document.addEventListener('click', onDocumentClick, true);
+  window.addEventListener('axel_consent_update', (ev) => {
+    const granted = !!(ev && ev.detail && ev.detail.analytics);
+    onConsent(granted);
+  });
+  startMutationWatch();
+  if (hasAnalyticsConsent(readStoredConsent())) observeNewSections();
+}
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot);
+  } else {
+    boot();
+  }
+}

--- a/frontend/tests/unit/marketingTracker.test.js
+++ b/frontend/tests/unit/marketingTracker.test.js
@@ -1,0 +1,221 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  eventsFromClick,
+  hasAnalyticsConsent,
+  resolveLinkUrl,
+  sanitizeCtaText,
+  isMarketingPath,
+  CTA_LINK_URLS,
+} from '../../public/track.js';
+
+const FRONTEND_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+
+test('cta React sans href : link_url depuis le catalogue, jamais unknown', () => {
+  const events = eventsFromClick({
+    dataAttr: 'home-hero-cta-signup',
+    dataTrack: 'cta',
+    dataZone: 'hero',
+    dataLevel: 'primary',
+    href: '',
+    text: 'Essayer gratuitement',
+    pageHost: 'job.axelproject.fr',
+  });
+  assert.equal(events.length, 1);
+  assert.equal(events[0].name, 'cta_click');
+  assert.equal(events[0].params.cta_id, 'home-hero-cta-signup');
+  assert.equal(events[0].params.cta_zone, 'hero');
+  assert.equal(events[0].params.cta_level, 'primary');
+  assert.equal(events[0].params.link_url, '/login');
+  assert.equal(events[0].params.cta_text, 'Essayer gratuitement');
+  assert.equal(events[0].params.cta_zone === 'unknown', false);
+});
+
+test('home-pricing-cta-pro → cta_click et select_plan pro', () => {
+  const events = eventsFromClick({
+    dataAttr: 'home-pricing-cta-pro',
+    dataTrack: 'cta',
+    dataZone: 'pricing',
+    dataLevel: 'primary',
+    href: '',
+    text: 'Passer Pro',
+    pageHost: 'job.axelproject.fr',
+  });
+  assert.deepEqual(
+    events.map((e) => e.name),
+    ['cta_click', 'select_plan'],
+  );
+  assert.deepEqual(events[1].params, { plan: 'pro', price: 10, zone: 'pricing' });
+  assert.equal(events[0].params.link_url, '/login?plan=pro');
+});
+
+test('home-pricing-cta-free → cta_click et select_plan free', () => {
+  const events = eventsFromClick({
+    dataAttr: 'home-pricing-cta-free',
+    dataTrack: 'cta',
+    dataZone: 'pricing',
+    dataLevel: 'secondary',
+    href: '/login',
+    text: 'Commencer gratuitement',
+    pageHost: 'job.axelproject.fr',
+  });
+  assert.deepEqual(
+    events.map((e) => e.name),
+    ['cta_click', 'select_plan'],
+  );
+  assert.deepEqual(events[1].params, { plan: 'free', price: 0, zone: 'pricing' });
+});
+
+test('href réel gagne sur la map catalogue', () => {
+  assert.equal(resolveLinkUrl('nav-cta-signup', '/login?plan=pro'), '/login?plan=pro');
+  assert.equal(resolveLinkUrl('nav-cta-signup', ''), '/login');
+  assert.equal(CTA_LINK_URLS['home-pricing-cta-pro'], '/login?plan=pro');
+});
+
+test('nav_click utilise nav_id + nav_type, pas cta_id', () => {
+  const events = eventsFromClick({
+    dataAttr: 'footer-link-faq',
+    dataTrack: 'nav',
+    dataZone: 'footer',
+    dataLevel: 'tertiary',
+    href: '/faq',
+    text: 'FAQ',
+    pageHost: 'job.axelproject.fr',
+  });
+  assert.equal(events.length, 1);
+  assert.equal(events[0].name, 'nav_click');
+  assert.equal(events[0].params.nav_id, 'footer-link-faq');
+  assert.equal(events[0].params.nav_type, 'footer');
+  assert.equal(events[0].params.link_url, '/faq');
+  assert.equal('cta_id' in events[0].params, false);
+});
+
+test('data-track=input : aucun event (jamais la valeur du champ)', () => {
+  const events = eventsFromClick({
+    dataAttr: 'login-input-email',
+    dataTrack: 'input',
+    dataZone: 'login',
+    dataLevel: 'tertiary',
+    href: '',
+    text: 'user@example.com',
+    pageHost: 'job.axelproject.fr',
+  });
+  assert.deepEqual(events, []);
+});
+
+test('h2 FAQ sans data-track : pas de nav_click', () => {
+  const events = eventsFromClick({
+    dataAttr: 'faq-question-cv-bonnes-competences',
+    dataTrack: '',
+    dataZone: 'faq',
+    dataLevel: 'tertiary',
+    href: '',
+    text: 'Pourquoi mon CV ne passe pas',
+    pageHost: 'job.axelproject.fr',
+  });
+  assert.deepEqual(events, []);
+});
+
+test('cta sans zone/level : pas d’event unknown', () => {
+  const events = eventsFromClick({
+    dataAttr: 'home-hero-cta-signup',
+    dataTrack: 'cta',
+    dataZone: '',
+    dataLevel: '',
+    href: '/login',
+    text: 'Essayer',
+    pageHost: 'job.axelproject.fr',
+  });
+  assert.deepEqual(events, []);
+});
+
+test('mailto → contact_click method email + nav si track=nav', () => {
+  const events = eventsFromClick({
+    dataAttr: 'footer-link-support',
+    dataTrack: 'nav',
+    dataZone: 'footer',
+    dataLevel: 'tertiary',
+    href: 'mailto:contact@example.com',
+    text: 'Support',
+    pageHost: 'job.axelproject.fr',
+  });
+  assert.deepEqual(
+    events.map((e) => e.name),
+    ['nav_click', 'contact_click'],
+  );
+  assert.equal(events[0].params.link_url, 'mailto:');
+  assert.equal(events[1].params.method, 'email');
+  assert.equal(JSON.stringify(events).includes('contact@example.com'), false);
+});
+
+test('lien externe → outbound_click', () => {
+  const events = eventsFromClick({
+    dataAttr: 'footer-link-axelproject',
+    dataTrack: 'nav',
+    dataZone: 'footer',
+    dataLevel: 'tertiary',
+    href: 'https://axelproject.fr/',
+    text: 'Axel Project',
+    pageHost: 'job.axelproject.fr',
+  });
+  assert.deepEqual(
+    events.map((e) => e.name),
+    ['nav_click', 'outbound_click'],
+  );
+  assert.equal(events[1].params.link_domain, 'axelproject.fr');
+  assert.equal(events[1].params.link_url, 'https://axelproject.fr/');
+});
+
+test('sanitizeCtaText retire les emails et tronque', () => {
+  assert.equal(sanitizeCtaText('  Bonjour  user@example.com  '), 'Bonjour');
+  assert.equal(sanitizeCtaText('x'.repeat(100)).length, 80);
+});
+
+test('consentement analytics : seulement v1 + analytics true', () => {
+  assert.equal(hasAnalyticsConsent(null), false);
+  assert.equal(hasAnalyticsConsent('{"v":1,"analytics":false}'), false);
+  assert.equal(hasAnalyticsConsent('{"v":1,"analytics":true}'), true);
+  assert.equal(hasAnalyticsConsent('{'), false);
+});
+
+test('hors /app', () => {
+  assert.equal(isMarketingPath('/'), true);
+  assert.equal(isMarketingPath('/login'), true);
+  assert.equal(isMarketingPath('/faq'), true);
+  assert.equal(isMarketingPath('/app'), false);
+  assert.equal(isMarketingPath('/app/postule'), false);
+});
+
+test('track.js chargé après la CMP sur index + pages publiques', async () => {
+  const index = await readFile(path.join(FRONTEND_ROOT, 'index.html'), 'utf8');
+  assert.ok(index.includes('src="/consent-gtm.js"'));
+  assert.ok(index.includes('src="/track.js"'));
+  assert.ok(index.indexOf('consent-gtm.js') < index.indexOf('track.js'));
+
+  const htmlFiles = [
+    'faq.html',
+    'ats.html',
+    'login.html',
+    '404.html',
+    '500.html',
+    'home.html',
+    'modeles-cv.html',
+    'guide-cv.html',
+    'erreurs-cv.html',
+    'cv-par-metier.html',
+    'cv-adapte-chaque-offre.html',
+    'mentions-legales.html',
+    'confidentialite.html',
+    'cgu.html',
+  ];
+  for (const file of htmlFiles) {
+    const html = await readFile(path.join(FRONTEND_ROOT, 'public', file), 'utf8');
+    assert.ok(html.includes('src="/track.js"'), `${file} charge track.js`);
+  }
+
+  const consent = await readFile(path.join(FRONTEND_ROOT, 'public', 'consent-gtm.js'), 'utf8');
+  assert.ok(consent.includes("CustomEvent('axel_consent_update'"));
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes AXE-361

## What changed

Tracker marketing unique `frontend/public/track.js` (ESM), chargé après la CMP sur `index.html` et toutes les pages `public/*.html`.

- Clic délégué sur `[data-attr]` : `cta_click`, `nav_click`, `select_plan` (pro/free), `outbound_click`, `contact_click`
- `section_view` via IntersectionObserver (≥ 50 %), une fois par session / `section_id`
- Aucun event avant consentement analytics (`axel_job_consent_v1` + CustomEvent `axel_consent_update`)
- Boutons React sans `href` : `link_url` via catalogue (`/login`, `/login?plan=pro`)
- Hors `/app/*`
- `mailto:` : pas d’adresse dans le payload (`link_url=mailto:`, `method=email`)
- `data-track=input` ignoré (jamais la valeur du champ)

## Why

Les `data-attr` sont posés (359–360) mais aucun listener n’envoyait `cta_click` / `nav_click` / `select_plan` / `section_view` vers GA4.

## Validation

- [x] `node --test tests/unit/marketingTracker.test.js` (parseur plan / outbound / consent / sans href)
- [x] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks` OK
- [x] Docs: pas de SDK PostHog (no-go 363)
- Recette manuelle (sans créer de compte) : accepter cookies, cliquer un CTA landing + un lien footer, scroller une section, vérifier DebugView / dataLayer. Hors `/app`.

## Risk and rollback

- Risk: events GA4 en trop si GTM mal filtré ; le tracker ne pousse rien sans consentement analytics.
- Rollback: revert de la PR (retirer `track.js` et le script des HTML).

Pas d’issue GitHub miroir (`gh` lecture seule).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

