### PR TITLE
docs(AXE-356): conventions de nomination analytics (events, props, pages)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,9 @@ Point d'entree de la documentation technique, securite et operations.
 | Workflow Git (main, wip/innovation, PR Draft) | [docs/git-workflow.md](git-workflow.md) |
 | Protections branches / passage push → PR | [docs/branch-protections.md](branch-protections.md) |
 | Workflow Linear ↔ GitHub (tickets AXE, liens, PR) | [docs/linear-github-workflow.md](linear-github-workflow.md) |
+| Conventions analytics (events, props, pages) | [docs/analytics-naming.md](analytics-naming.md) |
+| Taggage landing → signup (`data-attr`, tracker CMP) | [docs/taggage-analytics.md](taggage-analytics.md) |
+| Recette GA4 (GTM, DebugView) | [docs/ga4-recette.md](ga4-recette.md) |
 | Intégration `wip/innovation` → `main` (AXE-27) | [docs/axe-27-integration-strategy.md](axe-27-integration-strategy.md) |
 | Spike import PDF/Word → CV scoré (AXE-41) | [docs/axe-41-import-pipeline-spike.md](axe-41-import-pipeline-spike.md) |
 | Verifier la Definition of Done engineering | `docs/engineering-standards.md` |

--- a/docs/analytics-naming.md
+++ b/docs/analytics-naming.md
@@ -238,9 +238,10 @@ posthog.capture('sign_up', {
   source_cta_id: 'home-pricing-cta-pro',
 });
 
-// Produit (session /app — first-party aujourd’hui ; PH seulement si go + base légale)
-posthog.capture('adaptation_completed', { adaptation_id, template_id });
+// Produit front (mêmes noms que /api/events/track — PH seulement si go + base légale)
+posthog.capture('adapt_cta_clicked', { source: 'chat_send' });
 posthog.capture('page_view', { view: 'cv', path: '/app/cv' });
+// adaptation_completed reste backend-only (event_log) — ne pas le recapturer côté client
 ```
 
 ---

--- a/docs/analytics-naming.md
+++ b/docs/analytics-naming.md
@@ -1,0 +1,274 @@
+# Conventions de nomination analytics — AxeL Job (AXE-356)
+
+Ticket : [AXE-356](https://linear.app/axel-project/issue/AXE-356).  
+Vague landing → signup : [`docs/taggage-analytics.md`](taggage-analytics.md) (inventaire `data-attr` figé AXE-358).  
+Recette GA4 : [`docs/ga4-recette.md`](ga4-recette.md).
+
+> **Figé 2026-08-25.** Un nom posé en production **ne se renomme jamais**. On ajoute, on déprécie.  
+> Ce document est le contrat de naming **site entier** (public + `/app`). Il ne pose pas de nouveaux events.
+
+---
+
+## 1. Deux stacks — ne pas les mélanger
+
+| | Marketing (public) | Produit (app connectée) |
+|---|---|---|
+| Périmètre | `/`, `/login`, FAQ, ATS, articles, légales, 404/500 | `/app/*` une fois session OK |
+| Transport | `track.js` + `signupAttribution.js` → `dataLayer` / `gtag` | `trackEvent()` → `POST /api/events/track` → `event_log` (JSONL + Supabase) |
+| Outil | **GA4** `G-7524WTRGSY` via GTM (`VITE_AXEL_GTM_ID` au **build**) | First-party `event_log` — **pas** GA4, **pas** de SDK PostHog |
+| Consentement | CMP `axel_job_consent_v1` `{v:1, analytics, marketing}`. Aucun event marketing si `analytics` false | Session authentifiée. **Pas** derrière la CMP (déjà connecté) |
+| Identifiants DOM | `data-attr` / `data-track` / `data-zone` / `data-level` / `data-section` | Events explicites. `data-attr` C.9 (candidatures) posés mais **non lus** par `track.js` (ignore `/app`). `data-analytics-section` → `page_engagement.sections` |
+
+**PostHog :** no-go v1 ([AXE-363](https://linear.app/axel-project/issue/AXE-363), [AXE-364](https://linear.app/axel-project/issue/AXE-364) canceled). Si un go futur (A/B Cloud EU) : **réutiliser les mêmes noms** (exemples § 8), même case CMP « Mesure d’audience », pas d’autocapture sur `/app`.
+
+---
+
+## 2. Règles de naming
+
+### 2.1 Events
+
+Deux dialectes **déjà en prod** — on ne les unifie pas (rename = funnels cassés).
+
+| Stack | Forme | Exemples figés |
+|---|---|---|
+| Marketing GA4 | `objet_verbe` (présent / infinitif court) | `cta_click`, `nav_click`, `section_view`, `sign_up` |
+| Produit | `objet_action` snake_case, participe / état | `adaptation_started`, `pdf_generated`, `statut_changed` |
+
+**Nouveaux events**
+
+- snake_case ASCII, minuscules, pas d’accents.
+- Marketing : rester dans le dialecte GA4 (`*_click`, `*_view`, `sign_up_*`).
+- Produit : `objet_action` (`cv_imported` interdit si `cv_import` existe déjà — **on garde `cv_import`**).
+- Un nom = une intention. Pas de variante `AdaptCtaClicked` / `ADAPT_CTA`.
+- Pas de préfixe `job_` / `axel_` sur les noms d’events (les noms actuels n’en ont pas). Un préfixe éventuel se fait à l’ETL, pas dans le code.
+
+### 2.2 Propriétés
+
+- snake_case. Clés stables listées § 5. **Pas d’email, mot de passe, nom, texte d’offre, texte de CV.**
+- Valeurs enum en minuscules (`free` / `pro`, `form` / `email` / `google` / `linkedin`).
+- IDs DOM (`source_cta_id`, `cta_id`) = kebab du catalogue, pas un libellé bouton.
+- `cta_text` : sanitizé (max 80, emails strippés) — déjà `sanitizeCtaText` dans `track.js`.
+- Contexte produit : JSON ≤ 4000 caractères (`/api/events/track` tronque sinon).
+
+### 2.3 Pages / screens
+
+| Stack | Comment on nomme | Figé |
+|---|---|---|
+| Marketing | URL path réel (`/`, `/login`, `/faq`, …) — `page_view` GA4 auto | ne pas inventer un `page_home` parallèle |
+| Produit | `page_view` + `{ view, path }` | `view` ∈ `cv` \| `candidatures` \| `profil` \| `settings` \| `support` \| `monitoring` (`getViewFromPathname`). `/app/linkedin` → `view=profil` |
+
+`view` **est** le screen name. Ne pas ajouter `screen_name` / `page_title` tant que `view` + `path` suffisent.
+
+### 2.4 Identifiants DOM
+
+| Attribut | Forme | Où | Figé par |
+|---|---|---|---|
+| `data-attr` | kebab `page-zone-type-intention` ; globaux sans page (`nav-`, `footer-`) | 1 ID = 1 élément. Jamais dans une classe CSS | [AXE-358](https://linear.app/axel-project/issue/AXE-358) (55 IDs public) + C.9 candidatures |
+| `data-track` | `cta` \| `nav` \| `input` | public | 358 |
+| `data-zone` | kebab (`hero`, `header`, `pricing`, …) | public | 358 |
+| `data-level` | `primary` \| `secondary` \| `tertiary` | public | 358 |
+| `data-section` | kebab | marketing, observé 50 % → `section_view` | 358 C.7 |
+| `data-analytics-section` | **snake_case** (déjà en prod : `cv_workspace`, `candidatures_board`) | `/app`, observé → `page_engagement.sections` | ce doc |
+
+Nouveaux `data-attr` /app : même convention kebab que le public. Nouveaux `data-analytics-section` : snake_case (aligné code actuel, pas kebab).
+
+---
+
+## 3. Inventaire des surfaces
+
+### 3.1 Public (externe) — tagué vague 1
+
+SPA bundle (`entry-conditional.js`) seulement sur `/`, `/login`, `/app/*`. Le reste = HTML statique `frontend/public/*.html`. Tagger les **deux** arbres quand les deux existent.
+
+| Route | Surface | Funnel / CTA clés | État |
+|---|---|---|---|
+| `/` | Landing | hero / nav / pricing / final → `/login` | `data-attr` + tracker CMP |
+| `/login` | Auth | submit, Google, LinkedIn, toggle, forgot | idem + `sign_up_start` / `sign_up` |
+| `/faq` | FAQ | questions + CTA signup | idem |
+| `/ats` | Article ATS | CTA signup | idem |
+| `/modeles-cv` `/guide-cv` `/erreurs-cv` `/cv-par-metier` `/cv-adapte-chaque-offre` | Articles | CTA signup | idem |
+| `/mentions-legales` `/confidentialite` `/cgu` | Légales | footer only (pas de CTA signup dédié) | footer `data-attr` |
+| 404 / 500 | Erreurs | `error-cta-home` / `error-cta-login` | idem |
+
+**Hors vague 1 (ne pas inventer d’IDs ici) :** cookie banner, `faq_open`, drawer tertiaires, sources outbound FAQ (C.8).
+
+### 3.2 App (interne)
+
+| Route | `view` | Sections `data-analytics-section` (déjà là) | Events métier déjà émis | `data-attr` |
+|---|---|---|---|---|
+| `/app/cv` | `cv` | `cv_workspace`, `chat`, `preview`, `export` | adaptation\*, `adapt_cta_clicked`, `job_description_pasted`, `template_changed`, `cv_manually_edited`, `ats_details_opened`, `adaptation_rated`, `base_cv_pdf_downloaded` ⚠️, `first_offer_nudge_cta` ⚠️, onboarding\* | **aucun catalogue** |
+| `/app/postule` | `candidatures` | `candidatures_board`, `candidatures_stats`, `candidatures_list_mobile` | `new_candidature_workspace` ⚠️, `adapt_cta_clicked`, backend statut / refus / source offre | **C.9 posé** (7 IDs) — clics **non** relayés |
+| `/app/profil` `/app/linkedin` | `profil` | `profil_editor` | `base_cv_pdf_downloaded` ⚠️ (profil), backend `profile_saved` | aucun |
+| `/app/settings` | `settings` | `settings_page` | `promo_code_redeemed` (backend) | aucun |
+| `/app/support` | `support` | `support_page` | — | aucun |
+| `/app/monitoring` | `monitoring` | `monitoring_dashboard` | — | aucun |
+
+⚠️ = le front appelle `trackEvent` mais le nom **n’est pas** dans `_ALLOWED_FRONTEND_EVENTS` → HTTP 400, drop. Ticket fille whitelist.
+
+`EVENT_LOGIN` (`login`) est **déclaré** dans `event_log.py`, **jamais émis**. Ticket fille : émettre ou retirer.
+
+---
+
+## 4. Catalogue events figé
+
+### 4.1 Marketing → GA4 (ne pas renommer)
+
+| Event | Params | Source |
+|---|---|---|
+| `cta_click` | `cta_id`, `cta_zone`, `cta_level`, `cta_text`, `link_url` | `track.js` `data-track=cta` |
+| `nav_click` | `nav_id`, `nav_type`, `link_url` | `data-track=nav` |
+| `select_plan` | `plan`, `price`, `zone` | CTA pricing only |
+| `section_view` | `section_id` | `data-section` ≥ 50 %, 1× / session |
+| `outbound_click` | `link_domain`, `link_url` | href http(s) hors host |
+| `contact_click` | `method=email` | `mailto:` |
+| `sign_up_start` | `method`, `source_cta_id` | arrivée `/login` (1×) |
+| `sign_up` | `method`, `plan_intent`, `source_cta_id` | **nouveau** compte seulement |
+
+`page_view` marketing = celui de GA4/GTM (URL). Ne pas en émettre un second depuis `track.js`.
+
+### 4.2 Produit → event_log (ne pas renommer)
+
+**Frontend whitelist** (`_ALLOWED_FRONTEND_EVENTS`) — reçus via `/api/events/track` :
+
+| Event | Props typiques | Où |
+|---|---|---|
+| `onboarding_method_chosen` | `method` = `file_upload` \| `text_paste` \| `manual` | OnboardingWizard |
+| `onboarding_completed` | `method` | idem |
+| `onboarding_skipped` | — | idem |
+| `page_view` | `view`, `path`, `attribution?` (1× / session auth) | `useViewAnalytics` |
+| `page_engagement` | `view`, `path`, `duration_ms`, `scroll_pct_max`, `sections[]` | idem |
+| `job_description_pasted` | `word_count`, `source` | App CV |
+| `cv_manually_edited` | `adaptation_id` | preview |
+| `ats_details_opened` | `score` | rapport ATS |
+| `adaptation_rated` | `rating`, `adaptation_id`, `score_ats` | thumbs |
+| `template_changed` | `template_id` | preview |
+| `adapt_cta_clicked` | `source`, `desc_word_count` | chat / candidatures |
+
+**Backend only** (pas via le POST front) :
+
+| Event | Quand |
+|---|---|
+| `adaptation_started` / `adaptation_completed` / `adaptation_failed` | pipeline adapt |
+| `pdf_generated` | export PDF adapté |
+| `export_dossier` | export dossier |
+| `statut_changed` | kanban |
+| `refus_reason_submitted` | motif refus |
+| `interview_feedback_submitted` | feedback entretien |
+| `source_offre_submitted` | source de l’offre |
+| `profile_saved` | profil |
+| `cv_import` | import CV |
+| `promo_code_redeemed` | code promo |
+
+**Orphelins front (à whitelister, noms déjà figés)** :
+
+| Event | Props | Où |
+|---|---|---|
+| `base_cv_pdf_downloaded` | `template_id`, `source` = `cv_tab` \| `profile` | App + ProfileView |
+| `first_offer_nudge_cta` | `action` = `go_cv` \| `dismiss` | nudge 1ʳᵉ offre |
+| `new_candidature_workspace` | `had_adapted_cv` | nouvelle candidature |
+
+**Déclaré, jamais émis :** `login`.
+
+---
+
+## 5. Propriétés communes (réutiliser, ne pas inventer de synonyme)
+
+| Clé | Stack | Valeurs / notes |
+|---|---|---|
+| `cta_id` / `source_cta_id` | mkt | = `data-attr` kebab |
+| `cta_zone` / `zone` | mkt | kebab |
+| `cta_level` | mkt | `primary` \| `secondary` \| `tertiary` |
+| `plan` / `plan_intent` | mkt | `free` \| `pro` |
+| `method` | les deux | auth : `form` \| `email` \| `google` \| `linkedin` ; onboarding : `file_upload` \| `text_paste` \| `manual` |
+| `view` | produit | screen § 2.3 |
+| `path` | produit | pathname `/app/…` |
+| `template_id` | produit | id template canvas |
+| `adaptation_id` | produit | id adaptation |
+| `source` | produit | origine d’un geste (`chat_send`, `cv_tab`, `profile`, …) |
+| `session_id` | produit | header analytics, pas un event name |
+
+Interdit dans les props : email, téléphone, nom, contenu d’offre, contenu de CV, token.
+
+---
+
+## 6. Consentement / opt-out
+
+| Signal | Clé / comportement |
+|---|---|
+| CMP | `localStorage.axel_job_consent_v1` = `{v:1, analytics, marketing}` |
+| Event interne | `axel_consent_update` (dataLayer) — pas un event GA4 métier |
+| Marketing | `hasAnalyticsConsent` obligatoire avant tout `cta_click` / `sign_up*` |
+| Produit | pas de gate CMP ; l’utilisateur est dans l’app. Pas de tracking marketing `track.js` sur `/app` |
+| Opt-out marketing | refuser « Mesure d’audience » → zero event GA4 custom |
+| PII | `compactParams` strippe les emails dans les params marketing |
+
+Ne **pas** envoyer les events produit vers GA4 « pour simplifier » : ça mélangerait les stacks et le consentement.
+
+---
+
+## 7. Alignement cousin CRM (Axel Gestion)
+
+Le workspace Linear `axel-project` héberge **Axel Gestion (CRM)** et **AxeL Job** dans la même team `AXE`, distingués par labels (`CRM` vs `AxelJob`) — [`docs/linear-github-workflow.md`](linear-github-workflow.md).
+
+**Pas de document de tagging CRM dans ce repo**, ni de catalogue d’events partagé. Alignement retenu :
+
+- Même hygiène : snake_case, pas de PII dans les props, pas de rename en prod.
+- **Pas** de partage de noms d’events (`login`, `page_view` existent des deux côtés métier). Un entrepôt commun mapperait `source_app=axel_job` à l’ETL, sans préfixer le code Job.
+- `data-attr` kebab est spécifique Job (funnel growth). Ne pas l’imposer au CRM.
+- Label Linear `CRM` ne s’applique pas aux tickets Job.
+
+Si un doc tagging Gestion apparaît plus tard : pointer depuis cette section, ne pas fusionner les catalogues.
+
+---
+
+## 8. Exemples PostHog (si go futur uniquement)
+
+Mêmes noms, mêmes props. Pas d’autocapture `/app`. Pas de SDK tant que AXE-363 reste no-go.
+
+```js
+// Marketing (uniquement si consentement analytics)
+posthog.capture('cta_click', {
+  cta_id: 'home-hero-cta-signup',
+  cta_zone: 'hero',
+  cta_level: 'primary',
+});
+posthog.capture('sign_up', {
+  method: 'google',
+  plan_intent: 'pro',
+  source_cta_id: 'home-pricing-cta-pro',
+});
+
+// Produit (session /app — first-party aujourd’hui ; PH seulement si go + base légale)
+posthog.capture('adaptation_completed', { adaptation_id, template_id });
+posthog.capture('page_view', { view: 'cv', path: '/app/cv' });
+```
+
+---
+
+## 9. Tickets d’implémentation (filles AXE-356)
+
+Créés dans le projet [Tagging interne & externe](https://linear.app/axel-project/project/axel-job-tagging-interne-and-externe-f932ba5559ef), parent [AXE-356](https://linear.app/axel-project/issue/AXE-356).
+
+| # | Linear | Titre | Pourquoi |
+|---|---|---|---|
+| 1 | [AXE-394](https://linear.app/axel-project/issue/AXE-394) | Whitelist events orphelins produit | 3 `trackEvent` droppés (400) |
+| 2 | [AXE-395](https://linear.app/axel-project/issue/AXE-395) | Inventaire figé `data-attr` /app hors candidatures | cv, profil, settings, support, monitoring, onboarding — comme 358 |
+| 3 | [AXE-396](https://linear.app/axel-project/issue/AXE-396) | Balisage `data-attr` /app hors candidatures | pose les IDs d’AXE-395 |
+| 4 | [AXE-397](https://linear.app/axel-project/issue/AXE-397) | Émettre `login` produit **ou** retirer `EVENT_LOGIN` | constante morte |
+
+AXE-396 est bloqué par AXE-395.
+
+**Pas de ticket v1 :** relayer les `data-attr` /app vers GA4 ou un second `track.js`. Les clics produit restent des events métier explicites. C.9 sert la recette DOM + un tracker /app éventuel (v2).
+
+**Déjà livré (ne pas recréer) :** AXE-358…365 (sauf 364 canceled).
+
+---
+
+## 10. Checklist auteur d’un nouvel event
+
+1. Stack ? Marketing (CMP + GA4) vs produit (whitelist + `event_log`).
+2. Un nom existant couvre-t-il déjà le geste ? Réutiliser.
+3. Dialecte § 2.1 + props § 5. Aucune PII.
+4. Produit front : ajouter la constante `EVENT_*` **et** `_ALLOWED_FRONTEND_EVENTS`.
+5. Marketing : ajouter le déclencheur GTM (runbook [`ga4-recette.md`](ga4-recette.md)) — pas de filtre CSS.
+6. Documenter dans ce fichier (ajouter une ligne, jamais un rename).

--- a/docs/ga4-recette.md
+++ b/docs/ga4-recette.md
@@ -1,7 +1,8 @@
 # Recette GA4 — AxeL Job (AXE-365)
 
 Ticket Linear : [AXE-365](https://linear.app/axel-project/issue/AXE-365).  
-Tracker code : `frontend/public/track.js` (AXE-361). **PostHog hors v1.**
+Tracker code : `frontend/public/track.js` (AXE-361). **PostHog hors v1.**  
+Noms d’events / props (site entier) : [`docs/analytics-naming.md`](analytics-naming.md) ([AXE-356](https://linear.app/axel-project/issue/AXE-356)).
 
 Le tracker pousse deux choses dans `dataLayer` :
 

--- a/docs/taggage-analytics.md
+++ b/docs/taggage-analytics.md
@@ -112,12 +112,12 @@ Remplir la colonne `AXE-XX` après création.
 | 7 | `Feat: Brancher PostHog (événements + autocapture data-attr)` | AxelJob, Feature | 4 + 6 (go) | [AXE-364](https://linear.app/axel-project/issue/AXE-364) **Canceled** | `louisvedovato/axe-364-feat-brancher-posthog-evenements-autocapture-data-attr` |
 | 8 | `Chore: Recette GA4 — conversions, dimensions, DebugView` | AxelJob, Improvement | 4 + 5 | [AXE-365](https://linear.app/axel-project/issue/AXE-365) | `louisvedovato/axe-365-chore-recette-ga4-conversions-dimensions-debugview` |
 
-Convention site-wide (hors ces 8 tickets) : [AXE-356](https://linear.app/axel-project/issue/AXE-356). 358 fige l’instance landing → signup sans l’attendre.
+Convention site-wide (hors ces 8 tickets) : [AXE-356](https://linear.app/axel-project/issue/AXE-356) — contrat : [`docs/analytics-naming.md`](analytics-naming.md) (deux stacks GA4 vs event_log, inventaire surfaces, tickets filles). 358 fige l’instance landing → signup sans l’attendre.
 
-Backlog hors vague 1 (créer plus tard si besoin) :
+Backlog hors vague 1 :
 
 - `Improve: Un seul bouton primary visible par écran sur la landing`
-- `Fix: Whitelist /api/events/track — events orphelins (base_cv_pdf_downloaded, first_offer_nudge_cta, …)`
+- Events orphelins produit + balisage `/app` : filles d’AXE-356 — [AXE-394](https://linear.app/axel-project/issue/AXE-394) (whitelist), [AXE-395](https://linear.app/axel-project/issue/AXE-395) (inventaire `/app`), [AXE-396](https://linear.app/axel-project/issue/AXE-396) (balisage), [AXE-397](https://linear.app/axel-project/issue/AXE-397) (`login` produit). Contrat : [`docs/analytics-naming.md`](analytics-naming.md).
 
 ---
 
@@ -448,7 +448,7 @@ Globaux : **pas** de préfixe de page (`nav-`, `footer-`).
 | Surfaces A/B non-clic | Conservées dans le catalogue : `home-hero-title`, `home-pricing-card-free`, `home-pricing-card-pro`, `home-pricing-badge-popular` |
 | C.8 / v2 | Exclue de la vague 1 (drawer tertiaires, sources outbound FAQ, `faq_open`, cookie banner) |
 | C.9 candidatures | Hors vague 1 (déjà figé 2026-08-21) — ne pas retoucher |
-| AXE-356 | Convention site-wide peut attendre : 358 fige l’instance landing → signup |
+| AXE-356 | Convention site-wide : [`docs/analytics-naming.md`](analytics-naming.md) (figé 2026-08-25). 358 reste l’instance landing → signup |
 
 Attributs HTML types :
 

--- a/docs/taggage-analytics.md
+++ b/docs/taggage-analytics.md
@@ -600,7 +600,9 @@ Pas des `data-attr`. Observer à 50 %, une fois par session.
 ### C.9 App connectée — Mes candidatures (`/app/postule`) — **figé 2026-08-21**
 
 Extension hors vague 1 (landing → signup). Même convention `page-zone-type-intention`.  
-Un ID posé en prod ne se renomme jamais. Tracker app = `/api/events/track` + GA4 derrière CMP (PostHog hors v1).
+Un ID posé en prod ne se renomme jamais.
+
+**Transport `/app` (contrat [AXE-356](https://linear.app/axel-project/issue/AXE-356) / [`docs/analytics-naming.md`](analytics-naming.md)) :** events explicites `trackEvent()` → `POST /api/events/track` → `event_log`. **Pas** de GA4, **pas** de CMP, **pas** de `track.js` (ignore `/app`). Les `data-attr` C.9 servent la recette DOM ; ils n’émettent rien tant qu’un tracker /app n’existe pas (v2).
 
 | data-attr | type | level | Où | Intention |
 |---|---|---|---|---|
@@ -612,13 +614,15 @@ Un ID posé en prod ne se renomme jamais. Tracker app = `/api/events/track` + GA
 | `candidatures-controls-input-search` | input | tertiary | Barre de filtres | Champ recherche. **Ne jamais** envoyer la valeur dans un event. |
 | `candidatures-list-input-statut` | input | tertiary | Liste mobile (≤768px) | Select changement de statut. **Ne jamais** envoyer la valeur dans un event. |
 
-`data-section` (hors compte) :
+`data-analytics-section` (hors compte, snake_case — observé par `useViewAnalytics` → `page_engagement.sections`) :
 
-| data-section | Zone |
+| data-analytics-section | Zone |
 |---|---|
-| `candidatures` | Board kanban `/app/postule` |
-| `candidatures-stats` | Bandeau métriques |
-| `candidatures-list-mobile` | Liste groupée mobile (AXE-381) |
+| `candidatures_board` | Board kanban `/app/postule` |
+| `candidatures_stats` | Bandeau métriques |
+| `candidatures_list_mobile` | Liste groupée mobile (AXE-381) |
+
+Les `data-section` kebab encore présents sur les mêmes nœuds (`candidatures`, `candidatures-stats`, …) **ne sont pas lus** (`track.js` ignore `/app`). Ne pas s’en servir. Ne pas les renommer ici (markup = tickets filles AXE-395 / 396).
 
 V2 candidatures (ne pas poser maintenant) : ouverture carte, archive, drag colonne, métriques cliquables.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

- Contrat site-wide : [`docs/analytics-naming.md`](docs/analytics-naming.md) (deux stacks — GA4 marketing vs `event_log` produit, inventaire des surfaces, propriétés, consentement, exemples PostHog si go futur).
- Pointeurs depuis `docs/taggage-analytics.md`, `docs/ga4-recette.md`, `docs/README.md`.
- Tickets filles Linear : AXE-394 (whitelist orphelins), AXE-395 (inventaire `data-attr` /app), AXE-396 (balisage, bloqué par 395), AXE-397 (`login` produit).
- Suivi CodeRabbit : C.9 aligné (pas de GA4/CMP sur `/app` ; sections = `data-analytics-section`) ; exemple PostHog sans `adaptation_completed` client.

## Why

Avant d’instrumenter le reste du site, figer les noms (events, props, pages) pour ne pas divergir entre landing, login et `/app`. AXE-358 avait figé uniquement les 55 `data-attr` landing → signup.

## Linear

Fixes AXE-356

## GitHub issue

Closes #128

## Validation

- [x] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks` → `OK - pre-push terminé sans erreur.`
- [x] Docs only (pas de code produit)
- [x] Aucun secret commité

## Test plan

- [ ] Relire `docs/analytics-naming.md` : deux stacks bien séparés, aucun rename proposé
- [ ] Vérifier les 4 issues filles sur Linear (parent AXE-356, projet Tagging)
- [ ] CRM : section 7 (pas de doc cousin dans ce repo)
- [ ] C.9 : transport `/app` = event_log first-party (pas GA4)

## Risk and rollback

- Risk: faible (docs). Un mauvais freeze de nom serait plus coûteux plus tard — d’où le « ne jamais renommer en prod ».
- Rollback: revert des commits docs.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Ajout d’un référentiel complet des conventions de nommage analytics pour le site et l’application.
  * Documentation des événements, propriétés, identifiants, consentements et règles d’opt-out.
  * Mise à jour des guides de taggage et de recette GA4 avec des liens vers ce référentiel.
  * Ajout de liens rapides vers les nouvelles ressources analytics dans la documentation principale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->