### PR TITLE
feat(AXE-362): attribution source_cta_id et plan_intent jusqu’au compte créé

### DIFF
--- a/docs/ga4-recette.md
+++ b/docs/ga4-recette.md
@@ -141,20 +141,24 @@ Hors DebugView, console :
 
 ```js
 window.dataLayer.filter(e => e && typeof e === 'object' && e.event &&
-  ['cta_click','nav_click','select_plan','section_view','outbound_click','contact_click'].includes(e.event))
+  ['cta_click','nav_click','select_plan','section_view','outbound_click','contact_click','sign_up_start','sign_up'].includes(e.event))
 ```
 
 ## 4. Découpage vs AXE-362
 
-| Critère AXE-365 | Statut sans 362 |
+Code attribution : `frontend/public/signupAttribution.js` (AXE-362). Recette `sign_up*` après **deploy** de 362.
+
+| Critère | Statut |
 |---|---|
 | GTM prod ID réel | À vérifier (toi, console + Docker) |
-| DebugView `cta_click` / `nav_click` / `select_plan` / `section_view` / `outbound_click` / `contact_click` | Recettable **maintenant** |
-| DebugView `sign_up_start` / `sign_up` | **Après AXE-362** |
+| DebugView `cta_click` / `nav_click` / `select_plan` / `section_view` / `outbound_click` / `contact_click` | Recettable (361) |
+| DebugView `sign_up_start` (arrivée `/login`, `method=form`) | Après deploy 362 |
+| DebugView `sign_up` (`method`, `plan_intent`, `source_cta_id`) | Après deploy 362 + **nouveau** compte |
+| « Vous aviez déjà un compte » | **pas** de `sign_up` |
 | Dimensions perso | Créer maintenant |
 | Conversion `select_plan` | Maintenant |
-| Conversion `sign_up` | Déclarer maintenant, tester après 362 |
-| Funnel complet + test Pro → **nouveau** compte | Après 362 (recette signup = quelqu’un d’autre si besoin) |
+| Conversion `sign_up` | Tester après deploy 362 |
+| Funnel complet + test Pro → **nouveau** compte | Recette signup = quelqu’un d’autre si besoin |
 
 ## 5. Rollback
 

--- a/docs/taggage-analytics.md
+++ b/docs/taggage-analytics.md
@@ -3,11 +3,11 @@
 > **Inventaire vague 1 figé 2026-08-25** ([AXE-358](https://linear.app/axel-project/issue/AXE-358/spike-inventaire-fige-des-identifiants-data-attr)). 55 IDs, aucun doublon. On n’en renomme aucun ; on ajoute ou on déprécie.  
 > Tickets 2 ([AXE-359](https://linear.app/axel-project/issue/AXE-359)) et 3 ([AXE-360](https://linear.app/axel-project/issue/AXE-360)) : `data-attr` posés (mergés).  
 > **PostHog v1 : no-go** ([AXE-363](https://linear.app/axel-project/issue/AXE-363), 2026-08-25) — ticket 7 ([AXE-364](https://linear.app/axel-project/issue/AXE-364)) annulé. Recette = GA4 seul.  
-> Tracker CMP : [AXE-361](https://linear.app/axel-project/issue/AXE-361) mergé. Runbook GA4 : [`docs/ga4-recette.md`](ga4-recette.md) ([AXE-365](https://linear.app/axel-project/issue/AXE-365)).  
+> Tracker CMP : [AXE-361](https://linear.app/axel-project/issue/AXE-361) mergé. Runbook GA4 : [`docs/ga4-recette.md`](ga4-recette.md) ([AXE-365](https://linear.app/axel-project/issue/AXE-365)). Attribution signup : [AXE-362](https://linear.app/axel-project/issue/AXE-362).  
 > **Usage Linear (historique) :** coller le bloc « Projet » puis chaque ticket (titre + labels + description).  
 > **Workflow :** [`docs/linear-github-workflow.md`](linear-github-workflow.md) · 1 issue Linear = 1 branche = 1 PR.
 
-État du code (août 2026) : `data-attr` marketing posés (landing + globaux/login/contenu/404). Tracker unique `frontend/public/track.js` derrière la CMP (AXE-361). Infra : CMP + GTM/GA4 (si `VITE_AXEL_GTM_ID` en prod) + analytics **produit** interne (`/api/events/track`) limitée à l’app connectée. **Pas de SDK PostHog.** Attribution signup = [AXE-362](https://linear.app/axel-project/issue/AXE-362) (pas encore).
+État du code (août 2026) : `data-attr` marketing posés (landing + globaux/login/contenu/404). Tracker unique `frontend/public/track.js` derrière la CMP (AXE-361). Attribution signup : `frontend/public/signupAttribution.js` (`source_cta_id` / `plan_intent` / `sign_up*`, AXE-362). Infra : CMP + GTM/GA4 (si `VITE_AXEL_GTM_ID` en prod) + analytics **produit** interne (`/api/events/track`) limitée à l’app connectée. **Pas de SDK PostHog.**
 
 ---
 
@@ -33,9 +33,9 @@ Ordre de livraison (dépendances) :
 ```
 
 Ticket 1 **figé 2026-08-25**. Tickets 2, 3 et 4 ([AXE-361](https://linear.app/axel-project/issue/AXE-361)) **mergés**.  
-Ticket 5 ([AXE-362](https://linear.app/axel-project/issue/AXE-362)) attribution signup — prochain code.  
+Ticket 5 ([AXE-362](https://linear.app/axel-project/issue/AXE-362)) attribution signup.  
 Ticket 6 **no-go v1 (2026-08-25)**. Ticket 7 annulé.  
-Ticket 8 ([AXE-365](https://linear.app/axel-project/issue/AXE-365)) recette GA4 : runbook [`docs/ga4-recette.md`](ga4-recette.md). DebugView = ops (Louis).
+Ticket 8 ([AXE-365](https://linear.app/axel-project/issue/AXE-365)) recette GA4 : runbook [`docs/ga4-recette.md`](ga4-recette.md) mergé. DebugView `sign_up*` après deploy 362.
 
 ---
 
@@ -628,7 +628,7 @@ V2 candidatures (ne pas poser maintenant) : ouverture carte, archive, drag colon
 
 Runbook ops (GTM + GA4 DebugView) : **[`docs/ga4-recette.md`](ga4-recette.md)**.
 
-`sign_up*` / `plan_intent` : après [AXE-362](https://linear.app/axel-project/issue/AXE-362). Recettable dès maintenant : `cta_click`, `nav_click`, `select_plan`, `section_view`, `outbound_click`, `contact_click`.
+`sign_up*` / `plan_intent` / `source_cta_id` : [AXE-362](https://linear.app/axel-project/issue/AXE-362) (`signupAttribution.js`). Recette DebugView : events 361 + `sign_up_start` (arrivée `/login`) + `sign_up` (compte **nouveau** seulement).
 
 - [ ] 55 identifiants posés, uniques (grep `data-attr=` + table)
 - [ ] Aucun `data-attr` dans une feuille de style

--- a/frontend/public/signupAttribution.js
+++ b/frontend/public/signupAttribution.js
@@ -115,6 +115,13 @@ export function persistFromCtaClick({ dataAttr, dataTrack, linkUrl }) {
   return true;
 }
 
+/** Boutons React sans href : même persist que le tracker (landing SPA). */
+export function persistLoginCta(dataAttr) {
+  if (!dataAttr) return false;
+  const linkUrl = planIntentFromCta(dataAttr, '') === 'pro' ? '/login?plan=pro' : '/login';
+  return persistFromCtaClick({ dataAttr, dataTrack: 'cta', linkUrl });
+}
+
 /** URL ?plan=pro complète un plan_intent manquant (lien partagé / OAuth). */
 export function hydratePlanIntentFromSearch(search) {
   const params = new URLSearchParams(search || '');

--- a/frontend/public/signupAttribution.js
+++ b/frontend/public/signupAttribution.js
@@ -1,0 +1,263 @@
+/**
+ * AXE-362 — attribution signup (source_cta_id / plan_intent) + events GA4.
+ * sessionStorage survit à l’OAuth ; redirectTo doit aussi garder ?plan=pro + UTM.
+ * Aucun email dans les payloads. Rien avant consentement analytics.
+ */
+
+export const CONSENT_STORAGE_KEY = 'axel_job_consent_v1';
+export const SOURCE_CTA_KEY = 'source_cta_id';
+export const PLAN_INTENT_KEY = 'plan_intent';
+export const SIGN_UP_START_SENT_KEY = 'cv_bot_signup_start_sent';
+export const SIGN_UP_SENT_KEY = 'cv_bot_signup_done';
+
+const EMAIL_RE = /[^\s@]+@[^\s@]+\.[^\s@]+/g;
+
+const UTM_QUERY_KEYS = [
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_content',
+  'utm_term',
+  'gclid',
+  'fbclid',
+  'partner_code',
+  'bde_code',
+  'bde',
+  'partner',
+  'ref',
+];
+
+/** CTA déjà sur /login : ne pas écraser l’attribution landing. */
+const LOGIN_PAGE_ATTR_RE = /^(login-cta-|login-link-|login-input-)/;
+
+export const PLAN_INTENT_BY_CTA = {
+  'home-pricing-cta-pro': 'pro',
+  'home-pricing-cta-free': 'free',
+};
+
+export function hasAnalyticsConsent(raw) {
+  if (!raw) return false;
+  try {
+    const o = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    return !!(o && o.v === 1 && o.analytics);
+  } catch {
+    return false;
+  }
+}
+
+export function pathFromLinkUrl(linkUrl) {
+  const raw = (linkUrl || '').trim();
+  if (!raw || /^mailto:/i.test(raw) || /^\s*javascript:/i.test(raw)) return '';
+  try {
+    if (/^https?:\/\//i.test(raw)) {
+      return new URL(raw).pathname || '';
+    }
+    const u = new URL(raw, 'https://job.axelproject.fr');
+    return u.pathname || '';
+  } catch {
+    return raw.split('?')[0] || '';
+  }
+}
+
+export function isLoginLinkUrl(linkUrl) {
+  return pathFromLinkUrl(linkUrl) === '/login';
+}
+
+export function planIntentFromCta(dataAttr, linkUrl) {
+  if (dataAttr && PLAN_INTENT_BY_CTA[dataAttr]) return PLAN_INTENT_BY_CTA[dataAttr];
+  const raw = (linkUrl || '').trim();
+  try {
+    const u = new URL(raw || '/login', 'https://job.axelproject.fr');
+    if (u.searchParams.get('plan') === 'pro') return 'pro';
+  } catch {
+    if (/[?&]plan=pro(?:&|$)/.test(raw)) return 'pro';
+  }
+  return 'free';
+}
+
+export function shouldPersistSourceCta(dataAttr, dataTrack, linkUrl) {
+  if (dataTrack !== 'cta' || !dataAttr) return false;
+  if (LOGIN_PAGE_ATTR_RE.test(dataAttr)) return false;
+  return isLoginLinkUrl(linkUrl);
+}
+
+function storageGet(key) {
+  try {
+    return sessionStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function storageSet(key, value) {
+  try {
+    if (value == null || value === '') sessionStorage.removeItem(key);
+    else sessionStorage.setItem(key, value);
+  } catch {
+    /* private mode */
+  }
+}
+
+export function readSourceCtaId() {
+  const v = (storageGet(SOURCE_CTA_KEY) || '').trim();
+  return v || '';
+}
+
+export function readPlanIntent() {
+  const v = (storageGet(PLAN_INTENT_KEY) || '').trim();
+  return v === 'pro' ? 'pro' : v === 'free' ? 'free' : '';
+}
+
+export function persistFromCtaClick({ dataAttr, dataTrack, linkUrl }) {
+  if (!shouldPersistSourceCta(dataAttr, dataTrack, linkUrl)) return false;
+  storageSet(SOURCE_CTA_KEY, dataAttr);
+  storageSet(PLAN_INTENT_KEY, planIntentFromCta(dataAttr, linkUrl));
+  return true;
+}
+
+/** URL ?plan=pro complète un plan_intent manquant (lien partagé / OAuth). */
+export function hydratePlanIntentFromSearch(search) {
+  const params = new URLSearchParams(search || '');
+  if (params.get('plan') !== 'pro') return readPlanIntent();
+  if (readPlanIntent() !== 'pro') storageSet(PLAN_INTENT_KEY, 'pro');
+  return 'pro';
+}
+
+export function consumePlanIntentIfPro() {
+  if (readPlanIntent() !== 'pro') return false;
+  storageSet(PLAN_INTENT_KEY, '');
+  return true;
+}
+
+export function wantsProCheckout(search) {
+  const params = new URLSearchParams(search || '');
+  if (params.get('plan') === 'pro') return true;
+  return readPlanIntent() === 'pro';
+}
+
+/**
+ * redirectTo OAuth / reset : origin + /login + plan + UTM déjà présents.
+ * @param {string} origin
+ * @param {string} [search]
+ * @param {string} [planIntent]
+ */
+export function buildLoginRedirectTo(origin, search, planIntent) {
+  const base = (origin || '').replace(/\/$/, '');
+  const fromUrl = new URLSearchParams(search || '');
+  const params = new URLSearchParams();
+  const plan = fromUrl.get('plan') || planIntent || '';
+  if (plan === 'pro') params.set('plan', 'pro');
+  for (const k of UTM_QUERY_KEYS) {
+    const v = (fromUrl.get(k) || '').trim();
+    if (v) params.set(k, v);
+  }
+  const nextPath = fromUrl.get('next');
+  if (nextPath && nextPath.startsWith('/app/') && !nextPath.includes('//')) {
+    params.set('next', nextPath);
+  }
+  const qs = params.toString();
+  return `${base}/login${qs ? `?${qs}` : ''}`;
+}
+
+export function currentLoginRedirectTo() {
+  if (typeof window === 'undefined') return undefined;
+  hydratePlanIntentFromSearch(window.location.search);
+  return buildLoginRedirectTo(
+    window.location.origin,
+    window.location.search,
+    readPlanIntent(),
+  );
+}
+
+export function compactParams(obj) {
+  const out = {};
+  if (!obj || typeof obj !== 'object') return out;
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === undefined || v === null || v === '') continue;
+    if (typeof v === 'string') {
+      const cleaned = v.replace(EMAIL_RE, '').replace(/\s+/g, ' ').trim();
+      if (!cleaned) continue;
+      out[k] = cleaned;
+      continue;
+    }
+    out[k] = v;
+  }
+  return out;
+}
+
+export function signUpStartParams(method) {
+  return compactParams({
+    method: method || 'form',
+    source_cta_id: readSourceCtaId(),
+  });
+}
+
+export function signUpParams(method) {
+  const plan = readPlanIntent() || 'free';
+  return compactParams({
+    method: method || 'email',
+    plan_intent: plan === 'pro' ? 'pro' : 'free',
+    source_cta_id: readSourceCtaId(),
+  });
+}
+
+export function emitMarketingEvent(name, params) {
+  if (typeof window === 'undefined') return false;
+  let raw;
+  try {
+    raw = localStorage.getItem(CONSENT_STORAGE_KEY);
+  } catch {
+    raw = null;
+  }
+  if (!hasAnalyticsConsent(raw)) return false;
+  const payload = compactParams({ event: name, ...(params || {}) });
+  const gtagParams = compactParams(params || {});
+  if (typeof window.gtag === 'function') {
+    window.gtag('event', name, gtagParams);
+  }
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push(payload);
+  return true;
+}
+
+export function emitSignUpStartOnce(method) {
+  if (storageGet(SIGN_UP_START_SENT_KEY) === '1') return false;
+  const ok = emitMarketingEvent('sign_up_start', signUpStartParams(method));
+  if (ok) storageSet(SIGN_UP_START_SENT_KEY, '1');
+  return ok;
+}
+
+export function emitSignUpOnce(method) {
+  if (storageGet(SIGN_UP_SENT_KEY) === '1') return false;
+  const ok = emitMarketingEvent('sign_up', signUpParams(method));
+  if (ok) storageSet(SIGN_UP_SENT_KEY, '1');
+  return ok;
+}
+
+export function wasSignUpEmitted() {
+  return storageGet(SIGN_UP_SENT_KEY) === '1';
+}
+
+const NEW_USER_WINDOW_MS = 5 * 60_000;
+
+export function isLikelyNewAuthUser(user, nowMs = Date.now()) {
+  if (!user || !user.created_at) return false;
+  const created = Date.parse(user.created_at);
+  if (Number.isNaN(created)) return false;
+  const lastRaw = user.last_sign_in_at ? Date.parse(user.last_sign_in_at) : nowMs;
+  const last = Number.isNaN(lastRaw) ? nowMs : lastRaw;
+  return Math.abs(last - created) < NEW_USER_WINDOW_MS;
+}
+
+export function authMethodFromUser(user) {
+  const p = String(user?.app_metadata?.provider || user?.identities?.[0]?.provider || '').toLowerCase();
+  if (p === 'google') return 'google';
+  if (p === 'linkedin' || p === 'linkedin_oidc') return 'linkedin';
+  if (p === 'email') return 'email';
+  return p || 'email';
+}
+
+export function maybeEmitSignUpForSession(user) {
+  if (!isLikelyNewAuthUser(user)) return false;
+  return emitSignUpOnce(authMethodFromUser(user));
+}

--- a/frontend/public/track.js
+++ b/frontend/public/track.js
@@ -4,7 +4,14 @@
  * consentement analytics (`axel_job_consent_v1` / `axel_consent_update`).
  * Hors `/app/*`. Ne cible jamais une classe CSS.
  */
-export const CONSENT_STORAGE_KEY = 'axel_job_consent_v1';
+import {
+  CONSENT_STORAGE_KEY,
+  emitMarketingEvent,
+  hasAnalyticsConsent,
+  persistFromCtaClick,
+} from './signupAttribution.js';
+
+export { CONSENT_STORAGE_KEY, hasAnalyticsConsent };
 export const SECTION_VIEWED_KEY = 'axel_section_viewed_v1';
 
 /** Destinations des CTA React sans href (catalogue AXE-358). */
@@ -44,16 +51,6 @@ export function sanitizeCtaText(text) {
   s = s.replace(/\s+/g, ' ').trim();
   if (s.length > 80) s = s.slice(0, 80);
   return s;
-}
-
-export function hasAnalyticsConsent(raw) {
-  if (!raw) return false;
-  try {
-    const o = typeof raw === 'string' ? JSON.parse(raw) : raw;
-    return !!(o && o.v === 1 && o.analytics);
-  } catch {
-    return false;
-  }
 }
 
 export function resolveLinkUrl(dataAttr, href) {
@@ -152,13 +149,7 @@ function readStoredConsent() {
 }
 
 function emit(name, params) {
-  if (!hasAnalyticsConsent(readStoredConsent())) return;
-  const payload = { event: name, ...params };
-  if (typeof window.gtag === 'function') {
-    window.gtag('event', name, params);
-  }
-  window.dataLayer = window.dataLayer || [];
-  window.dataLayer.push(payload);
+  emitMarketingEvent(name, params);
 }
 
 function attrsFromEl(el) {
@@ -186,6 +177,11 @@ function onDocumentClick(e) {
   const input = attrsFromEl(el);
   if (!input) return;
   const events = eventsFromClick(input);
+  persistFromCtaClick({
+    dataAttr: input.dataAttr,
+    dataTrack: input.dataTrack,
+    linkUrl: resolveLinkUrl(input.dataAttr, input.href),
+  });
   for (const ev of events) emit(ev.name, ev.params);
 }
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,6 +16,7 @@ import {
   trackEvent,
 } from './api';
 import { ensureAnalyticsFirstTouch, getStoredAttribution } from './analyticsSession';
+import { consumePlanIntentIfPro, maybeEmitSignUpForSession, wantsProCheckout } from '../public/signupAttribution.js';
 import { resetTemplateOptionsToDefaults } from './lib/templateOptionsSchema.js';
 import { useViewAnalytics } from './useViewAnalytics';
 import { supabase } from './lib/supabase';
@@ -1111,6 +1112,7 @@ export default function App() {
       setAuthToken(s?.access_token ?? null);
       if (event === 'PASSWORD_RECOVERY') setRecoveryMode(true);
       if (s) setMfaChallengeChecked(false);
+      if (event === 'SIGNED_IN' && s?.user) maybeEmitSignUpForSession(s.user);
     });
     return () => subscription?.unsubscribe();
   }, []);
@@ -1280,7 +1282,8 @@ export default function App() {
     if (session) {
       const params = new URLSearchParams(location.search);
       if (pathname === '/' || pathname === '/login') {
-        if (params.get('plan') === 'pro') {
+        if (wantsProCheckout(location.search)) {
+          consumePlanIntentIfPro();
           navigate(APP_DEFAULT_ROUTE, { replace: true });
           setTimeout(() => handleUpgradeClick(), 500);
         } else {

--- a/frontend/src/components/ArticlesPages.jsx
+++ b/frontend/src/components/ArticlesPages.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { ARTICLE_SOURCE_URLS as U } from '../content/articleSources.js';
 import { analyticsAttrs } from '../lib/analyticsAttrs.js';
+import { persistLoginCta } from '../../public/signupAttribution.js';
 import ContentScrollToTop from './ContentScrollToTop';
 import './ContentPages.css';
 
@@ -106,7 +107,7 @@ function ArticleLayout({ title, lead, sections, onBack, prose, signupId }) {
         <div className="content-cta-inner">
           <h2>Un CV adapté à chaque offre, en un clic</h2>
           <p>Essaie AxeL Job gratuitement. 3 adaptations offertes, sans carte bancaire.</p>
-          <Link to="/login" className="button button-primary" {...analyticsAttrs(signupId, 'content', 'primary', 'cta')}>Essayer gratuitement</Link>
+          <Link to="/login" className="button button-primary" onClick={() => persistLoginCta(signupId)} {...analyticsAttrs(signupId, 'content', 'primary', 'cta')}>Essayer gratuitement</Link>
         </div>
       </section>
 

--- a/frontend/src/components/AtsPage.jsx
+++ b/frontend/src/components/AtsPage.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { ARTICLE_SOURCE_URLS as U } from '../content/articleSources.js';
 import { analyticsAttrs } from '../lib/analyticsAttrs.js';
+import { persistLoginCta } from '../../public/signupAttribution.js';
 import ContentScrollToTop from './ContentScrollToTop';
 import './ContentPages.css';
 
@@ -185,7 +186,7 @@ export default function AtsPage({ onBack }) {
         <div className="content-cta-inner">
           <h2>Passe les filtres ATS à chaque candidature</h2>
           <p>Adapte ton CV en un clic à chaque offre. Essai gratuit, sans carte bancaire.</p>
-          <Link to="/login" className="button button-primary" {...analyticsAttrs('ats-cta-signup', 'content', 'primary', 'cta')}>Essayer AxeL Job gratuitement</Link>
+          <Link to="/login" className="button button-primary" onClick={() => persistLoginCta('ats-cta-signup')} {...analyticsAttrs('ats-cta-signup', 'content', 'primary', 'cta')}>Essayer AxeL Job gratuitement</Link>
         </div>
       </section>
 

--- a/frontend/src/components/AuthForm.jsx
+++ b/frontend/src/components/AuthForm.jsx
@@ -1,6 +1,12 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { supabase } from '../lib/supabase';
 import { analyticsAttrs } from '../lib/analyticsAttrs.js';
+import {
+  currentLoginRedirectTo,
+  emitSignUpOnce,
+  emitSignUpStartOnce,
+  hydratePlanIntentFromSearch,
+} from '../../public/signupAttribution.js';
 import '../styles/AuthForm.css';
 
 function GoogleIcon() {
@@ -34,6 +40,17 @@ export default function AuthForm({ onSuccess, linkedInOnly = false }) {
   const [message, setMessage] = useState('');
   const [showAlreadyHadAccountPopup, setShowAlreadyHadAccountPopup] = useState(false);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    hydratePlanIntentFromSearch(window.location.search);
+    emitSignUpStartOnce('form');
+    const onConsent = (ev) => {
+      if (ev && ev.detail && ev.detail.analytics) emitSignUpStartOnce('form');
+    };
+    window.addEventListener('axel_consent_update', onConsent);
+    return () => window.removeEventListener('axel_consent_update', onConsent);
+  }, []);
+
   const handleGoogle = async () => {
     setError('');
     setGoogleLoading(true);
@@ -41,7 +58,7 @@ export default function AuthForm({ onSuccess, linkedInOnly = false }) {
       const { error: err } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: {
-          redirectTo: typeof window !== 'undefined' ? window.location.origin + '/login' : undefined,
+          redirectTo: currentLoginRedirectTo(),
         },
       });
       if (err) throw err;
@@ -58,7 +75,7 @@ export default function AuthForm({ onSuccess, linkedInOnly = false }) {
       const { error: err } = await supabase.auth.signInWithOAuth({
         provider: 'linkedin_oidc',
         options: {
-          redirectTo: typeof window !== 'undefined' ? window.location.origin + '/login' : undefined,
+          redirectTo: currentLoginRedirectTo(),
         },
       });
       if (err) throw err;
@@ -79,7 +96,7 @@ export default function AuthForm({ onSuccess, linkedInOnly = false }) {
     setLoading(true);
     try {
       const { error: err } = await supabase.auth.resetPasswordForEmail(email.trim(), {
-        redirectTo: typeof window !== 'undefined' ? window.location.origin + '/login' : undefined,
+        redirectTo: currentLoginRedirectTo(),
       });
       if (err) throw err;
       setMessage('Email de réinitialisation envoyé. Vérifie ta boîte mail.');
@@ -123,6 +140,7 @@ export default function AuthForm({ onSuccess, linkedInOnly = false }) {
           return;
         }
         if (err) throw err;
+        emitSignUpOnce('email');
         setMessage('Compte créé. Un email de confirmation a été envoyé - clique sur le lien pour activer ton compte.');
       } else {
         const { error: err } = await supabase.auth.signInWithPassword({ email: email.trim(), password });

--- a/frontend/src/components/ErrorPages.jsx
+++ b/frontend/src/components/ErrorPages.jsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Button from './ui/Button.jsx';
 import { analyticsAttrs } from '../lib/analyticsAttrs.js';
+import { persistLoginCta } from '../../public/signupAttribution.js';
 
 function setNoindexFollow() {
   if (typeof document === 'undefined') return;
@@ -36,7 +37,7 @@ export function NotFoundPage() {
           <Button variant="primary" onClick={() => navigate('/')} {...analyticsAttrs('error-cta-home', 'error', 'primary', 'cta')}>
             Accueil
           </Button>
-          <Button variant="secondary" onClick={() => navigate('/login')} {...analyticsAttrs('error-cta-login', 'error', 'secondary', 'cta')}>
+          <Button variant="secondary" onClick={() => { persistLoginCta('error-cta-login'); navigate('/login'); }} {...analyticsAttrs('error-cta-login', 'error', 'secondary', 'cta')}>
             Connexion
           </Button>
         </div>

--- a/frontend/src/components/FaqPage.jsx
+++ b/frontend/src/components/FaqPage.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { ARTICLE_SOURCE_URLS as U } from '../content/articleSources.js';
 import { analyticsAttrs } from '../lib/analyticsAttrs.js';
+import { persistLoginCta } from '../../public/signupAttribution.js';
 import ContentScrollToTop from './ContentScrollToTop';
 import './ContentPages.css';
 
@@ -129,7 +130,7 @@ export default function FaqPage({ onBack }) {
         <div className="content-cta-inner">
           <h2>Un CV adapté à chaque offre, en un clic</h2>
           <p>Essaie AxeL Job gratuitement. 3 adaptations offertes, sans carte bancaire.</p>
-          <Link to="/login" className="button button-primary" {...analyticsAttrs('faq-cta-signup', 'content', 'primary', 'cta')}>Essayer gratuitement</Link>
+          <Link to="/login" className="button button-primary" onClick={() => persistLoginCta('faq-cta-signup')} {...analyticsAttrs('faq-cta-signup', 'content', 'primary', 'cta')}>Essayer gratuitement</Link>
         </div>
       </section>
 

--- a/frontend/src/components/LandingPage.jsx
+++ b/frontend/src/components/LandingPage.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useId, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { CONTACT_EMAIL } from '../constants';
 import { analyticsAttrs } from '../lib/analyticsAttrs.js';
+import { persistLoginCta } from '../../public/signupAttribution.js';
 import './LandingPage.css';
 
 /** Liens articles / guides (menu mobile + cohérence avec le footer) */
@@ -84,6 +85,13 @@ export default function LandingPage({ onCtaClick, onProClick }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const drawerId = useId();
   const closeMenu = useCallback(() => setMenuOpen(false), []);
+  const goLogin = useCallback(
+    (dataAttr, then) => {
+      persistLoginCta(dataAttr);
+      then?.();
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!menuOpen) return undefined;
@@ -127,7 +135,7 @@ export default function LandingPage({ onCtaClick, onProClick }) {
               <Link to="/faq" {...analyticsAttrs('nav-link-faq', 'header', 'tertiary', 'nav')}>FAQ</Link>
               <Link to="/modeles-cv" {...analyticsAttrs('nav-link-modeles', 'header', 'tertiary', 'nav')}>Modèles CV</Link>
               <Link to="/guide-cv" {...analyticsAttrs('nav-link-guide', 'header', 'tertiary', 'nav')}>Guide CV</Link>
-              <button type="button" className="button button-primary landing-cta-nav" onClick={onCtaClick} {...analyticsAttrs('nav-cta-signup', 'header', 'primary', 'cta')}>
+              <button type="button" className="button button-primary landing-cta-nav" onClick={() => goLogin('nav-cta-signup', onCtaClick)} {...analyticsAttrs('nav-cta-signup', 'header', 'primary', 'cta')}>
                 Essayer gratuitement
               </button>
             </nav>
@@ -143,7 +151,7 @@ export default function LandingPage({ onCtaClick, onProClick }) {
               >
                 <BurgerIcon open={menuOpen} />
               </button>
-              <button type="button" className="landing-mobile-cta button button-primary" onClick={onCtaClick} {...analyticsAttrs('nav-cta-start', 'header', 'primary', 'cta')}>
+              <button type="button" className="landing-mobile-cta button button-primary" onClick={() => goLogin('nav-cta-start', onCtaClick)} {...analyticsAttrs('nav-cta-start', 'header', 'primary', 'cta')}>
                 Commencer
               </button>
             </div>
@@ -195,7 +203,7 @@ export default function LandingPage({ onCtaClick, onProClick }) {
                 <li><Link to="/cgu" onClick={closeMenu}>CGU</Link></li>
               </ul>
               <div className="landing-nav-drawer-cta">
-                <button type="button" className="button button-primary" onClick={() => { closeMenu(); onCtaClick(); }} {...analyticsAttrs('nav-cta-drawer', 'drawer', 'primary', 'cta')}>
+                <button type="button" className="button button-primary" onClick={() => { closeMenu(); goLogin('nav-cta-drawer', onCtaClick); }} {...analyticsAttrs('nav-cta-drawer', 'drawer', 'primary', 'cta')}>
                   Essayer gratuitement
                 </button>
               </div>
@@ -216,7 +224,7 @@ export default function LandingPage({ onCtaClick, onProClick }) {
                 {"L'IA analyse l'offre d'emploi et adapte instantanément ton CV pour passer les filtres (ATS) et taper dans l'œil des recruteurs."}
               </p>
               <div className="landing-hero-ctas">
-                <button type="button" className="button button-primary landing-cta-hero" onClick={onCtaClick} {...analyticsAttrs('home-hero-cta-signup', 'hero', 'primary', 'cta')}>
+                <button type="button" className="button button-primary landing-cta-hero" onClick={() => goLogin('home-hero-cta-signup', onCtaClick)} {...analyticsAttrs('home-hero-cta-signup', 'hero', 'primary', 'cta')}>
                   Essayer gratuitement
                 </button>
                 <span className="landing-hero-hint">3 adaptations offertes</span>
@@ -305,7 +313,7 @@ export default function LandingPage({ onCtaClick, onProClick }) {
                   </li>
                 ))}
               </ul>
-              <button type="button" className="button button-secondary pricing-cta" onClick={onCtaClick} {...analyticsAttrs('home-pricing-cta-free', 'pricing', 'secondary', 'cta')}>
+              <button type="button" className="button button-secondary pricing-cta" onClick={() => goLogin('home-pricing-cta-free', onCtaClick)} {...analyticsAttrs('home-pricing-cta-free', 'pricing', 'secondary', 'cta')}>
                 Commencer gratuitement
               </button>
             </div>
@@ -327,7 +335,7 @@ export default function LandingPage({ onCtaClick, onProClick }) {
                   </li>
                 ))}
               </ul>
-              <button type="button" className="button button-primary pricing-cta" onClick={onProClick || onCtaClick} {...analyticsAttrs('home-pricing-cta-pro', 'pricing', 'primary', 'cta')}>
+              <button type="button" className="button button-primary pricing-cta" onClick={() => goLogin('home-pricing-cta-pro', onProClick || onCtaClick)} {...analyticsAttrs('home-pricing-cta-pro', 'pricing', 'primary', 'cta')}>
                 Passer Pro
               </button>
             </div>
@@ -370,7 +378,7 @@ export default function LandingPage({ onCtaClick, onProClick }) {
         <div className="landing-container">
           <h2>Prêt à décrocher le job de tes rêves ?</h2>
           <p>Crée ton compte gratuit et teste 3 adaptations de CV.</p>
-          <button type="button" className="button button-primary landing-cta-hero" onClick={onCtaClick} {...analyticsAttrs('home-final-cta-signup', 'final', 'primary', 'cta')}>
+          <button type="button" className="button button-primary landing-cta-hero" onClick={() => goLogin('home-final-cta-signup', onCtaClick)} {...analyticsAttrs('home-final-cta-signup', 'final', 'primary', 'cta')}>
             Essayer gratuitement
           </button>
         </div>

--- a/frontend/tests/unit/signupAttribution.test.js
+++ b/frontend/tests/unit/signupAttribution.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   PLAN_INTENT_BY_CTA,
   persistFromCtaClick,
+  persistLoginCta,
   readSourceCtaId,
   readPlanIntent,
   shouldPersistSourceCta,
@@ -70,6 +71,15 @@ test('pricing Pro → plan_intent pro et source_cta_id', () => {
     dataTrack: 'cta',
     linkUrl: '/login?plan=pro',
   });
+  assert.equal(readSourceCtaId(), 'home-pricing-cta-pro');
+  assert.equal(readPlanIntent(), 'pro');
+});
+
+test('persistLoginCta (boutons React sans href)', () => {
+  persistLoginCta('home-hero-cta-signup');
+  assert.equal(readSourceCtaId(), 'home-hero-cta-signup');
+  assert.equal(readPlanIntent(), 'free');
+  persistLoginCta('home-pricing-cta-pro');
   assert.equal(readSourceCtaId(), 'home-pricing-cta-pro');
   assert.equal(readPlanIntent(), 'pro');
 });

--- a/frontend/tests/unit/signupAttribution.test.js
+++ b/frontend/tests/unit/signupAttribution.test.js
@@ -1,0 +1,242 @@
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  PLAN_INTENT_BY_CTA,
+  persistFromCtaClick,
+  readSourceCtaId,
+  readPlanIntent,
+  shouldPersistSourceCta,
+  planIntentFromCta,
+  buildLoginRedirectTo,
+  hydratePlanIntentFromSearch,
+  wantsProCheckout,
+  consumePlanIntentIfPro,
+  isLikelyNewAuthUser,
+  authMethodFromUser,
+  signUpStartParams,
+  signUpParams,
+  compactParams,
+  emitSignUpStartOnce,
+  emitSignUpOnce,
+  SOURCE_CTA_KEY,
+  PLAN_INTENT_KEY,
+  SIGN_UP_START_SENT_KEY,
+  SIGN_UP_SENT_KEY,
+  CONSENT_STORAGE_KEY,
+} from '../../public/signupAttribution.js';
+
+function memoryStorage() {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => {
+      m.set(String(k), String(v));
+    },
+    removeItem: (k) => {
+      m.delete(String(k));
+    },
+    clear: () => m.clear(),
+  };
+}
+
+function grantConsent() {
+  globalThis.localStorage.setItem(CONSENT_STORAGE_KEY, JSON.stringify({ v: 1, analytics: true }));
+}
+
+beforeEach(() => {
+  globalThis.sessionStorage = memoryStorage();
+  globalThis.localStorage = memoryStorage();
+  globalThis.window = globalThis;
+  globalThis.window.dataLayer = [];
+  globalThis.window.gtag = undefined;
+});
+
+test('hero CTA → source_cta_id + plan_intent free', () => {
+  const ok = persistFromCtaClick({
+    dataAttr: 'home-hero-cta-signup',
+    dataTrack: 'cta',
+    linkUrl: '/login',
+  });
+  assert.equal(ok, true);
+  assert.equal(readSourceCtaId(), 'home-hero-cta-signup');
+  assert.equal(readPlanIntent(), 'free');
+  assert.equal(PLAN_INTENT_BY_CTA['home-hero-cta-signup'], undefined);
+  assert.equal(planIntentFromCta('home-hero-cta-signup', '/login'), 'free');
+});
+
+test('pricing Pro → plan_intent pro et source_cta_id', () => {
+  persistFromCtaClick({
+    dataAttr: 'home-pricing-cta-pro',
+    dataTrack: 'cta',
+    linkUrl: '/login?plan=pro',
+  });
+  assert.equal(readSourceCtaId(), 'home-pricing-cta-pro');
+  assert.equal(readPlanIntent(), 'pro');
+});
+
+test('CTA login page n’écrase pas l’attribution landing', () => {
+  persistFromCtaClick({
+    dataAttr: 'home-pricing-cta-pro',
+    dataTrack: 'cta',
+    linkUrl: '/login?plan=pro',
+  });
+  const again = persistFromCtaClick({
+    dataAttr: 'login-cta-google',
+    dataTrack: 'cta',
+    linkUrl: '/login',
+  });
+  assert.equal(again, false);
+  assert.equal(shouldPersistSourceCta('login-cta-google', 'cta', '/login'), false);
+  assert.equal(readSourceCtaId(), 'home-pricing-cta-pro');
+  assert.equal(readPlanIntent(), 'pro');
+});
+
+test('nav / hors login : pas de persist', () => {
+  assert.equal(shouldPersistSourceCta('footer-link-faq', 'nav', '/faq'), false);
+  assert.equal(
+    persistFromCtaClick({ dataAttr: 'error-cta-home', dataTrack: 'cta', linkUrl: '/' }),
+    false,
+  );
+});
+
+test('buildLoginRedirectTo garde plan=pro et UTM', () => {
+  assert.equal(
+    buildLoginRedirectTo('https://job.axelproject.fr', '?plan=pro&utm_source=meta', 'free'),
+    'https://job.axelproject.fr/login?plan=pro&utm_source=meta',
+  );
+  assert.equal(
+    buildLoginRedirectTo('https://job.axelproject.fr', '', 'pro'),
+    'https://job.axelproject.fr/login?plan=pro',
+  );
+  assert.equal(
+    buildLoginRedirectTo('https://job.axelproject.fr', '?utm_campaign=a', 'free'),
+    'https://job.axelproject.fr/login?utm_campaign=a',
+  );
+  assert.equal(
+    buildLoginRedirectTo('https://job.axelproject.fr', '?next=/app/profil', ''),
+    'https://job.axelproject.fr/login?next=%2Fapp%2Fprofil',
+  );
+  assert.equal(
+    buildLoginRedirectTo('https://job.axelproject.fr', '?next=https://evil.example/', ''),
+    'https://job.axelproject.fr/login',
+  );
+});
+
+test('hydrate URL plan=pro + wantsProCheckout sans query (OAuth perdu)', () => {
+  persistFromCtaClick({
+    dataAttr: 'home-pricing-cta-pro',
+    dataTrack: 'cta',
+    linkUrl: '/login?plan=pro',
+  });
+  assert.equal(wantsProCheckout(''), true);
+  assert.equal(hydratePlanIntentFromSearch('?plan=pro'), 'pro');
+  consumePlanIntentIfPro();
+  assert.equal(readPlanIntent(), '');
+  assert.equal(wantsProCheckout(''), false);
+  assert.equal(wantsProCheckout('?plan=pro'), true);
+});
+
+test('isLikelyNewAuthUser : fenêtre created_at / last_sign_in', () => {
+  const now = Date.parse('2026-08-25T12:00:00.000Z');
+  assert.equal(
+    isLikelyNewAuthUser(
+      { created_at: '2026-08-25T12:00:00.000Z', last_sign_in_at: '2026-08-25T12:00:02.000Z' },
+      now,
+    ),
+    true,
+  );
+  assert.equal(
+    isLikelyNewAuthUser(
+      { created_at: '2026-08-25T11:58:00.000Z', last_sign_in_at: '2026-08-25T12:00:00.000Z' },
+      now,
+    ),
+    true,
+  );
+  assert.equal(
+    isLikelyNewAuthUser(
+      { created_at: '2026-01-01T00:00:00.000Z', last_sign_in_at: '2026-08-25T12:00:00.000Z' },
+      now,
+    ),
+    false,
+  );
+  assert.equal(isLikelyNewAuthUser(null, now), false);
+});
+
+test('authMethodFromUser google / linkedin / email', () => {
+  assert.equal(authMethodFromUser({ app_metadata: { provider: 'google' } }), 'google');
+  assert.equal(authMethodFromUser({ identities: [{ provider: 'linkedin_oidc' }] }), 'linkedin');
+  assert.equal(authMethodFromUser({ app_metadata: { provider: 'email' } }), 'email');
+});
+
+test('payloads sign_up* : method + attribution, jamais d’email', () => {
+  persistFromCtaClick({
+    dataAttr: 'home-pricing-cta-pro',
+    dataTrack: 'cta',
+    linkUrl: '/login?plan=pro',
+  });
+  sessionStorage.setItem(SOURCE_CTA_KEY, 'home-pricing-cta-pro');
+  assert.deepEqual(signUpStartParams('form'), {
+    method: 'form',
+    source_cta_id: 'home-pricing-cta-pro',
+  });
+  assert.deepEqual(signUpParams('email'), {
+    method: 'email',
+    plan_intent: 'pro',
+    source_cta_id: 'home-pricing-cta-pro',
+  });
+  const dirty = compactParams({ method: 'email', note: 'hello user@example.com' });
+  assert.equal(JSON.stringify(dirty).includes('@'), false);
+  assert.equal(dirty.note, 'hello');
+});
+
+test('emit sign_up derrière consentement, une seule fois', () => {
+  persistFromCtaClick({
+    dataAttr: 'home-hero-cta-signup',
+    dataTrack: 'cta',
+    linkUrl: '/login',
+  });
+  assert.equal(emitSignUpOnce('email'), false);
+  assert.equal(sessionStorage.getItem(SIGN_UP_SENT_KEY), null);
+  grantConsent();
+  assert.equal(emitSignUpOnce('email'), true);
+  const events = window.dataLayer.filter((e) => e && e.event === 'sign_up');
+  assert.equal(events.length, 1);
+  assert.equal(events[0].method, 'email');
+  assert.equal(events[0].plan_intent, 'free');
+  assert.equal(events[0].source_cta_id, 'home-hero-cta-signup');
+  assert.equal(JSON.stringify(events[0]).includes('@'), false);
+  assert.equal(emitSignUpOnce('email'), false);
+});
+
+test('emit sign_up_start une fois après consentement', () => {
+  grantConsent();
+  persistFromCtaClick({
+    dataAttr: 'home-pricing-cta-pro',
+    dataTrack: 'cta',
+    linkUrl: '/login?plan=pro',
+  });
+  assert.equal(emitSignUpStartOnce('form'), true);
+  assert.equal(emitSignUpStartOnce('form'), false);
+  const start = window.dataLayer.find((e) => e && e.event === 'sign_up_start');
+  assert.equal(start.method, 'form');
+  assert.equal(start.source_cta_id, 'home-pricing-cta-pro');
+  assert.equal('plan_intent' in start, false);
+  assert.equal(sessionStorage.getItem(SIGN_UP_START_SENT_KEY), '1');
+  assert.equal(sessionStorage.getItem(PLAN_INTENT_KEY), 'pro');
+});
+
+test('AuthForm : OAuth redirectTo + sign_up seulement après vrai signup', async () => {
+  const { readFile } = await import('node:fs/promises');
+  const { fileURLToPath } = await import('node:url');
+  const path = await import('node:path');
+  const root = fileURLToPath(new URL('../..', import.meta.url));
+  const src = await readFile(path.join(root, 'src/components/AuthForm.jsx'), 'utf8');
+  assert.ok(src.includes('currentLoginRedirectTo'));
+  assert.ok(src.includes("emitSignUpOnce('email')"));
+  assert.ok(src.includes('emitSignUpStartOnce'));
+  const alreadyIdx = src.indexOf('alreadyRegistered');
+  const emitIdx = src.indexOf("emitSignUpOnce('email')");
+  const returnIdx = src.indexOf('setShowAlreadyHadAccountPopup');
+  assert.ok(alreadyIdx > 0 && emitIdx > alreadyIdx);
+  assert.ok(returnIdx > 0 && returnIdx < emitIdx);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes AXE-362

## What changed

- `frontend/public/signupAttribution.js` : `sessionStorage.source_cta_id` + `plan_intent` au clic CTA vers `/login`.
- OAuth Google/LinkedIn : `redirectTo` garde `?plan=pro` + UTM.
- `sign_up_start` à l’arrivée `/login` ; `sign_up` seulement compte **nouveau**.
- Checkout Pro si `?plan=pro` **ou** `plan_intent=pro`.
- Persist aussi sur les **boutons React sans href** (`persistLoginCta`) — recette locale : `cta_click` OK mais sessionStorage vide tant que `/track.js` était en cache Vite.

## Validation

- [x] Tests unitaires
- [x] Pre-push local (commit initial)
- [ ] Recette : après pull + **hard refresh**, `sessionStorage.source_cta_id` / `plan_intent` + `sign_up_start` avec `source_cta_id`

## Linear

https://linear.app/axel-project/issue/AXE-362/feat-attribution-source-cta-id-et-plan-intent-jusquau-compte-cree

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

