### PR TITLE
docs(AXE-365): runbook recette GA4 — conversions, dimensions, DebugView

### DIFF
--- a/docs/ga4-recette.md
+++ b/docs/ga4-recette.md
@@ -1,0 +1,157 @@
+# Recette GA4 — AxeL Job (AXE-365)
+
+Ticket Linear : [AXE-365](https://linear.app/axel-project/issue/AXE-365).  
+Tracker code : `frontend/public/track.js` (AXE-361). **PostHog hors v1.**
+
+Le tracker pousse deux choses dans `dataLayer` :
+
+1. la commande gtag (`event`, nom, params) — file d’attente Consent Mode ;
+2. un objet `{ event: '<nom>', …params }` — **c’est celui-ci** que GTM écoute le plus simplement (déclencheur « Événement personnalisé »).
+
+Sans balises GTM qui **relayaient** ces events vers GA4, DebugView ne montrera que les `page_view` de la balise Google tag.
+
+## 0. Prérequis prod
+
+Sur [job.axelproject.fr](https://job.axelproject.fr) (après deploy de AXE-361), console :
+
+```js
+window.__AXEL_GTM_ID__   // doit être GTM-… réel, pas '' ni GTM-XXXXXXX
+document.querySelector('script[src*="/track.js"]')
+JSON.parse(localStorage.getItem('axel_job_consent_v1') || 'null')
+```
+
+- `__AXEL_GTM_ID__` vide → le conteneur ne charge pas. Variable Docker `VITE_AXEL_GTM_ID` au **build** (`docker compose build`), pas seulement au runtime.
+- ID de mesure déjà documenté : `G-7524WTRGSY` (`frontend/public/analytics-config.js`).
+
+Consentement : **Mesure d’audience** ON, sinon le tracker n’émet rien.
+
+## 1. GTM — ne pas cibler de classe CSS
+
+Interdit : déclencheur « Clic — tous les éléments » filtré sur `.button` / `.btn`.  
+Les clics sont déjà captés par `track.js` via `data-attr`.
+
+### 1.1 Variables couche de données (portée événement)
+
+| Nom GTM | Nom de la clé dataLayer |
+|---|---|
+| `dlv - cta_id` | `cta_id` |
+| `dlv - cta_zone` | `cta_zone` |
+| `dlv - cta_level` | `cta_level` |
+| `dlv - cta_text` | `cta_text` |
+| `dlv - link_url` | `link_url` |
+| `dlv - nav_id` | `nav_id` |
+| `dlv - nav_type` | `nav_type` |
+| `dlv - plan` | `plan` |
+| `dlv - price` | `price` |
+| `dlv - zone` | `zone` |
+| `dlv - section_id` | `section_id` |
+| `dlv - link_domain` | `link_domain` |
+| `dlv - method` | `method` |
+
+### 1.2 Déclencheurs (événement personnalisé)
+
+Un déclencheur par nom, **nom d’événement = nom GA4** :
+
+| Nom du déclencheur | Event name |
+|---|---|
+| `CE - cta_click` | `cta_click` |
+| `CE - nav_click` | `nav_click` |
+| `CE - select_plan` | `select_plan` |
+| `CE - section_view` | `section_view` |
+| `CE - outbound_click` | `outbound_click` |
+| `CE - contact_click` | `contact_click` |
+| `CE - sign_up_start` | `sign_up_start` *(après AXE-362)* |
+| `CE - sign_up` | `sign_up` *(après AXE-362)* |
+
+Consentement GTM : ces balises en **analytics_storage = Granted** (Consent Mode v2 déjà initialisé par `consent-gtm.js`).
+
+### 1.3 Balises GA4 Event
+
+Pour chaque déclencheur : balise **Google Analytics : événement GA4** (ou Event du Google tag).
+
+- Configuration / ID de mesure : `G-7524WTRGSY` (ou variable de la balise Google tag déjà posée).
+- Nom de l’événement : le même que le déclencheur (`cta_click`, etc.).
+- Paramètres (seulement ceux utiles) :
+
+| Event | Paramètres |
+|---|---|
+| `cta_click` | `cta_id`, `cta_zone`, `cta_level`, `cta_text`, `link_url` |
+| `nav_click` | `nav_id`, `nav_type`, `link_url` |
+| `select_plan` | `plan`, `price`, `zone` |
+| `section_view` | `section_id` |
+| `outbound_click` | `link_domain`, `link_url` |
+| `contact_click` | `method` |
+| `sign_up_start` | `method`, `source_cta_id` *(362)* |
+| `sign_up` | `method`, `plan_intent`, `source_cta_id` *(362)* |
+
+Publier le conteneur.
+
+## 2. GA4 — dimensions et conversions
+
+Admin → Propriété `G-7524WTRGSY` (ou la propriété liée au GTM prod).
+
+### Dimensions personnalisées (portée **événement**)
+
+Créer (noms d’affichage libres, **paramètre d’événement** = clé exacte) :
+
+`cta_id` · `cta_zone` · `cta_level` · `plan` · `section_id` · `nav_id` · `source_cta_id` · `plan_intent`
+
+Les rapports standards peuvent mettre 24–48 h ; **DebugView est immédiat**.
+
+### Conversions (événements clés)
+
+Marquer comme conversion / événement clé :
+
+- `select_plan` — **maintenant** (déjà émis par AXE-361)
+- `sign_up` — **déclarer maintenant**, volume 0 jusqu’à AXE-362
+
+Ne pas marquer `cta_click` en conversion (trop bruité).
+
+### Funnel de référence (Exploration)
+
+Tant que 362 n’est pas mergé, un funnel **partiel** suffit :
+
+`page_view` → `section_view` (filtrer `section_id` = `pricing`) → `cta_click` (filtrer `cta_level` = `primary`) → `select_plan` (`plan` = `pro`)
+
+Funnel cible après 362 :
+
+`page_view` → `section_view` (pricing) → `cta_click` (primary) → `sign_up_start` → `sign_up` → `select_plan` (pro)
+
+## 3. DebugView — parcours (toi, sans créer de compte)
+
+1. GA4 → Admin → DebugView (ou extension [GA Debugger](https://chrome.google.com/webstore) / `debug_mode`).
+2. Site prod, consentement audience ON.
+3. Parcours :
+
+| Action | Event DebugView | Checks |
+|---|---|---|
+| CTA hero | `cta_click` | `cta_id=home-hero-cta-signup`, zone/level **pas** `unknown` |
+| Passer Pro | `cta_click` **et** `select_plan` | `plan=pro`, `price=10`, `zone=pricing` |
+| Commencer gratuitement | `cta_click` + `select_plan` | `plan=free`, `price=0` |
+| Lien footer FAQ | `nav_click` | `nav_id=footer-link-faq` |
+| Scroll tarifs ≥ 50 % | `section_view` | `section_id=pricing`, **une fois** par onglet |
+| `/app` connecté | — | **aucun** de ces events marketing |
+
+Hors DebugView, console :
+
+```js
+window.dataLayer.filter(e => e && typeof e === 'object' && e.event &&
+  ['cta_click','nav_click','select_plan','section_view','outbound_click','contact_click'].includes(e.event))
+```
+
+## 4. Découpage vs AXE-362
+
+| Critère AXE-365 | Statut sans 362 |
+|---|---|
+| GTM prod ID réel | À vérifier (toi, console + Docker) |
+| DebugView `cta_click` / `nav_click` / `select_plan` / `section_view` | Recettable **maintenant** |
+| DebugView `sign_up_start` / `sign_up` | **Après AXE-362** |
+| Dimensions perso | Créer maintenant |
+| Conversion `select_plan` | Maintenant |
+| Conversion `sign_up` | Déclarer maintenant, tester après 362 |
+| Funnel complet + test Pro → **nouveau** compte | Après 362 (recette signup = quelqu’un d’autre si besoin) |
+
+## 5. Rollback
+
+GTM : restaurer la version précédente du conteneur.  
+Aucun rollback code nécessaire pour cette recette ops (le tracker reste AXE-361).

--- a/docs/ga4-recette.md
+++ b/docs/ga4-recette.md
@@ -47,6 +47,8 @@ Les clics sont déjà captés par `track.js` via `data-attr`.
 | `dlv - section_id` | `section_id` |
 | `dlv - link_domain` | `link_domain` |
 | `dlv - method` | `method` |
+| `dlv - source_cta_id` | `source_cta_id` *(après AXE-362)* |
+| `dlv - plan_intent` | `plan_intent` *(après AXE-362)* |
 
 ### 1.2 Déclencheurs (événement personnalisé)
 
@@ -63,7 +65,7 @@ Un déclencheur par nom, **nom d’événement = nom GA4** :
 | `CE - sign_up_start` | `sign_up_start` *(après AXE-362)* |
 | `CE - sign_up` | `sign_up` *(après AXE-362)* |
 
-Consentement GTM : ces balises en **analytics_storage = Granted** (Consent Mode v2 déjà initialisé par `consent-gtm.js`).
+Consentement : `consent-gtm.js` pose Consent Mode v2 avec `analytics_storage` **denied** par défaut, puis `update` selon le bandeau (`granted` / `denied`). Les balises Google (GA4 Event) ont déjà un contrôle intégré — **ne pas** ajouter un « additional consent check » GTM sur `analytics_storage`, ça peut entrer en conflit. Le tracker n’émet rien tant que la mesure d’audience n’est pas ON. Recetter les deux états (refusé : aucun event marketing ; accordé : events ci-dessous).
 
 ### 1.3 Balises GA4 Event
 
@@ -129,7 +131,10 @@ Funnel cible après 362 :
 | Passer Pro | `cta_click` **et** `select_plan` | `plan=pro`, `price=10`, `zone=pricing` |
 | Commencer gratuitement | `cta_click` + `select_plan` | `plan=free`, `price=0` |
 | Lien footer FAQ | `nav_click` | `nav_id=footer-link-faq` |
+| Lien Axel Project (footer) | `nav_click` **et** `outbound_click` | host `axelproject.fr` ≠ `job.axelproject.fr` |
+| Support (`mailto:`, footer React) | `nav_click` **et** `contact_click` | `method=email` ; `link_url` = `mailto:` (pas l’adresse) |
 | Scroll tarifs ≥ 50 % | `section_view` | `section_id=pricing`, **une fois** par onglet |
+| Audience **refusée** | — | **aucun** event marketing (tracker silencieux) |
 | `/app` connecté | — | **aucun** de ces events marketing |
 
 Hors DebugView, console :
@@ -144,7 +149,7 @@ window.dataLayer.filter(e => e && typeof e === 'object' && e.event &&
 | Critère AXE-365 | Statut sans 362 |
 |---|---|
 | GTM prod ID réel | À vérifier (toi, console + Docker) |
-| DebugView `cta_click` / `nav_click` / `select_plan` / `section_view` | Recettable **maintenant** |
+| DebugView `cta_click` / `nav_click` / `select_plan` / `section_view` / `outbound_click` / `contact_click` | Recettable **maintenant** |
 | DebugView `sign_up_start` / `sign_up` | **Après AXE-362** |
 | Dimensions perso | Créer maintenant |
 | Conversion `select_plan` | Maintenant |

--- a/docs/taggage-analytics.md
+++ b/docs/taggage-analytics.md
@@ -628,7 +628,7 @@ V2 candidatures (ne pas poser maintenant) : ouverture carte, archive, drag colon
 
 Runbook ops (GTM + GA4 DebugView) : **[`docs/ga4-recette.md`](ga4-recette.md)**.
 
-`sign_up*` / `plan_intent` : après [AXE-362](https://linear.app/axel-project/issue/AXE-362). Recettable dès maintenant : `cta_click`, `nav_click`, `select_plan`, `section_view`.
+`sign_up*` / `plan_intent` : après [AXE-362](https://linear.app/axel-project/issue/AXE-362). Recettable dès maintenant : `cta_click`, `nav_click`, `select_plan`, `section_view`, `outbound_click`, `contact_click`.
 
 - [ ] 55 identifiants posés, uniques (grep `data-attr=` + table)
 - [ ] Aucun `data-attr` dans une feuille de style

--- a/docs/taggage-analytics.md
+++ b/docs/taggage-analytics.md
@@ -3,10 +3,11 @@
 > **Inventaire vague 1 figé 2026-08-25** ([AXE-358](https://linear.app/axel-project/issue/AXE-358/spike-inventaire-fige-des-identifiants-data-attr)). 55 IDs, aucun doublon. On n’en renomme aucun ; on ajoute ou on déprécie.  
 > Tickets 2 ([AXE-359](https://linear.app/axel-project/issue/AXE-359)) et 3 ([AXE-360](https://linear.app/axel-project/issue/AXE-360)) : `data-attr` posés (mergés).  
 > **PostHog v1 : no-go** ([AXE-363](https://linear.app/axel-project/issue/AXE-363), 2026-08-25) — ticket 7 ([AXE-364](https://linear.app/axel-project/issue/AXE-364)) annulé. Recette = GA4 seul.  
+> Tracker CMP : [AXE-361](https://linear.app/axel-project/issue/AXE-361) mergé. Runbook GA4 : [`docs/ga4-recette.md`](ga4-recette.md) ([AXE-365](https://linear.app/axel-project/issue/AXE-365)).  
 > **Usage Linear (historique) :** coller le bloc « Projet » puis chaque ticket (titre + labels + description).  
 > **Workflow :** [`docs/linear-github-workflow.md`](linear-github-workflow.md) · 1 issue Linear = 1 branche = 1 PR.
 
-État du code (août 2026) : `data-attr` marketing posés (landing + globaux/login/contenu/404). Pas encore de tracker CTA. Infra déjà là : CMP + GTM/GA4 (si `VITE_AXEL_GTM_ID` en prod) + analytics **produit** interne (`/api/events/track`) limitée à l’app connectée. **Pas de SDK PostHog.**
+État du code (août 2026) : `data-attr` marketing posés (landing + globaux/login/contenu/404). Tracker unique `frontend/public/track.js` derrière la CMP (AXE-361). Infra : CMP + GTM/GA4 (si `VITE_AXEL_GTM_ID` en prod) + analytics **produit** interne (`/api/events/track`) limitée à l’app connectée. **Pas de SDK PostHog.** Attribution signup = [AXE-362](https://linear.app/axel-project/issue/AXE-362) (pas encore).
 
 ---
 
@@ -31,11 +32,10 @@ Ordre de livraison (dépendances) :
 6 spike PostHog  →  no-go v1  (7 AXE-364 annulé)
 ```
 
-Ticket 1 **figé 2026-08-25**. Tickets 2 et 3 **mergés**.  
-Ticket 4 **après** 2 (sinon le listener n’a rien à lire) — prochain code.  
-Ticket 5 peut chevaucher 4.  
+Ticket 1 **figé 2026-08-25**. Tickets 2, 3 et 4 ([AXE-361](https://linear.app/axel-project/issue/AXE-361)) **mergés**.  
+Ticket 5 ([AXE-362](https://linear.app/axel-project/issue/AXE-362)) attribution signup — prochain code.  
 Ticket 6 **no-go v1 (2026-08-25)**. Ticket 7 annulé.  
-Ticket 8 est ops (GA4 UI), pas forcément une PR code. Recette = GA4 seul.
+Ticket 8 ([AXE-365](https://linear.app/axel-project/issue/AXE-365)) recette GA4 : runbook [`docs/ga4-recette.md`](ga4-recette.md). DebugView = ops (Louis).
 
 ---
 
@@ -626,7 +626,9 @@ V2 candidatures (ne pas poser maintenant) : ouverture carte, archive, drag colon
 
 ## D. Recette (après tickets 4–5–8)
 
-**Intégration**
+Runbook ops (GTM + GA4 DebugView) : **[`docs/ga4-recette.md`](ga4-recette.md)**.
+
+`sign_up*` / `plan_intent` : après [AXE-362](https://linear.app/axel-project/issue/AXE-362). Recettable dès maintenant : `cta_click`, `nav_click`, `select_plan`, `section_view`.
 
 - [ ] 55 identifiants posés, uniques (grep `data-attr=` + table)
 - [ ] Aucun `data-attr` dans une feuille de style


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes AXE-365

## What changed

- Ajout de `docs/ga4-recette.md` : runbook ops pour relayer `track.js` (AXE-361) vers GA4 via GTM (variables dataLayer, déclencheurs Custom Event, balises, dimensions perso, conversions, parcours DebugView).
- Mise à jour de `docs/taggage-analytics.md` : tracker 361 mergé, lien vers le runbook, découpage vs AXE-362.

Pas de changement code. L’agent n’a pas accès à la console GTM/GA4.

## Why

Le tracker pousse déjà `cta_click` / `nav_click` / `select_plan` / `section_view` (et outbound/contact) dans `dataLayer`. Sans balises GTM qui relaient ces events, DebugView ne montre que les `page_view` du Google tag.

## Découpage vs AXE-362

Recettable **maintenant** (après deploy 361 + consentement audience) : `cta_click`, `nav_click`, `select_plan`, `section_view`, `outbound_click`, `contact_click`.

**Après AXE-362** : `sign_up_start`, `sign_up`, `plan_intent`, `source_cta_id`, funnel complet, test Pro → nouveau compte.

## Validation

- [x] Docs only
- [x] Pre-push local (`scripts/pre-push.sh --skip-extras --skip-gitleaks`) : `OK - pre-push terminé sans erreur.`
- [x] CodeRabbit : consentement GTM, DLV `source_cta_id`/`plan_intent`, recette outbound/contact
- [ ] Recette DebugView Louis : events 361 (checklist du runbook § 3)
- [ ] GTM prod : `window.__AXEL_GTM_ID__` réel (build Docker)

## Risk and rollback

- Risk: aucun (docs). Mauvaise config GTM = rollback de version de conteneur.
- Rollback: revert du commit docs ; GTM = restaurer la version précédente du conteneur.

## Linear

https://linear.app/axel-project/issue/AXE-365/chore-recette-ga4-conversions-dimensions-debugview

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Ajout d’un guide opérationnel pour configurer, vérifier et restaurer le suivi GA4 en production.
  * Documentation des événements, du funnel, des conversions et des contrôles via DebugView.
  * Mise à jour du statut du chantier de taggage : le suivi CMP est actif et les événements principaux sont prêts à être testés.
  * Clarification du calendrier de disponibilité du suivi des inscriptions et des intentions de formule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->