### PR TITLE
docs(AXE-366): spike Sentry Job — org, sampling, PII, hors CMP

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ Point d'entree de la documentation technique, securite et operations.
 | Appliquer la baseline securite | `docs/security.md` |
 | Secrets Cursor Cloud / `.env` local | [README.md](../README.md) (section Cursor Cloud Agents) + `scripts/materialize_dotenv.py` |
 | Deployer en production | `docs/deploy.md` |
+| Observabilite Sentry (spike AXE-366) | [docs/observabilite.md](observabilite.md) |
 | Utiliser les commandes ops courantes | `docs/ops-commands.md` |
 | Acceder a la version courte des commandes | `docs/COMMANDS.md` |
 | Comprendre la vision editeur L1->L3 et le scoring ATS | `docs/editor-vision.md` |

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -10,6 +10,7 @@ Reference de deploiement `cv-bot` avec Docker.
 4. Mise a jour
 5. Configuration critique
 6. Checklist production
+7. Sentry (observabilite)
 
 ## 1) Prerequis
 
@@ -74,3 +75,14 @@ docker compose up -d
 - [ ] Workflow securite CI vert.
 
 Pour les commandes d'exploitation quotidiennes, voir `docs/ops-commands.md`.
+
+## 7) Sentry (observabilite)
+
+Decisions figées : [`docs/observabilite.md`](observabilite.md) ([AXE-366](https://linear.app/axel-project/issue/AXE-366)).
+
+- Pas de SDK tant que [AXE-367](https://linear.app/axel-project/issue/AXE-367) / [AXE-368](https://linear.app/axel-project/issue/AXE-368) ne sont pas livrés.
+- DSN vide = no-op (dev / CI). Variables : ticket [AXE-369](https://linear.app/axel-project/issue/AXE-369).
+- `VITE_SENTRY_DSN` et `VITE_SENTRY_ENVIRONMENT` sont des **build args** Docker (comme `VITE_AXEL_GTM_ID`), pas du runtime.
+- `SENTRY_AUTH_TOKEN` : secret de build uniquement, jamais dans l'image.
+- Session Replay : **off**. CV / annonce : **jamais** dans un event.
+- Recette post-deploy : [AXE-371](https://linear.app/axel-project/issue/AXE-371).

--- a/docs/guide-bonnes-pratiques.md
+++ b/docs/guide-bonnes-pratiques.md
@@ -110,6 +110,7 @@ Contrat : `docs/design-system.md`. Tokens : `frontend/src/design/tokens.json` (`
 - Retourner des codes HTTP coherents avec des messages actionnables cote client.
 - Eviter de logger des secrets ou donnees personnelles brutes dans les logs.
 - Preserver les endpoints d'ops (`/health`, `/metrics`) et leur securisation.
+- Sentry : decisions [`docs/observabilite.md`](observabilite.md) — erreurs 100 %, traces 0.1 en prod, Replay off, hors CMP.
 
 ---
 

--- a/docs/observabilite.md
+++ b/docs/observabilite.md
@@ -1,0 +1,132 @@
+# Observabilité AxeL Job — Sentry (AXE-366)
+
+Spike : [AXE-366](https://linear.app/axel-project/issue/AXE-366) · 2026-08-26  
+Décalque CRM : [AXE-22](https://linear.app/axel-project/issue/AXE-22) (Done), [AXE-271](https://linear.app/axel-project/issue/AXE-271) (sampling front), [AXE-269](https://linear.app/axel-project/issue/AXE-269) (alertes), [AXE-270](https://linear.app/axel-project/issue/AXE-270) (pas de routes de test).  
+Consentement : même logique que [AXE-363](https://linear.app/axel-project/issue/AXE-363) (PostHog = CMP / Sentry ≠ CMP).
+
+**Pas de SDK dans ce ticket.** Code : [AXE-367](https://linear.app/axel-project/issue/AXE-367) (backend), [AXE-368](https://linear.app/axel-project/issue/AXE-368) (frontend), [AXE-369](https://linear.app/axel-project/issue/AXE-369) (env), [AXE-370](https://linear.app/axel-project/issue/AXE-370) (contextes métier), [AXE-371](https://linear.app/axel-project/issue/AXE-371) (recette + alertes).
+
+---
+
+## Verdict
+
+**Go Sentry** pour le diagnostic d’erreurs (front React + back FastAPI).  
+**Pas** un outil analytics. **Pas** de Session Replay. **Pas** derrière la CMP.
+
+État `main` (août 2026) : 0 dépendance Sentry, 0 DSN, Prometheus seulement (`monitoring_ops.py` / `/metrics`). Ça reste : Prometheus = volume ; Sentry = stack + contexte.
+
+---
+
+## Décisions figées
+
+### Org / projets
+
+| | Décision |
+|---|---|
+| Org | Réutiliser l’org CRM **`axel-project`** ([axel-project.sentry.io](https://axel-project.sentry.io)) — mêmes membres, même canal d’alerte email ([AXE-269](https://linear.app/axel-project/issue/AXE-269)) |
+| Projets Job | **2 nouveaux** : `axel-job-frontend` et `axel-job-backend` (DSN distincts). **Ne pas** réutiliser `javascript-react` / `python-fastapi` (CRM) |
+| Région | Org actuelle = **US** `sentry.io` (comme le CRM). Écart vs « EU obligatoire » du ticket : **accepté** — le CV ne doit **jamais** partir (scrub), les autres sous-traitants US (Supabase, Stripe, Gemini) sont déjà déclarés avec CCT. Si un org EU (`de.sentry.io`) est créé plus tard : seuls les DSN changent |
+
+Créer les deux projets **avant** [AXE-367](https://linear.app/axel-project/issue/AXE-367) / [AXE-368](https://linear.app/axel-project/issue/AXE-368) (sinon no-op silencieux en prod).
+
+### Sampling
+
+Leçon CRM [AXE-271](https://linear.app/axel-project/issue/AXE-271) : un build Vite Docker a `MODE=production` même sur staging. **Ne pas** dériver le sample rate du `import.meta.env.MODE`. Utiliser `VITE_SENTRY_ENVIRONMENT`.
+
+| Environnement | Erreurs | Traces | Profiling | Replay |
+|---|---|---|---|---|
+| local / CI (`SENTRY_DSN` / `VITE_SENTRY_DSN` vide) | no-op | no-op | off | off |
+| `staging` | 100 % | 100 % (`1.0`) | off | **off** |
+| `production` | 100 % | 10 % (`0.1`) | off | **off** |
+
+Backend : `SENTRY_ENVIRONMENT` sinon `ENVIRONMENT`. Frontend : `VITE_SENTRY_ENVIRONMENT` (défaut `production` seulement si la variable est absente **et** qu’un DSN est posé).
+
+### PII — liste noire (never send)
+
+`send_default_pii=False`. `before_send` / `beforeSend` + filtrage breadcrumbs.
+
+| Jamais | Exemples |
+|---|---|
+| Contenu de CV | JSON `cv`, HTML preview, PDF, texte collé, photo |
+| Texte d’annonce | `annonce`, job description, `offer_text` |
+| Identifiants nominatifs | email, nom, téléphone, adresse |
+| Secrets | JWT Supabase, `GEMINI_API_KEY`, `STRIPE_*`, `SUPABASE_SERVICE_KEY`, `SENTRY_AUTH_TOKEN` |
+| Corps HTTP sensibles | `POST /api/adapt*`, `/api/import*`, `/api/cv*`, webhooks Stripe |
+| Chemins fichiers utilisateur | uploads locaux |
+| `setUser` | **pas d’email**. `id` = UUID Supabase (opaque) + tag `plan` = `free` \| `pro` |
+
+OK : route, status HTTP, `flow`, moteur PDF, durée, taille fichier, code d’erreur fournisseur, `release`, `environment`.
+
+### Consentement (RGPD)
+
+| | Décision |
+|---|---|
+| Base légale | **Intérêt légitime** art. 6(1)(f) — sécurité / continuité du service (diagnostic d’erreurs techniques) |
+| CMP | **Hors CMP.** Refuser « Mesure d’audience » ne doit **pas** couper Sentry (sinon on est aveugles sur `/app`) |
+| vs PostHog / GA4 | Analytics = consentement ([AXE-363](https://linear.app/axel-project/issue/AXE-363) no-go PostHog ; GA4 derrière la bannière). Sentry ≠ mesure d’audience |
+| Session Replay | **Non** tant que l’éditeur affiche un CV. Un replay = capture d’écran de données pro + coordonnées → consentement + risque inacceptable |
+| Information | Ligne sous-traitant + finalité dans `/confidentialite` (**HTML et JSX**, ils divergent déjà) |
+
+### Session Replay / autres signaux
+
+- Replay : **off**, et le rester (critère [AXE-368](https://linear.app/axel-project/issue/AXE-368)).
+- Autocapture / tracing des corps `fetch` : URL ok, body **strip** sur adapt/import/cv.
+- Pages HTML statiques (FAQ, ATS, guides) : **pas** de SDK v1. SPA seulement (`/`, `/login`, `/app/*`) — même périmètre que `entry-conditional.js`.
+- Pas de route `/sentry-test` en prod ([AXE-270](https://linear.app/axel-project/issue/AXE-270)).
+
+### Environnements et releases
+
+| Tag Sentry | Source |
+|---|---|
+| `environment` | `staging` \| `production` (local = DSN vide, no-op) |
+| `release` | SHA git du **build Docker** (`SENTRY_RELEASE` / `VITE_SENTRY_RELEASE`) — pour attacher les source maps |
+
+`ENVIRONMENT=production` dans `docker-compose.yml` prod. Staging DO : poser `VITE_SENTRY_ENVIRONMENT=staging` au build front (leçon AXE-271).
+
+---
+
+## Variables (pour [AXE-369](https://linear.app/axel-project/issue/AXE-369))
+
+Aucune n’est à committer en dur. DSN vide = no-op (dev + CI).
+
+| Variable | Où | Rôle |
+|---|---|---|
+| `SENTRY_DSN` | backend runtime | DSN `axel-job-backend` |
+| `VITE_SENTRY_DSN` | **build arg** frontend (comme `VITE_AXEL_GTM_ID`) | DSN `axel-job-frontend` |
+| `SENTRY_ENVIRONMENT` | backend runtime | sinon `ENVIRONMENT` |
+| `VITE_SENTRY_ENVIRONMENT` | build arg frontend | tag + sample rate traces ; **ne pas** utiliser `MODE` |
+| `SENTRY_RELEASE` | build backend | SHA git |
+| `VITE_SENTRY_RELEASE` | build arg frontend | SHA git (source maps) |
+| `SENTRY_TRACES_SAMPLE_RATE` | optionnel, les deux | override ; défauts = tableau sampling |
+| `SENTRY_AUTH_TOKEN` | **secret de build uniquement** | upload source maps — **jamais** dans l’image finale |
+
+`.env.example` + `frontend/Dockerfile` ARG : ticket 369, pas ici.
+
+---
+
+## Mention `/confidentialite` (posée dans ce spike)
+
+À garder alignée HTML (`frontend/public/confidentialite.html`) **et** React (`LegalPages.jsx`) :
+
+- Finalité : diagnostic des erreurs techniques / sécurité du service — **intérêt légitime**.
+- Sous-traitant : Functional Software, Inc. (Sentry) — diagnostic d’erreurs, hors CMP.
+- Cookies : Sentry n’est **pas** un traceur de mesure d’audience ; pas dans la bannière GA4.
+
+---
+
+## Suite (ordre)
+
+1. **Ops** : créer `axel-job-frontend` + `axel-job-backend` dans l’org `axel-project` (Louis / admin Sentry).
+2. [AXE-369](https://linear.app/axel-project/issue/AXE-369) env/secrets (peut chevaucher 367/368).
+3. [AXE-367](https://linear.app/axel-project/issue/AXE-367) + [AXE-368](https://linear.app/axel-project/issue/AXE-368) en parallèle.
+4. [AXE-370](https://linear.app/axel-project/issue/AXE-370) contextes métier.
+5. [AXE-371](https://linear.app/axel-project/issue/AXE-371) smoke + alertes email high-priority (même recette que CRM AXE-269 : pas Slack v1).
+
+---
+
+## Hors scope v1
+
+- Grafana / logs Sentry / metrics Sentry (Prometheus reste).
+- Slack Sentry (CRM : email seulement).
+- Source maps des HTML statiques.
+- Replay, profiling, Crons, Seer AI comme prérequis.

--- a/docs/observabilite.md
+++ b/docs/observabilite.md
@@ -97,7 +97,8 @@ Aucune n’est à committer en dur. DSN vide = no-op (dev + CI).
 | `VITE_SENTRY_ENVIRONMENT` | build arg frontend | tag + sample rate traces ; **ne pas** utiliser `MODE` |
 | `SENTRY_RELEASE` | build backend | SHA git |
 | `VITE_SENTRY_RELEASE` | build arg frontend | SHA git (source maps) |
-| `SENTRY_TRACES_SAMPLE_RATE` | optionnel, les deux | override ; défauts = tableau sampling |
+| `SENTRY_TRACES_SAMPLE_RATE` | backend runtime, optionnel | override traces ; défauts = tableau sampling |
+| `VITE_SENTRY_TRACES_SAMPLE_RATE` | build arg frontend, optionnel | idem côté client (Vite n’expose que `VITE_*`) |
 | `SENTRY_AUTH_TOKEN` | **secret de build uniquement** | upload source maps — **jamais** dans l’image finale |
 
 `.env.example` + `frontend/Dockerfile` ARG : ticket 369, pas ici.
@@ -109,7 +110,8 @@ Aucune n’est à committer en dur. DSN vide = no-op (dev + CI).
 À garder alignée HTML (`frontend/public/confidentialite.html`) **et** React (`LegalPages.jsx`) :
 
 - Finalité : diagnostic des erreurs techniques / sécurité du service — **intérêt légitime**.
-- Sous-traitant : Functional Software, Inc. (Sentry) — diagnostic d’erreurs, hors CMP.
+- Données transmises (contrat 367/368) : stack traces, tags `environment` / `release`, identifiant technique de compte (UUID, pas l’e-mail), tag `plan` (`free` / `pro`).
+- Sous-traitant : Functional Software, Inc. (Sentry) — hors CMP.
 - Cookies : Sentry n’est **pas** un traceur de mesure d’audience ; pas dans la bannière GA4.
 
 ---

--- a/docs/security.md
+++ b/docs/security.md
@@ -52,6 +52,7 @@ Cette politique couvre :
 - Stocker les secrets uniquement dans l'environnement d'execution.
 - Ne pas logger de JWT, cles API, payloads complets contenant des donnees personnelles.
 - Masquer ou tronquer les donnees sensibles dans les traces d'erreur.
+- Sentry (quand branché) : `send_default_pii=False`, scrub CV / annonce / email / JWT — [`docs/observabilite.md`](observabilite.md). Pas de Session Replay.
 
 ## 6) Checklist securite avant merge
 

--- a/frontend/public/confidentialite.html
+++ b/frontend/public/confidentialite.html
@@ -45,7 +45,7 @@
         <main class="legal-container legal-content">
           <h1>Politique de confidentialité</h1>
           <p>Conformément au RGPD (Règlement UE 2016/679) et à la loi « Informatique et Libertés ».</p>
-          <p><em>Dernière mise à jour : 21 mars 2026</em></p>
+          <p><em>Dernière mise à jour : 26 août 2026</em></p>
 
           <h2>1. Responsable du traitement</h2>
           <ul>
@@ -108,6 +108,10 @@
                 <td>Réponse aux demandes de contact</td>
                 <td>Intérêt légitime</td>
               </tr>
+              <tr>
+                <td>Diagnostic des erreurs techniques et sécurité du service (Sentry)</td>
+                <td>Intérêt légitime</td>
+              </tr>
             </tbody>
           </table>
 
@@ -141,6 +145,10 @@
                 <td>Google Ireland Limited (Google Tag Manager, Google Analytics)</td>
                 <td>Mesure d’audience et, le cas échéant, publicité - uniquement avec votre consentement (bannière ou « Paramètres cookies »)</td>
               </tr>
+              <tr>
+                <td>Functional Software, Inc. (Sentry)</td>
+                <td>Diagnostic des erreurs techniques (stack traces, tags d’environnement). Hors bandeau cookies. Aucun contenu de CV ni d’annonce n’est envoyé.</td>
+              </tr>
             </tbody>
           </table>
           <p>Ces sous-traitants sont établis hors de l'Union européenne. Les transferts de données sont encadrés par des garanties appropriées conformes au RGPD (clauses contractuelles types approuvées par la Commission européenne).</p>
@@ -159,6 +167,7 @@
           <h2>8. Cookies et traceurs</h2>
           <p>Le site <strong>job.axelproject.fr</strong> utilise des cookies strictement nécessaires au fonctionnement du service (session, authentification, préférences, sécurité, paiement). Ils sont dispensés de consentement préalable dans les conditions fixées par la CNIL pour les cookies « strictement nécessaires ».</p>
           <p>Les traceurs liés à la mesure d’audience (Google Tag Manager, Google Analytics) et, le cas échéant, à la publicité, ne sont activés qu’après votre accord via la bannière cookies ou le lien « Paramètres cookies ». Vous pouvez modifier ou retirer votre consentement à tout moment ; le choix est enregistré dans votre navigateur (localStorage).</p>
+          <p>Le diagnostic d’erreurs (Sentry) n’est pas un traceur de mesure d’audience : il n’est pas soumis à ce bandeau. Il sert à la sécurité et à la continuité du service (intérêt légitime). Le Session Replay Sentry n’est pas activé.</p>
 
           <h2>9. Vos droits</h2>
           <p>Conformément au RGPD, vous disposez des droits suivants sur vos données personnelles :</p>

--- a/frontend/public/confidentialite.html
+++ b/frontend/public/confidentialite.html
@@ -147,7 +147,7 @@
               </tr>
               <tr>
                 <td>Functional Software, Inc. (Sentry)</td>
-                <td>Diagnostic des erreurs techniques (stack traces, tags d’environnement). Hors bandeau cookies. Aucun contenu de CV ni d’annonce n’est envoyé.</td>
+                <td>Diagnostic des erreurs techniques (stack traces, tags d’environnement et de version, identifiant technique de compte sans e-mail, type d’abonnement gratuit/pro). Hors bandeau cookies. Aucun contenu de CV ni d’annonce n’est envoyé.</td>
               </tr>
             </tbody>
           </table>

--- a/frontend/src/components/LegalPages.jsx
+++ b/frontend/src/components/LegalPages.jsx
@@ -97,8 +97,10 @@ function PolitiqueConfidentialite() {
           et, le cas échéant, publicité ; uniquement si vous y consentez via la bannière cookies)
         </li>
         <li>
-          <strong>Functional Software, Inc. (Sentry)</strong> — diagnostic des erreurs techniques.
-          Hors bandeau cookies (intérêt légitime). Aucun contenu de CV ni d’annonce n’est envoyé.
+          <strong>Functional Software, Inc. (Sentry)</strong> — diagnostic des erreurs techniques
+          (stack traces, tags d’environnement et de version, identifiant technique de compte sans e-mail,
+          type d’abonnement gratuit/pro). Hors bandeau cookies (intérêt légitime).
+          Aucun contenu de CV ni d’annonce n’est envoyé.
         </li>
       </ul>
 

--- a/frontend/src/components/LegalPages.jsx
+++ b/frontend/src/components/LegalPages.jsx
@@ -52,7 +52,7 @@ function PolitiqueConfidentialite() {
   return (
     <>
       <h1>Politique de confidentialité</h1>
-      <p><em>Dernière mise à jour : mars 2026</em></p>
+      <p><em>Dernière mise à jour : août 2026</em></p>
 
       <h2>1. Responsable du traitement</h2>
       <p>
@@ -75,13 +75,14 @@ function PolitiqueConfidentialite() {
         <li>Fournir le service de génération et d'adaptation de CV par IA.</li>
         <li>Gérer votre compte utilisateur et vos abonnements.</li>
         <li>Améliorer le service (métriques anonymisées).</li>
-        <li>Assurer la sécurité du service.</li>
+        <li>Assurer la sécurité du service, y compris le diagnostic des erreurs techniques (Sentry, intérêt légitime).</li>
       </ul>
 
       <h2>4. Base légale</h2>
       <p>
-        Le traitement est fondé sur l'exécution du contrat (fourniture du service) et le consentement
-        de l'utilisateur lors de l'inscription.
+        Le traitement est fondé sur l'exécution du contrat (fourniture du service), le consentement
+        de l'utilisateur lors de l'inscription, et l'intérêt légitime pour la sécurité du service
+        (diagnostic des erreurs techniques via Sentry).
       </p>
 
       <h2>5. Partage des données</h2>
@@ -94,6 +95,10 @@ function PolitiqueConfidentialite() {
         <li>
           <strong>Google Ireland Limited</strong> (Google Tag Manager, Google Analytics - mesure d’audience
           et, le cas échéant, publicité ; uniquement si vous y consentez via la bannière cookies)
+        </li>
+        <li>
+          <strong>Functional Software, Inc. (Sentry)</strong> — diagnostic des erreurs techniques.
+          Hors bandeau cookies (intérêt légitime). Aucun contenu de CV ni d’annonce n’est envoyé.
         </li>
       </ul>
 
@@ -129,6 +134,10 @@ function PolitiqueConfidentialite() {
         à la publicité, ne sont activés qu’après votre accord, via le bandeau de consentement ou le lien
         « Paramètres cookies ». Vous pouvez retirer ou modifier votre consentement à tout moment ; les choix
         sont mémorisés localement sur votre navigateur (localStorage).
+      </p>
+      <p>
+        Le diagnostic d’erreurs (Sentry) n’est pas un traceur de mesure d’audience et n’est pas soumis
+        à ce bandeau. Le Session Replay Sentry n’est pas activé.
       </p>
 
       <h2>9. Sécurité</h2>

--- a/frontend/tests/unit/confidentialiteSentry.test.js
+++ b/frontend/tests/unit/confidentialiteSentry.test.js
@@ -1,0 +1,23 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+test('confidentialite HTML + JSX déclarent Sentry hors CMP (AXE-366)', async () => {
+  const html = await readFile(path.join(ROOT, 'public/confidentialite.html'), 'utf8');
+  const jsx = await readFile(path.join(ROOT, 'src/components/LegalPages.jsx'), 'utf8');
+
+  for (const [label, text] of [
+    ['html', html],
+    ['jsx', jsx],
+  ]) {
+    assert.match(text, /Sentry/, `${label} mentionne Sentry`);
+    assert.match(text, /intérêt légitime/i, `${label} base légale`);
+    assert.match(text, /Session Replay/, `${label} Replay off`);
+    assert.match(text, /CV/, `${label} CV non envoyé`);
+    assert.match(text, /bandeau/, `${label} hors CMP`);
+  }
+});

--- a/frontend/tests/unit/confidentialiteSentry.test.js
+++ b/frontend/tests/unit/confidentialiteSentry.test.js
@@ -16,8 +16,30 @@ test('confidentialite HTML + JSX déclarent Sentry hors CMP (AXE-366)', async ()
   ]) {
     assert.match(text, /Sentry/, `${label} mentionne Sentry`);
     assert.match(text, /intérêt légitime/i, `${label} base légale`);
-    assert.match(text, /Session Replay/, `${label} Replay off`);
-    assert.match(text, /CV/, `${label} CV non envoyé`);
-    assert.match(text, /bandeau/, `${label} hors CMP`);
+    assert.match(
+      text,
+      /Session Replay[^.]*n['’]est pas activ[ée]/i,
+      `${label} Replay off`,
+    );
+    assert.match(
+      text,
+      /Aucun contenu de CV ni d['’]annonce n['’]est envoyé/i,
+      `${label} CV et annonce non envoyés`,
+    );
+    assert.match(
+      text,
+      /Sentry[\s\S]{0,400}(?:Hors bandeau cookies|n['’]est pas soumis)/i,
+      `${label} Sentry hors CMP`,
+    );
+    assert.match(
+      text,
+      /identifiant technique de compte sans e-mail/i,
+      `${label} UUID opaque, pas d’email`,
+    );
+    assert.match(
+      text,
+      /type d['’]abonnement gratuit\/pro/i,
+      `${label} tag plan`,
+    );
   }
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Spike **sans SDK**. Décisions figées dans [`docs/observabilite.md`](docs/observabilite.md).

- Org CRM `axel-project` · 2 projets Job `axel-job-frontend` / `axel-job-backend` (ne pas réutiliser les projets CRM).
- Erreurs 100 %, traces `0.1` prod / `1.0` staging · **Replay off**.
- `VITE_SENTRY_ENVIRONMENT` (pas `MODE`) — leçon AXE-271.
- PII : jamais CV, annonce, email, JWT, clés.
- Consentement : **intérêt légitime, hors CMP** (≠ GA4 / PostHog).
- Mention `/confidentialite` HTML **et** JSX (ils divergaient).
- Liste des env vars transmise à AXE-369.

## Why

Aucun monitoring d’erreurs Job. Avant d’installer un SDK, il fallait trancher org / sampling / PII / CMP — surtout à cause des CV.

## Linear

Fixes AXE-366

## Validation

- [x] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks` OK
- [x] `node --test frontend/tests/unit/confidentialiteSentry.test.js`

## Test plan

- [ ] Relire `docs/observabilite.md` : go / Replay off / hors CMP
- [ ] `/confidentialite` (HTML + SPA) : sous-traitant Sentry + intérêt légitime
- [ ] Créer les 2 projets Sentry dans l’org `axel-project` (ops, avant 367/368)

## Risk and rollback

- Risk: nul côté runtime (pas de SDK).
- Rollback: revert du commit docs.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Ajout d’une spécification complète de l’observabilité Sentry pour le frontend et le backend.
  - Mise à jour des guides de déploiement, des bonnes pratiques et de la politique de sécurité.
  - Ajout d’un lien vers la documentation d’observabilité.

- **Confidentialité**
  - Mise à jour de la politique de confidentialité avec les informations relatives à Sentry, à sa base légale et aux données transmises.
  - Confirmation de la désactivation du Session Replay et de l’absence de suivi d’audience.

- **Tests**
  - Ajout de vérifications automatisées couvrant les mentions Sentry dans les politiques de confidentialité.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->