### PR TITLE
feat(AXE-396): baliser data-attr /app hors candidatures

### DIFF
--- a/docs/analytics-naming.md
+++ b/docs/analytics-naming.md
@@ -96,13 +96,13 @@ SPA bundle (`entry-conditional.js`) seulement sur `/`, `/login`, `/app/*`. Le re
 
 | Route | `view` | Sections `data-analytics-section` (déjà là) | Events métier déjà émis | `data-attr` |
 |---|---|---|---|---|
-| `/app/cv` | `cv` | `cv_workspace`, `chat`, `preview`, `export` | adaptation\*, `adapt_cta_clicked`, `job_description_pasted`, `template_changed`, `cv_manually_edited`, `ats_details_opened`, `adaptation_rated`, `base_cv_pdf_downloaded`, `first_offer_nudge_cta`, onboarding\* | **C.11 + C.12 figés** (8 + 11) — markup [AXE-396](https://linear.app/axel-project/issue/AXE-396) |
+| `/app/cv` | `cv` | `cv_workspace`, `chat`, `preview`, `export` | adaptation\*, `adapt_cta_clicked`, `job_description_pasted`, `template_changed`, `cv_manually_edited`, `ats_details_opened`, `adaptation_rated`, `base_cv_pdf_downloaded`, `first_offer_nudge_cta`, onboarding\* | **C.11 + C.12 posés** (8 + 11) — clics **non** relayés |
 | `/app/postule` | `candidatures` | `candidatures_board`, `candidatures_stats`, `candidatures_list_mobile` | `new_candidature_workspace`, `adapt_cta_clicked`, backend statut / refus / source offre | **C.9 posé** (7 IDs) — clics **non** relayés |
-| `/app/profil` `/app/linkedin` | `profil` | `profil_editor` | `base_cv_pdf_downloaded` (profil), backend `profile_saved` | **C.13 figé** (6) — `/app/linkedin` = `profil`, pas d’IDs `linkedin-*` |
-| `/app/settings` | `settings` | `settings_page` | `promo_code_redeemed` (backend) | **C.14 figé** (5) |
-| `/app/support` | `support` | `support_page` | — | **C.15 figé** (6) |
-| `/app/monitoring` | `monitoring` | `monitoring_dashboard` | — | **C.16 figé** (1, compte support) |
-| toutes `/app/*` | — | — | — | **C.10 topbar** (12 `app-nav-*`) |
+| `/app/profil` `/app/linkedin` | `profil` | `profil_editor` | `base_cv_pdf_downloaded` (profil), backend `profile_saved` | **C.13 posé** (6) — `/app/linkedin` = `profil`, pas d’IDs `linkedin-*` |
+| `/app/settings` | `settings` | `settings_page` | `promo_code_redeemed` (backend) | **C.14 posé** (5) |
+| `/app/support` | `support` | `support_page` | — | **C.15 posé** (6) |
+| `/app/monitoring` | `monitoring` | `monitoring_dashboard` | — | **C.16 posé** (1, compte support) |
+| toutes `/app/*` | — | — | — | **C.10 topbar posé** (12 `app-nav-*`) |
 
 `EVENT_LOGIN` (`login`) est **déclaré** dans `event_log.py`, **jamais émis**. Ticket fille : émettre ou retirer ([AXE-397](https://linear.app/axel-project/issue/AXE-397)).
 
@@ -248,7 +248,7 @@ Créés dans le projet [Tagging interne & externe](https://linear.app/axel-proje
 |---|---|---|---|
 | 1 | [AXE-394](https://linear.app/axel-project/issue/AXE-394) | Whitelist events orphelins produit | 3 `trackEvent` droppés (400) |
 | 2 | [AXE-395](https://linear.app/axel-project/issue/AXE-395) | Inventaire figé `data-attr` /app hors candidatures | **49 IDs** C.10–C.16 dans [`taggage-analytics.md`](taggage-analytics.md) |
-| 3 | [AXE-396](https://linear.app/axel-project/issue/AXE-396) | Balisage `data-attr` /app hors candidatures | pose les IDs d’AXE-395 |
+| 3 | [AXE-396](https://linear.app/axel-project/issue/AXE-396) | Balisage `data-attr` /app hors candidatures | pose les 49 IDs C.10–C.16 |
 | 4 | [AXE-397](https://linear.app/axel-project/issue/AXE-397) | Émettre `login` produit **ou** retirer `EVENT_LOGIN` | constante morte |
 
 AXE-396 est bloqué par AXE-395.

--- a/docs/taggage-analytics.md
+++ b/docs/taggage-analytics.md
@@ -448,7 +448,7 @@ Globaux : **pas** de préfixe de page (`nav-`, `footer-`).
 | Surfaces A/B non-clic | Conservées dans le catalogue : `home-hero-title`, `home-pricing-card-free`, `home-pricing-card-pro`, `home-pricing-badge-popular` |
 | C.8 / v2 | Exclue de la vague 1 (drawer tertiaires, sources outbound FAQ, `faq_open`, cookie banner) |
 | C.9 candidatures | Hors vague 1 (déjà figé 2026-08-21) — ne pas retoucher |
-| C.10–C.16 `/app` hors candidatures | Figé 2026-08-25 ([AXE-395](https://linear.app/axel-project/issue/AXE-395)) : **49** IDs. Markup : [AXE-396](https://linear.app/axel-project/issue/AXE-396). Préfixe topbar `app-nav-` (≠ `nav-` marketing). |
+| C.10–C.16 `/app` hors candidatures | Figé 2026-08-25 ([AXE-395](https://linear.app/axel-project/issue/AXE-395)) : **49** IDs. Markup posé ([AXE-396](https://linear.app/axel-project/issue/AXE-396)). Préfixe topbar `app-nav-` (≠ `nav-` marketing). |
 | AXE-356 | Convention site-wide : [`docs/analytics-naming.md`](analytics-naming.md) (figé 2026-08-25). 358 reste l’instance landing → signup |
 
 Attributs HTML types :
@@ -630,7 +630,7 @@ V2 candidatures (ne pas poser maintenant) : ouverture carte, archive, drag colon
 ### C.10–C.16 App connectée hors candidatures — **figé 2026-08-25** ([AXE-395](https://linear.app/axel-project/issue/AXE-395))
 
 Même convention kebab `page-zone-type-intention`. Un ID = un élément. Jamais de doublon avec les 55 public ni C.9.  
-Transport : recette DOM seulement (`track.js` ignore `/app`). Markup : [AXE-396](https://linear.app/axel-project/issue/AXE-396).
+Transport : recette DOM seulement (`track.js` ignore `/app`). **Markup posé** ([AXE-396](https://linear.app/axel-project/issue/AXE-396)).
 
 **Total = 49** : 12 topbar + 8 onboarding + 11 cv + 6 profil + 5 settings + 6 support + 1 monitoring.
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -575,7 +575,7 @@ function SupportTicketSection() {
                 required
               />
               {error && <p className="support-ticket-error">{error}</p>}
-              <button type="submit" className="button button-primary support-ticket-submit" disabled={loading}>
+              <button type="submit" className="button button-primary support-ticket-submit" disabled={loading} {...analyticsAttrs('support-ticket-cta-submit', 'ticket', 'primary', 'cta')}>
                 {loading ? 'Envoi…' : 'Envoyer le ticket'}
               </button>
             </form>
@@ -3495,6 +3495,7 @@ export default function App() {
                   onClick={requestNewCandidatureWorkspace}
                   disabled={adapting}
                   title="Vider le chat et l’aperçu pour adapter ton CV à une autre offre (sans supprimer tes candidatures enregistrées)"
+                  {...analyticsAttrs('cv-header-cta-new', 'header', 'secondary', 'cta')}
                 >
                   Nouvelle candidature
                 </button>
@@ -3524,7 +3525,7 @@ export default function App() {
                 const rem = usage.adaptations_quota_remaining ?? (usage.adaptations_limit - usage.adaptations_used);
                 return rem <= 0 ? 'Tes adaptations gratuites sont épuisées.' : `Il te reste ${rem} adaptation${rem > 1 ? 's' : ''} gratuite${rem > 1 ? 's' : ''}.`;
               })()}</span>
-              <button type="button" className="button button-primary button--sm" onClick={handleUpgradeClick} disabled={checkoutLoading}>
+              <button type="button" className="button button-primary button--sm" onClick={handleUpgradeClick} disabled={checkoutLoading} {...analyticsAttrs('cv-banner-cta-upgrade', 'banner', 'primary', 'cta')}>
                 {checkoutLoading ? '…' : 'Passer Pro - 10€/mois'}
               </button>
             </div>
@@ -3673,6 +3674,7 @@ export default function App() {
                                     )
                                   )
                                 }
+                                {...analyticsAttrs('cv-todo-cta-run', 'todo', 'primary', 'cta')}
                               >
                                 Valider et lancer
                               </Button>
@@ -3778,8 +3780,9 @@ export default function App() {
                   onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleChatSend(); } }}
                   rows={1}
                   disabled={adapting || adaptPlanLoading || (!!adaptTodoPlan && !lastAdaptedCv)}
+                  {...analyticsAttrs('cv-chat-input-offer', 'chat', 'tertiary', 'input')}
                 />
-                <button type="button" className="cv-chat-input-send" onClick={handleChatSend} disabled={adapting || adaptPlanLoading || !chatInput.trim() || (!!adaptTodoPlan && !lastAdaptedCv)} aria-label="Envoyer">
+                <button type="button" className="cv-chat-input-send" onClick={handleChatSend} disabled={adapting || adaptPlanLoading || !chatInput.trim() || (!!adaptTodoPlan && !lastAdaptedCv)} aria-label="Envoyer" {...analyticsAttrs('cv-chat-cta-send', 'chat', 'primary', 'cta')}>
                   <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M22 2L11 13"/><path d="M22 2L15 22L11 13L2 9L22 2Z"/></svg>
                 </button>
               </div>
@@ -3808,6 +3811,7 @@ export default function App() {
                       onClick={downloadBaseCvPdf}
                       disabled={baseCvPdfLoading}
                       title="Télécharger ton CV de profil (sans adaptation) en PDF, avec le template et les options actuels"
+                      {...analyticsAttrs('cv-preview-cta-base-pdf', 'preview', 'secondary', 'cta')}
                     >
                       <span className="tpl-btn-bar-extra-icon" aria-hidden>
                         <HiArrowDownTray size={16} strokeWidth={2} />
@@ -3978,6 +3982,7 @@ export default function App() {
                           aria-expanded={atsScoreOpen}
                           aria-haspopup="dialog"
                           aria-controls="ats-score-modal"
+                          {...analyticsAttrs('cv-export-cta-ats', 'export', 'tertiary', 'cta')}
                         >
                           <span className="ats-score-pill-label">Score ATS</span>
                           {rapportBefore?.score_global != null && rapportBefore.score_global !== rapport.score_global ? (
@@ -4046,8 +4051,8 @@ export default function App() {
                     </>
                   )}
                   <div className="cv-chat-export-btns">
-                    <button type="button" className="button button-success" onClick={handlePdf} disabled={exporting}>Télécharger le PDF</button>
-                    <button type="button" className="button button-secondary" onClick={handleExportDossier} disabled={exporting} aria-busy={exporting}>
+                    <button type="button" className="button button-success" onClick={handlePdf} disabled={exporting} {...analyticsAttrs('cv-export-cta-pdf', 'export', 'primary', 'cta')}>Télécharger le PDF</button>
+                    <button type="button" className="button button-secondary" onClick={handleExportDossier} disabled={exporting} aria-busy={exporting} {...analyticsAttrs('cv-export-cta-dossier', 'export', 'secondary', 'cta')}>
                       {exporting ? (
                         <>
                           <span className="export-spinner" aria-hidden="true" />
@@ -4699,6 +4704,7 @@ export default function App() {
                       type="button"
                       className="support-usecase-card support-usecase-card--clickable"
                       onClick={() => navigate(topic.route, { state: { supportHighlight: { route: topic.route, selector: topic.selector, title: topic.bubbleTitle, content: topic.bubbleContent, position: topic.position, ...(topic.openTemplateOptions && { openTemplateOptions: true }) } } })}
+                      {...analyticsAttrs(`support-topic-${topic.id}`, 'topic', 'tertiary', 'nav')}
                     >
                       <div className="support-usecase-icon-wrap">
                         <Icon className="support-usecase-icon" aria-hidden />
@@ -4892,6 +4898,7 @@ export default function App() {
                     requestAnimationFrame(() => cvChatInputRef.current?.focus());
                     trackEvent('first_offer_nudge_cta', { action: 'go_cv' });
                   }}
+                  {...analyticsAttrs('cv-nudge-cta-go', 'nudge', 'primary', 'cta')}
                 >
                   Coller une offre
                 </button>
@@ -4905,6 +4912,7 @@ export default function App() {
                     } catch (_) { /* ignore */ }
                     trackEvent('first_offer_nudge_cta', { action: 'dismiss' });
                   }}
+                  {...analyticsAttrs('cv-nudge-cta-dismiss', 'nudge', 'secondary', 'cta')}
                 >
                   Plus tard
                 </button>

--- a/frontend/src/components/AppTopbar.jsx
+++ b/frontend/src/components/AppTopbar.jsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { NavLink } from 'react-router-dom';
 import { HiDocumentText, HiClipboardDocumentList, HiPencilSquare, HiChatBubbleLeftRight, HiChartBarSquare, HiCog6Tooth } from 'react-icons/hi2';
+import { analyticsAttrs } from '../lib/analyticsAttrs.js';
 import TopbarPartnerCode from './TopbarPartnerCode';
 
 import BetaModeToggle from './BetaModeToggle.jsx';
@@ -46,28 +47,28 @@ export default function AppTopbar({
         <span className="topbar-brand">AxeL Job</span>
       </div>
       <nav className="topbar-nav">
-        <NavLink to="/app/cv" className={({ isActive }) => `topbar-link ${isActive ? 'active' : ''}`}>
+        <NavLink to="/app/cv" className={({ isActive }) => `topbar-link ${isActive ? 'active' : ''}`} {...analyticsAttrs('app-nav-link-cv', 'nav', 'tertiary', 'nav')}>
           <HiDocumentText size={18} />
           <span>Adapter CV</span>
         </NavLink>
-        <NavLink to="/app/postule" className={({ isActive }) => `topbar-link ${isActive ? 'active' : ''}`}>
+        <NavLink to="/app/postule" className={({ isActive }) => `topbar-link ${isActive ? 'active' : ''}`} {...analyticsAttrs('app-nav-link-candidatures', 'nav', 'tertiary', 'nav')}>
           <HiClipboardDocumentList size={18} />
           <span>Candidatures</span>
         </NavLink>
-        <NavLink to="/app/profil" className={({ isActive }) => `topbar-link ${isActive ? 'active' : ''}`}>
+        <NavLink to="/app/profil" className={({ isActive }) => `topbar-link ${isActive ? 'active' : ''}`} {...analyticsAttrs('app-nav-link-profil', 'nav', 'tertiary', 'nav')}>
           <HiPencilSquare size={18} />
           <span>Profil</span>
         </NavLink>
-        <NavLink to="/app/settings" className={({ isActive }) => `topbar-link ${isActive ? 'active' : ''}`}>
+        <NavLink to="/app/settings" className={({ isActive }) => `topbar-link ${isActive ? 'active' : ''}`} {...analyticsAttrs('app-nav-link-settings', 'nav', 'tertiary', 'nav')}>
           <HiCog6Tooth size={18} />
           <span>Paramètres</span>
         </NavLink>
-        <NavLink to="/app/support" className={({ isActive }) => `topbar-link ${isActive ? 'active' : ''}`}>
+        <NavLink to="/app/support" className={({ isActive }) => `topbar-link ${isActive ? 'active' : ''}`} {...analyticsAttrs('app-nav-link-support', 'nav', 'tertiary', 'nav')}>
           <HiChatBubbleLeftRight size={18} />
           <span>Support</span>
         </NavLink>
         {usage?.is_support && (
-          <NavLink to="/app/monitoring" className={({ isActive }) => `topbar-link ${isActive ? 'active' : ''}`}>
+          <NavLink to="/app/monitoring" className={({ isActive }) => `topbar-link ${isActive ? 'active' : ''}`} {...analyticsAttrs('app-nav-link-monitoring', 'nav', 'tertiary', 'nav')}>
             <HiChartBarSquare size={18} />
             <span>Monitoring</span>
           </NavLink>
@@ -76,12 +77,12 @@ export default function AppTopbar({
       <div className="topbar-right">
         {session && <BetaModeToggle />}
         {session && usage && usage.plan !== 'pro' && (
-          <button type="button" className="topbar-upgrade-btn" onClick={onUpgradeClick} disabled={checkoutLoading}>
+          <button type="button" className="topbar-upgrade-btn" onClick={onUpgradeClick} disabled={checkoutLoading} {...analyticsAttrs('app-nav-cta-upgrade', 'nav', 'primary', 'cta')}>
             {checkoutLoading ? '…' : 'Passer Pro'}
           </button>
         )}
         {session && usage && usage.plan === 'pro' && (
-          <button type="button" className="topbar-pro-badge" onClick={onProBadgeClick}>
+          <button type="button" className="topbar-pro-badge" onClick={onProBadgeClick} {...analyticsAttrs('app-nav-cta-pro', 'nav', 'secondary', 'cta')}>
             Pro
           </button>
         )}
@@ -95,6 +96,7 @@ export default function AppTopbar({
               aria-haspopup="menu"
               aria-controls="topbar-account-menu"
               title="Compte et déconnexion"
+              {...analyticsAttrs('app-nav-cta-account', 'account', 'tertiary', 'cta')}
             >
               <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="8" r="4"/><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/></svg>
             </button>
@@ -114,6 +116,7 @@ export default function AppTopbar({
                     setAccountMenuOpen(false);
                     onCookieSettingsClick?.();
                   }}
+                  {...analyticsAttrs('app-nav-cta-cookies', 'account', 'tertiary', 'cta')}
                 >
                   Paramètres cookies
                 </button>
@@ -126,6 +129,7 @@ export default function AppTopbar({
                     setAccountMenuOpen(false);
                     onSignOutClick();
                   }}
+                  {...analyticsAttrs('app-nav-cta-signout', 'account', 'tertiary', 'cta')}
                 >
                   Déconnexion
                 </button>

--- a/frontend/src/components/MonitoringDashboard.jsx
+++ b/frontend/src/components/MonitoringDashboard.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { apiGet } from '../api';
 import { HiChartBarSquare } from 'react-icons/hi2';
+import { analyticsAttrs } from '../lib/analyticsAttrs.js';
 
 const DAY_OPTIONS = [7, 14, 30];
 
@@ -123,7 +124,7 @@ export default function MonitoringDashboard({ usage }) {
               ))}
             </select>
           </label>
-          <button type="button" className="button button-secondary monitoring-refresh" onClick={load} disabled={loading}>
+          <button type="button" className="button button-secondary monitoring-refresh" onClick={load} disabled={loading} {...analyticsAttrs('monitoring-header-cta-refresh', 'header', 'secondary', 'cta')}>
             {loading ? 'Chargement…' : 'Actualiser'}
           </button>
         </div>

--- a/frontend/src/components/OnboardingWizard.jsx
+++ b/frontend/src/components/OnboardingWizard.jsx
@@ -1,5 +1,6 @@
 import { useState, useRef } from 'react';
 import { apiPost, apiPostFile, apiPut, trackEvent } from '../api';
+import { analyticsAttrs } from '../lib/analyticsAttrs.js';
 import { cvFromImportPayload } from '../lib/cvImportUtils.js';
 import '../styles/OnboardingWizard.css';
 
@@ -123,7 +124,7 @@ export default function OnboardingWizard({ session, onComplete }) {
             {error && <div className="onb-error">{error}</div>}
 
             <div className="onb-methods">
-              <button type="button" className="onb-method-card" onClick={() => fileRef.current?.click()} disabled={loading}>
+              <button type="button" className="onb-method-card" onClick={() => fileRef.current?.click()} disabled={loading} {...analyticsAttrs('onboarding-methods-cta-import', 'methods', 'primary', 'cta')}>
                 <div className="onb-method-icon">
                   <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
                     <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M12 18v-6"/><path d="M9 15l3-3 3 3"/>
@@ -133,7 +134,7 @@ export default function OnboardingWizard({ session, onComplete }) {
                 <span className="onb-method-desc">PDF texte ou Word (.docx) — pas de PDF scanné</span>
               </button>
 
-              <button type="button" className="onb-method-card" onClick={handleManual} disabled={loading}>
+              <button type="button" className="onb-method-card" onClick={handleManual} disabled={loading} {...analyticsAttrs('onboarding-methods-cta-manual', 'methods', 'secondary', 'cta')}>
                 <div className="onb-method-icon">
                   <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
                     <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
@@ -153,12 +154,14 @@ export default function OnboardingWizard({ session, onComplete }) {
                   onChange={(e) => setCvText(e.target.value)}
                   placeholder="Copie-colle le contenu de ton CV ici..."
                   rows={6}
+                  {...analyticsAttrs('onboarding-paste-input-text', 'paste', 'tertiary', 'input')}
                 />
                 <button
                   type="button"
                   className="button button-primary onb-btn-parse"
                   onClick={handleTextImport}
                   disabled={loading || !cvText.trim()}
+                  {...analyticsAttrs('onboarding-paste-cta-parse', 'paste', 'secondary', 'cta')}
                 >
                   {loading && method === 'text' ? 'Analyse en cours…' : 'Analyser mon CV'}
                 </button>
@@ -237,7 +240,7 @@ export default function OnboardingWizard({ session, onComplete }) {
             </div>
 
             <div className="onb-actions">
-              <button type="button" className="button button-primary" onClick={handleConfirmProfile} disabled={loading}>
+              <button type="button" className="button button-primary" onClick={handleConfirmProfile} disabled={loading} {...analyticsAttrs('onboarding-review-cta-confirm', 'review', 'primary', 'cta')}>
                 {loading ? 'Sauvegarde…' : 'On continue'}
               </button>
             </div>
@@ -257,10 +260,10 @@ export default function OnboardingWizard({ session, onComplete }) {
               Colle une annonce et l'IA fera le reste.
             </p>
             <div className="onb-actions">
-              <button type="button" className="button button-primary button--lg" onClick={handleLaunch}>
+              <button type="button" className="button button-primary button--lg" onClick={handleLaunch} {...analyticsAttrs('onboarding-done-cta-launch', 'done', 'primary', 'cta')}>
                 Créer mon CV adapté
               </button>
-              <button type="button" className="button ds-button ds-button--link onb-actions__link" onClick={handleGoToProfile}>
+              <button type="button" className="button ds-button ds-button--link onb-actions__link" onClick={handleGoToProfile} {...analyticsAttrs('onboarding-done-cta-profil', 'done', 'secondary', 'cta')}>
                 Compléter mon profil d&apos;abord
               </button>
             </div>
@@ -268,7 +271,7 @@ export default function OnboardingWizard({ session, onComplete }) {
         )}
 
         {step === 0 && (
-          <button type="button" className="onb-skip" onClick={() => { trackEvent('onboarding_skipped', {}); onComplete('candidatures'); }}>
+          <button type="button" className="onb-skip" onClick={() => { trackEvent('onboarding_skipped', {}); onComplete('candidatures'); }} {...analyticsAttrs('onboarding-cta-skip', 'overlay', 'tertiary', 'cta')}>
             Passer pour l'instant
           </button>
         )}

--- a/frontend/src/components/ProfileView.jsx
+++ b/frontend/src/components/ProfileView.jsx
@@ -21,6 +21,7 @@ import { applyA4PageFramesToDocument, syncCvPreviewIframeHeight } from '../lib/c
 import { buildBetaToStableOffer } from '../lib/designModeBridge.js';
 import { betaCanvasRenderFields } from '../lib/betaCanvasTemplate.js';
 import { HiArrowDownTray } from 'react-icons/hi2';
+import { analyticsAttrs } from '../lib/analyticsAttrs.js';
 import '../styles/ProfileView.css';
 import '../styles/TemplatePicker.css';
 import '../styles/DesignModeBridgeModal.css';
@@ -825,11 +826,11 @@ export default function ProfileView({ onSaveSuccess, session, refreshKey, usage,
         <p className="profile-subtitle">Complète tes informations. Le CV est généré à partir de ces données.</p>
         <div className="profile-header-actions">
           <input ref={importFileRef} type="file" accept=".pdf,.docx,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document" style={{ display: 'none' }} onChange={handleImportCv} />
-          <button type="button" className="btn btn-import-cv" onClick={() => importFileRef.current?.click()} disabled={importLoading}>
+          <button type="button" className="btn btn-import-cv" onClick={() => importFileRef.current?.click()} disabled={importLoading} {...analyticsAttrs('profil-header-cta-import', 'header', 'secondary', 'cta')}>
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
             {importLoading ? 'Import…' : 'Importer un CV'}
           </button>
-          <button type="button" className="button button-primary profile-save-btn" onClick={handleSave} disabled={saving}>
+          <button type="button" className="button button-primary profile-save-btn" onClick={handleSave} disabled={saving} {...analyticsAttrs('profil-header-cta-save', 'header', 'primary', 'cta')}>
             {saving ? 'Enregistrement…' : 'Enregistrer les modifications'}
           </button>
         </div>
@@ -1128,11 +1129,12 @@ export default function ProfileView({ onSaveSuccess, session, refreshKey, usage,
                       className="button button-secondary profile-btn-cancel-sub"
                       onClick={() => setCancelSubModalOpen(true)}
                       disabled={cancelSubLoading}
+                      {...analyticsAttrs('profil-billing-cta-cancel', 'billing', 'tertiary', 'cta')}
                     >
                       Résilier mon abonnement
                     </button>
                     {typeof onBillingPortalClick === 'function' && (
-                      <button type="button" className="button button-secondary" onClick={onBillingPortalClick}>
+                      <button type="button" className="button button-secondary" onClick={onBillingPortalClick} {...analyticsAttrs('profil-billing-cta-portal', 'billing', 'tertiary', 'cta')}>
                         Facturation &amp; moyens de paiement (Stripe)
                       </button>
                     )}
@@ -1146,7 +1148,7 @@ export default function ProfileView({ onSaveSuccess, session, refreshKey, usage,
                 Le détail Stripe n&apos;est pas disponible pour l&apos;instant (connexion ou synchronisation). Tu peux ouvrir le portail de facturation pour gérer ton abonnement.
               </p>
               {typeof onBillingPortalClick === 'function' && (
-                <button type="button" className="button button-secondary" onClick={onBillingPortalClick}>
+                <button type="button" className="button button-secondary" onClick={onBillingPortalClick} {...analyticsAttrs('profil-billing-cta-portal', 'billing', 'tertiary', 'cta')}>
                   Ouvrir le portail de facturation
                 </button>
               )}
@@ -1204,7 +1206,7 @@ export default function ProfileView({ onSaveSuccess, session, refreshKey, usage,
       )}
 
       <div className="profile-footer">
-        <button type="button" className="button button-primary" onClick={handleSave} disabled={saving}>
+        <button type="button" className="button button-primary" onClick={handleSave} disabled={saving} {...analyticsAttrs('profil-footer-cta-save', 'footer', 'primary', 'cta')}>
           {saving ? 'Enregistrement…' : 'Enregistrer le CV'}
         </button>
       </div>
@@ -1234,6 +1236,7 @@ export default function ProfileView({ onSaveSuccess, session, refreshKey, usage,
                 onClick={downloadBaseCvPdf}
                 disabled={baseCvPdfLoading || loading}
                 title="Télécharger ton CV de profil (tel qu’affiché dans l’aperçu) en PDF"
+                {...analyticsAttrs('profil-preview-cta-pdf', 'preview', 'secondary', 'cta')}
               >
                 <span className="tpl-btn-bar-extra-icon" aria-hidden>
                   <HiArrowDownTray size={16} strokeWidth={2} />

--- a/frontend/src/components/SettingsView.jsx
+++ b/frontend/src/components/SettingsView.jsx
@@ -22,6 +22,7 @@ import {
 } from '../lib/settingsLocalData.js';
 import BetaModeToggle from './BetaModeToggle.jsx';
 import Button from './ui/Button.jsx';
+import { analyticsAttrs } from '../lib/analyticsAttrs.js';
 import '../styles/app/settings.css';
 
 const PDF_VARIABLES = ['{prenom}', '{nom}', '{poste}', '{entreprise}'];
@@ -369,16 +370,17 @@ export default function SettingsView({
               setSetPasswordConfirm('');
               setSetPasswordError('');
             }}
+            {...analyticsAttrs('settings-account-cta-password', 'account', 'secondary', 'cta')}
           >
             Mot de passe
           </Button>
           {usage && !isPro && typeof onUpgradeClick === 'function' && (
-            <Button type="button" variant="primary" size="sm" onClick={onUpgradeClick}>
+            <Button type="button" variant="primary" size="sm" onClick={onUpgradeClick} {...analyticsAttrs('settings-account-cta-upgrade', 'account', 'primary', 'cta')}>
               Passer Pro
             </Button>
           )}
           {usage && isPro && usage.stripe_subscription && typeof onBillingPortalClick === 'function' && (
-            <Button type="button" variant="secondary" size="sm" onClick={onBillingPortalClick}>
+            <Button type="button" variant="secondary" size="sm" onClick={onBillingPortalClick} {...analyticsAttrs('settings-account-cta-billing', 'account', 'secondary', 'cta')}>
               Gérer l&apos;abonnement
             </Button>
           )}
@@ -440,7 +442,7 @@ export default function SettingsView({
           </div>
         </div>
         <div className="settings-actions">
-          <Button type="button" variant="primary" size="sm" onClick={saveExportPrefs}>
+          <Button type="button" variant="primary" size="sm" onClick={saveExportPrefs} {...analyticsAttrs('settings-export-cta-save', 'export', 'primary', 'cta')}>
             Enregistrer
           </Button>
           <Button
@@ -527,7 +529,7 @@ export default function SettingsView({
       <SettingsSection id="settings-privacy-title" title="Confidentialité" lead="Cookies et documents légaux.">
         {typeof onCookieSettingsClick === 'function' && (
           <div className="settings-actions settings-actions--spaced">
-            <Button type="button" variant="secondary" size="sm" onClick={onCookieSettingsClick}>
+            <Button type="button" variant="secondary" size="sm" onClick={onCookieSettingsClick} {...analyticsAttrs('settings-privacy-cta-cookies', 'privacy', 'tertiary', 'cta')}>
               Paramètres cookies
             </Button>
           </div>

--- a/frontend/src/components/TopbarPartnerCode.jsx
+++ b/frontend/src/components/TopbarPartnerCode.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { apiPost } from '../api';
+import { analyticsAttrs } from '../lib/analyticsAttrs.js';
 
 /**
  * Saisie code partenaire / concours (menu compte).
@@ -49,6 +50,7 @@ export default function TopbarPartnerCode({ onSuccess }) {
           disabled={loading}
           maxLength={32}
           aria-label="Code partenaire ou concours"
+          {...analyticsAttrs('app-nav-input-promo', 'account', 'tertiary', 'input')}
         />
         <button
           type="submit"

--- a/frontend/tests/unit/appDataAttr.test.js
+++ b/frontend/tests/unit/appDataAttr.test.js
@@ -1,0 +1,125 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FRONTEND_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+
+/** C.10–C.16 figés AXE-395, posés AXE-396. */
+const FROZEN_IDS = [
+  'app-nav-link-cv',
+  'app-nav-link-candidatures',
+  'app-nav-link-profil',
+  'app-nav-link-settings',
+  'app-nav-link-support',
+  'app-nav-link-monitoring',
+  'app-nav-cta-upgrade',
+  'app-nav-cta-pro',
+  'app-nav-cta-account',
+  'app-nav-cta-cookies',
+  'app-nav-cta-signout',
+  'app-nav-input-promo',
+  'onboarding-methods-cta-import',
+  'onboarding-methods-cta-manual',
+  'onboarding-paste-input-text',
+  'onboarding-paste-cta-parse',
+  'onboarding-review-cta-confirm',
+  'onboarding-done-cta-launch',
+  'onboarding-done-cta-profil',
+  'onboarding-cta-skip',
+  'cv-header-cta-new',
+  'cv-banner-cta-upgrade',
+  'cv-chat-input-offer',
+  'cv-chat-cta-send',
+  'cv-todo-cta-run',
+  'cv-preview-cta-base-pdf',
+  'cv-export-cta-pdf',
+  'cv-export-cta-dossier',
+  'cv-export-cta-ats',
+  'cv-nudge-cta-go',
+  'cv-nudge-cta-dismiss',
+  'profil-header-cta-import',
+  'profil-header-cta-save',
+  'profil-footer-cta-save',
+  'profil-preview-cta-pdf',
+  'profil-billing-cta-cancel',
+  'profil-billing-cta-portal',
+  'settings-account-cta-password',
+  'settings-account-cta-upgrade',
+  'settings-account-cta-billing',
+  'settings-export-cta-save',
+  'settings-privacy-cta-cookies',
+  'support-topic-adapter-cv',
+  'support-topic-exporter-pdf',
+  'support-topic-suivre-candidatures',
+  'support-topic-modifier-texte-cv',
+  'support-topic-personnaliser-couleurs',
+  'support-ticket-cta-submit',
+  'monitoring-header-cta-refresh',
+];
+
+const SUPPORT_TOPIC_IDS = [
+  'adapter-cv',
+  'exporter-pdf',
+  'suivre-candidatures',
+  'modifier-texte-cv',
+  'personnaliser-couleurs',
+];
+
+const SOURCE_FILES = [
+  'src/components/AppTopbar.jsx',
+  'src/components/TopbarPartnerCode.jsx',
+  'src/components/OnboardingWizard.jsx',
+  'src/App.jsx',
+  'src/components/ProfileView.jsx',
+  'src/components/SettingsView.jsx',
+  'src/components/MonitoringDashboard.jsx',
+];
+
+function idsFromSource(text) {
+  const fromHelper = [...text.matchAll(/analyticsAttrs\('([a-z0-9-]+)'/g)].map((m) => m[1]);
+  const fromAttr = [...text.matchAll(/\bdata-attr="([a-z0-9-]+)"/g)].map((m) => m[1]);
+  return [...fromHelper, ...fromAttr];
+}
+
+test('AXE-396 : 49 data-attr C.10–C.16 posés une fois via analyticsAttrs', async () => {
+  assert.equal(FROZEN_IDS.length, 49);
+
+  const texts = {};
+  for (const rel of SOURCE_FILES) {
+    texts[rel] = await readFile(path.join(FRONTEND_ROOT, rel), 'utf8');
+  }
+  const blob = Object.values(texts).join('\n');
+  const collected = Object.values(texts).flatMap(idsFromSource);
+
+  assert.ok(
+    texts['src/App.jsx'].includes("analyticsAttrs(`support-topic-${topic.id}`"),
+    'support topics : template analyticsAttrs',
+  );
+  for (const topicId of SUPPORT_TOPIC_IDS) {
+    assert.ok(
+      texts['src/App.jsx'].includes(`id: '${topicId}'`),
+      `SUPPORT_TOPICS id ${topicId}`,
+    );
+    collected.push(`support-topic-${topicId}`);
+  }
+
+  const counts = Object.create(null);
+  for (const id of collected) {
+    counts[id] = (counts[id] || 0) + 1;
+  }
+
+  for (const id of FROZEN_IDS) {
+    const n = counts[id] || 0;
+    if (id === 'profil-billing-cta-portal') {
+      assert.ok(n >= 1 && n <= 2, `${id} attendu 1–2 (états Stripe), got ${n}`);
+      continue;
+    }
+    assert.equal(n, 1, `${id} attendu 1 fois, got ${n}`);
+  }
+
+  for (const id of FROZEN_IDS) {
+    assert.equal(blob.includes(`[data-attr="${id}"]`), false, `pas de sélecteur CSS pour ${id}`);
+  }
+});


### PR DESCRIPTION
## Summary
- Pose les **49** `data-attr` C.10–C.16 via `analyticsAttrs()` (topbar, onboarding, `/app/cv`, profil, settings, support, monitoring).
- Recette DOM : inspect. `track.js` ignore `/app` (test `isMarketingPath` déjà là).
- Test unitaire `frontend/tests/unit/appDataAttr.test.js` : chaque ID une fois (portail Stripe 1–2).

## Why
Sans markup, le freeze AXE-395 ne sert pas la recette. Pas de tracker `/app` v1.

## Linear

Fixes AXE-396

## GitHub issue

Closes #203

## Test plan
- [x] `node --test tests/unit/appDataAttr.test.js`
- [x] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks` → OK
- [ ] Recette connecté : inspect topbar `app-nav-link-cv`, onboarding skip, chat send, save profil (header **et** footer), settings cookies, support topic, monitoring refresh
- [ ] Confirmer qu’un clic `/app` n’émet pas `cta_click` GA4

## Risk and rollback
- Risk: markup only, aucun event marketing nouveau.
- Rollback: revert du commit.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * Les principales actions de l’application disposent désormais d’un suivi analytique plus complet : navigation, onboarding, profil, paramètres, monitoring, candidatures, exports et support.
  * Les boutons et champs concernés conservent leur comportement habituel.

* **Documentation**
  * La documentation des balises analytiques a été actualisée pour refléter la couverture des écrans et des actions disponibles.

* **Qualité**
  * Des contrôles automatisés vérifient la présence, l’unicité et la cohérence des identifiants analytiques.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->