### PR TITLE
docs(AXE-319): ADR + runbook main → prod (Option C)

### DIFF
--- a/.cursor/hooks/before-git-push.sh
+++ b/.cursor/hooks/before-git-push.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Bloque push vers main/master et exige la CI locale avant git push.
+# Bloque push vers main/master/prod et exige la CI locale avant git push.
 # Contournement d'urgence : SKIP_PREPUSH=1 git push …
 set -euo pipefail
 
@@ -24,7 +24,7 @@ cd "$repo_root" || {
 
 if ! bash "$repo_root/scripts/guard-push-via-pr.sh" --git-command "$command"; then
   printf '%s\n' "$(cat <<'EOF'
-{"permission":"deny","user_message":"Push direct vers main/master interdit - utiliser une branche et gh pr create.","agent_message":"Ne jamais git push origin main. Travailler sur une branche feature, lancer bash scripts/pre-push.sh --skip-extras --skip-gitleaks, puis git push -u origin HEAD et gh pr create --base main."}
+{"permission":"deny","user_message":"Push direct vers main/master/prod interdit - utiliser une branche et gh pr create.","agent_message":"Ne jamais git push origin main ni origin prod. main = integration, prod = production (docs/ADR_MAIN_PROD.md). Travailler sur une branche feature, lancer bash scripts/pre-push.sh --skip-extras --skip-gitleaks, puis git push -u origin HEAD et gh pr create --base main. Promote prod : gh pr create --base prod --head main."}
 EOF
 )"
   exit 2

--- a/.cursor/rules/pre-push-ci.mdc
+++ b/.cursor/rules/pre-push-ci.mdc
@@ -1,5 +1,5 @@
 ---
-description: CI locale + workflow PR (pas de push direct sur main)
+description: CI locale + workflow PR (pas de push direct sur main ni prod)
 alwaysApply: true
 ---
 
@@ -7,11 +7,14 @@ alwaysApply: true
 
 ## Règle principale
 
-**Ne jamais pousser directement sur `main` ou `master`.** Toute intégration passe par une branche de feature et une **Pull Request** (`gh pr create`).
+**Ne jamais pousser directement sur `main`, `master` ou `prod`.** Toute intégration **et** toute mise en production passent par une branche de feature (ou une PR promote) et une **Pull Request** (`gh pr create`).
+
+`main` **n'est pas** la prod. Décision : [`docs/ADR_MAIN_PROD.md`](docs/ADR_MAIN_PROD.md).
 
 Branches de travail typiques :
-- **`main`** - prod (merge via PR uniquement)
-- **`wip/innovation`** - dev éditeur Beta / canvas (PR Draft #33, voir `docs/git-workflow.md`)
+- **`main`** — intégration (merge via PR uniquement). Un merge ici **ne déploie pas**.
+- **`prod`** — production. Uniquement via PR **promote** `main` → `prod` (ou hotfix depuis `prod`). Jamais `git push origin prod`.
+- **`wip/innovation`** — dev éditeur Beta / canvas (PR Draft #33, voir `docs/git-workflow.md`)
 
 ## Avant push ou création de PR
 
@@ -27,13 +30,14 @@ Branches de travail typiques :
 
 ## Flux agent (recommandé)
 
-1. Travailler sur une branche de feature (ex. `wip/innovation`, `feat/…`, `fix/…`).
+1. Travailler sur une branche de feature (ex. `wip/innovation`, `feat/…`, `fix/…`, ou le `gitBranchName` Linear).
 2. Commits locaux.
 3. CI locale (`pre-push.sh --skip-extras --skip-gitleaks`).
 4. Push de la branche de feature vers `origin` (autorisé).
-5. **`gh pr create`** vers `main` - ne pas merger sans validation explicite de l'utilisateur.
+5. **`gh pr create` vers `main`** — ne pas merger sans validation explicite de l'utilisateur.
+6. **Ne pas** traiter ce merge comme un déploiement. La prod = PR `--base prod --head main` (runbook ADR), puis CD ou fallback `docs/deploy.md`.
 
-Ne pas utiliser `git push origin main` ni merger localement dans `main` puis pousser.
+Ne pas utiliser `git push origin main` ni `git push origin prod`, ni merger localement dans `main`/`prod` puis pousser.
 
 ## Outils (alignés CI)
 
@@ -53,7 +57,7 @@ bash scripts/setup-dev.sh
 # ou seulement : bash scripts/install-git-hooks.sh
 ```
 
-Les hooks bloquent aussi les push directs vers `main`/`master`.
+Les hooks bloquent aussi les push directs vers `main`/`master`/`prod`.
 
 ## Contournement (urgence uniquement)
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Hook Git : refuse push vers main/master + gate CI locale (scripts/pre-push.*).
+# Hook Git : refuse push vers main/master/prod + gate CI locale (scripts/pre-push.*).
 # Activer une fois : bash scripts/setup-dev.sh   ou   bash scripts/install-git-hooks.sh
 
 if [ -n "${SKIP_PREPUSH:-}" ]; then

--- a/docs/ADR_MAIN_PROD.md
+++ b/docs/ADR_MAIN_PROD.md
@@ -1,0 +1,124 @@
+# ADR : Option C — `main` = intégration, `prod` = production
+
+| | |
+| --- | --- |
+| **Statut** | Accepté (figé) |
+| **Date** | 2026-08-26 |
+| **Ticket** | [AXE-319](https://linear.app/axel-project/issue/AXE-319) |
+| **Projet** | [Axel Job — Déploiement prod](https://linear.app/axel-project/project/axel-job-deploiement-prod-branche-prod-cd-7a2f9ce7e5ed) |
+
+Décision d’architecture Git : les agents et l’équipe **ne traitent plus `main` comme la production**.
+
+Runbook quotidien : [`git-workflow.md`](git-workflow.md) · protections : [`branch-protections.md`](branch-protections.md) · serveur : [`deploy.md`](deploy.md).
+
+---
+
+## Contexte
+
+Jusqu’ici la doc du repo disait **`main` = prod** (pas de branche `prod` dédiée, contrairement au CRM / WhatsApp Inbox). Conséquences :
+
+- Merger une PR dans `main` était lu comme « c’est en prod ».
+- Le serveur se mettait à jour avec `git pull origin main`.
+- Un agent pouvait croire qu’un merge `main` déclenchait le déploiement.
+
+Le chantier [Déploiement prod](https://linear.app/axel-project/project/axel-job-deploiement-prod-branche-prod-cd-7a2f9ce7e5ed) aligne AxeL Job sur le modèle CRM : **intégration ≠ production**.
+
+`origin/prod` existe déjà. Au moment de cette ADR elle est **en retard** sur `origin/main` : le premier promote `main` → `prod` (PR dédiée) rattrape l’écart.
+
+---
+
+## Décision (Option C)
+
+| Branche | Rôle | Comment on y arrive |
+| --- | --- | --- |
+| **`main`** | Intégration. Code revu, CI verte, **pas** déployé en production. | PR feature / fix / `wip/innovation` → `main` |
+| **`prod`** | Production. C’est **la seule** branche que le serveur (ou le CD) checkout. | PR **promote** `main` → `prod` (ou hotfix depuis `prod`) |
+| **`wip/innovation`** | Chantier long éditeur Beta (PR Draft [#33](https://github.com/presidentaxel/Axeljob/pull/33)). | Ne merge **pas** tant que non prêt ; jamais directement vers `prod` |
+
+```mermaid
+flowchart LR
+  feat["feat/* · fix/* · gitBranchName Linear"] -->|"PR"| main["main (intégration)"]
+  wip["wip/innovation"] -->|"PR Draft #33"| main
+  main -->|"PR promote"| prod["prod (production)"]
+```
+
+**Ne jamais** `git push origin main` ni `git push origin prod`. Toute intégration **et** toute mise en production passent par une Pull Request.
+
+### Runbook — promote `main` → `prod`
+
+```bash
+gh pr create --base prod --head main \
+  --title "release: promote main → prod" \
+  --body "$(cat <<'EOF'
+## Summary
+Promote intégration (`main`) vers production (`prod`).
+
+## Linear
+Fixes AXE-XX
+
+## Test plan
+- [ ] CI verte sur cette PR
+- [ ] Après merge : CD auto (AXE-317) **ou** fallback serveur `docs/deploy.md`
+- [ ] `curl …/health` → ok
+EOF
+)"
+```
+
+Titre / body : garder `Fixes AXE-XX` si un ticket Linear suit cette release. Ne pas y coller des features isolées : le promote emporte **tout** `main` qui n’est pas déjà dans `prod`.
+
+### Runbook — hotfix prod
+
+1. Brancher depuis **`origin/prod`** (pas depuis `main`) :  
+   `git fetch origin && git checkout -b hotfix/<sujet> origin/prod`
+2. Fix minimal + tests + CI locale.
+3. PR **vers `prod`** → merge → deploy (CD ou fallback).
+4. **Backport** vers `main` : cherry-pick (ou PR `hotfix/…` → `main`) pour que le correctif ne disparaisse pas au prochain promote.
+
+---
+
+## Conséquences
+
+Pour les **agents** :
+
+- Une PR feature se base sur `main` et cible `main`. Ce n’est **pas** un déploiement.
+- Un merge dans `main` ne justifie **pas** un `git pull` sur le serveur de production.
+- La prod se met à jour uniquement après merge d’une PR dont la base est `prod`.
+- Push direct vers `main` **et** `prod` : interdit (hooks + `scripts/guard-push-via-pr.sh`).
+
+Pour le **serveur** : checkout `prod`, `git pull origin prod`. Plus de `git pull origin main` en production. Détail : [`deploy.md`](deploy.md).
+
+Pour le **chantier** : cette ADR fige **Option C**. Les tickets suivants livrent le câblage GitHub ; tant qu’ils ne sont pas mergés, le **comportement Git reste Option C**, le **déploiement auto** pas encore.
+
+| Ticket | Rôle | État au moment de l’ADR |
+| --- | --- | --- |
+| [AXE-316](https://linear.app/axel-project/issue/AXE-316) | CI sur les PR vers `prod` | In Review — [PR #168](https://github.com/presidentaxel/Axeljob/pull/168) |
+| [AXE-317](https://linear.app/axel-project/issue/AXE-317) | CD `deploy-prod.yml` sur `push` à `prod` seulement | Todo |
+| [AXE-318](https://linear.app/axel-project/issue/AXE-318) | Branch protection GitHub `main` + `prod` (Settings) | Todo — clics humains |
+| [AXE-319](https://linear.app/axel-project/issue/AXE-319) | Cette ADR + runbook + garde-fous locaux | Ce document |
+| [AXE-320](https://linear.app/axel-project/issue/AXE-320) | Smoke E2E promote + hotfix/backport | Backlog — bloqué par 316–319 |
+
+### Fallback jusqu’à AXE-317
+
+Le workflow CD n’existe pas encore. Après merge de la PR promote dans `prod` :
+
+1. Sur le serveur : `git fetch origin && git checkout prod && git pull origin prod`
+2. `docker compose build && docker compose up -d`
+3. Vérifier `/health`
+
+Si le CD est down plus tard : **même fallback**, toujours depuis `prod`, jamais depuis `main`.
+
+### Protections GitHub (AXE-318)
+
+Les hooks locaux bloquent déjà `main` / `master` / `prod` sur une machine configurée. GitHub Settings n’est **pas** encore coché : un admin peut encore pousser en urgence. Checklist : [`branch-protections.md`](branch-protections.md).
+
+---
+
+## Alternatives non retenues
+
+| Option | Idée | Pourquoi pas |
+| --- | --- | --- |
+| **A** — `main` = prod | Statu quo. Simple. | Un merge d’intégration = mise en prod. Pas de filet, pas d’alignement CRM. |
+| **B** — Git Flow (`develop` + `main`) | `develop` intégration, `main` prod. | Trois lignes de vie (`develop` / `main` / `wip/innovation`). Plus lourd que le besoin. |
+| **C** — `main` + `prod` | **Retenu.** Même vocabulaire que le CRM. | — |
+
+Ne pas réintroduire « `main` = prod » dans la doc, les règles Cursor, ou les scripts.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -124,7 +124,7 @@ docker compose logs --tail 100 backend
 
 ```bash
 cd /opt/cv-bot
-git pull origin main
+git fetch origin && git checkout prod && git pull origin prod
 docker compose build --no-cache backend
 docker compose up -d backend
 docker compose build --no-cache frontend
@@ -134,7 +134,7 @@ docker compose up -d frontend
 ### PowerShell (Windows)
 
 ```powershell
-git pull origin main
+git fetch origin; git checkout prod; git pull origin prod
 docker compose build --no-cache backend
 docker compose up -d backend
 docker compose build --no-cache frontend
@@ -161,15 +161,16 @@ docker compose restart frontend
 
 ## 7) Git (workflow PR)
 
-> Guide complet : **`docs/git-workflow.md`** (branches, PR Draft #33, FAQ).
+> Guide complet : **`docs/git-workflow.md`**. Décision : **`docs/ADR_MAIN_PROD.md`** (`main` = intégration, `prod` = production).
 
 ### Branches
 
 | Branche | Usage |
 | --- | --- |
-| `main` | Prod — merge **via PR uniquement** |
+| `main` | Intégration — merge **via PR uniquement**. **Pas** la prod. |
+| `prod` | Production — PR **promote** `main` → `prod` (ou hotfix depuis `prod`). Jamais de push direct. |
 | `wip/innovation` | Dev actif (éditeur Beta, import PDF, ATS) — PR **Draft** [#33](https://github.com/presidentaxel/Axeljob/pull/33), **ne pas merger** pour l'instant |
-| `feat/*`, `fix/*` | Petites évolutions mergeables indépendamment |
+| `feat/*`, `fix/*` | Petites évolutions mergeables vers `main`, puis promote vers `prod` |
 
 ### Bash (Linux / macOS) — quotidien sur `wip/innovation`
 
@@ -212,7 +213,7 @@ gh pr create --base main --title "fix: …" --body "…"
 > [!WARNING]
 > Ne pas committer de secrets (`.env`, cles API, tokens).
 >
-> **Ne jamais** `git push origin main` — toute intégration passe par PR.
+> **Ne jamais** `git push origin main` ni `git push origin prod` — intégration **et** mise en prod passent par PR.
 
 ## 8) Pre-push (CI + security locale)
 
@@ -225,15 +226,15 @@ bash scripts/setup-dev.sh
 # ou : make setup
 ```
 
-Branches : **`main`** = prod ; **`wip/innovation`** = dev éditeur Beta / canvas (PR Draft [#33](https://github.com/presidentaxel/Axeljob/pull/33), ne pas merger). Voir **`docs/git-workflow.md`**.
+Branches : **`main`** = intégration ; **`prod`** = production ; **`wip/innovation`** = dev éditeur Beta / canvas (PR Draft [#33](https://github.com/presidentaxel/Axeljob/pull/33), ne pas merger). Voir **`docs/git-workflow.md`** et **`docs/ADR_MAIN_PROD.md`**.
 
 Configure `.venv` (Black **24.10.0** comme GitHub), active le hook **pre-push** Git (`.githooks/`), et rappelle les hooks **Cursor** (`.cursor/hooks.json`).
 
 ### Cursor (tous les chats / agent)
 
-- **Règle** : `.cursor/rules/pre-push-ci.mdc` — CI locale avant push/PR ; **pas de push direct sur `main`**.
-- **Hook** : `.cursor/hooks.json` — bloque `git push` vers `main`/`master` et si la CI locale échoue (timeout 15 min).
-- Flux recommandé : branche feature → CI locale → `git push -u origin HEAD` → `gh pr create --base main`.
+- **Règle** : `.cursor/rules/pre-push-ci.mdc` — CI locale avant push/PR ; **pas de push direct sur `main` ni `prod`**.
+- **Hook** : `.cursor/hooks.json` — bloque `git push` vers `main`/`master`/`prod` et si la CI locale échoue (timeout 15 min).
+- Flux recommandé : branche feature → CI locale → `git push -u origin HEAD` → `gh pr create --base main`. Promote prod : `gh pr create --base prod --head main`.
 - Contournement urgence : `SKIP_PREPUSH=1 git push`.
 - Après modification de `hooks.json`, redémarrer Cursor si le hook ne se déclenche pas (onglet **Hooks** / canal **Hooks**).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,8 @@ Point d'entree de la documentation technique, securite et operations.
 | --- | --- |
 | Coder selon les standards du repo | `docs/guide-bonnes-pratiques.md` |
 | Contribuer (branches, PR, quality gates) | [docs/contributing.md](contributing.md) |
-| Workflow Git (main, wip/innovation, PR Draft) | [docs/git-workflow.md](git-workflow.md) |
+| Workflow Git (`main` intégration, `prod` production, wip/innovation) | [docs/git-workflow.md](git-workflow.md) |
+| ADR Option C : `main` ≠ prod (promote / hotfix) | [docs/ADR_MAIN_PROD.md](ADR_MAIN_PROD.md) |
 | Protections branches / passage push → PR | [docs/branch-protections.md](branch-protections.md) |
 | Workflow Linear ↔ GitHub (tickets AXE, liens, PR) | [docs/linear-github-workflow.md](linear-github-workflow.md) |
 | Conventions analytics (events, props, pages) | [docs/analytics-naming.md](analytics-naming.md) |
@@ -22,7 +23,7 @@ Point d'entree de la documentation technique, securite et operations.
 | Verifier la Definition of Done engineering | `docs/engineering-standards.md` |
 | Appliquer la baseline securite | `docs/security.md` |
 | Secrets Cursor Cloud / `.env` local | [README.md](../README.md) (section Cursor Cloud Agents) + `scripts/materialize_dotenv.py` |
-| Deployer en production | `docs/deploy.md` |
+| Deployer en production (branche `prod`, pas `main`) | [docs/deploy.md](deploy.md) · runbook [ADR_MAIN_PROD.md](ADR_MAIN_PROD.md) |
 | Observabilite Sentry (spike AXE-366) | [docs/observabilite.md](observabilite.md) |
 | Utiliser les commandes ops courantes | `docs/ops-commands.md` |
 | Acceder a la version courte des commandes | `docs/COMMANDS.md` |

--- a/docs/branch-protections.md
+++ b/docs/branch-protections.md
@@ -1,9 +1,9 @@
 # Protections branches GitHub (Axel Job / cv-bot)
 
 > Repo : [`presidentaxel/Axeljob`](https://github.com/presidentaxel/Axeljob) (**public**).  
-> Modèle branches : **`main` = prod** (pas de branche `prod` séparée comme CRM / WhatsApp Inbox).  
+> Modèle branches : **Option C** — **`main` = intégration**, **`prod` = production** ([`ADR_MAIN_PROD.md`](ADR_MAIN_PROD.md)).  
 > Workflow quotidien : [`git-workflow.md`](git-workflow.md) · Linear : [`linear-github-workflow.md`](linear-github-workflow.md).  
-> Pattern inspiré de `axel-crm/docs/BRANCH_PROTECTIONS.md` et `whatsapp-inbox/docs/equipe/branch-protections.md`.
+> Pattern aligné sur `axel-crm/docs/BRANCH_PROTECTIONS.md` et `whatsapp-inbox/docs/equipe/branch-protections.md`.
 
 ---
 
@@ -11,13 +11,17 @@
 
 | Contrôle | Statut | Notes |
 |----------|--------|-------|
-| Branch protection `main` | **Non activée** | Repo public → disponible sans GitHub Pro, mais **pas encore configurée** (API 404) |
+| Branch protection `main` | **Non activée** | Repo public → disponible sans GitHub Pro ; **pas encore configurée** (API 404). Ticket [AXE-318](https://linear.app/axel-project/issue/AXE-318) |
+| Branch protection `prod` | **Non activée** | Même ticket AXE-318 — clics Settings |
 | Repository rulesets | **Non activés** | Disponibles sur repo public ; à activer si on préfère rulesets aux classic rules |
-| CI sur PR | **Actif** | [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) + [`security.yml`](../.github/workflows/security.yml) |
-| CD auto | **Manuel** | Deploy serveur via `git pull origin main` + Docker — voir [`deploy.md`](deploy.md) |
-| Garde-fous locaux | **Actifs** | Hooks Git + Cursor (voir §2) |
+| CI sur PR vers `main` | **Actif** | [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) + [`security.yml`](../.github/workflows/security.yml) |
+| CI sur PR vers `prod` | **En cours** | [AXE-316](https://linear.app/axel-project/issue/AXE-316) — [PR #168](https://github.com/presidentaxel/Axeljob/pull/168) (In Review). Sur `main` aujourd’hui, `pull_request` ne liste pas encore `prod` |
+| CD auto sur `prod` | **Pas encore** | [AXE-317](https://linear.app/axel-project/issue/AXE-317) (`deploy-prod.yml`). **Fallback :** `git pull origin prod` + Docker — [`deploy.md`](deploy.md) |
+| Garde-fous locaux | **Actifs** | Hooks Git + Cursor (voir §2) — `main` / `master` / **`prod`** |
 
-**Conséquence :** GitHub n’empêche pas encore un admin de pousser direct sur `main`. La discipline équipe + les hooks locaux + la CI sur les PR sont les garde-fous effectifs aujourd’hui. **À faire :** activer la branch protection §4 (repo public → pas besoin de Pro).
+**Conséquence :** GitHub n’empêche pas encore un admin de pousser direct sur `main` ou `prod`. La discipline équipe + les hooks locaux + la CI sur les PR vers `main` sont les garde-fous effectifs aujourd’hui. **À faire :** activer la branch protection §4 (repo public → pas besoin de Pro).
+
+`origin/prod` **existe**. Elle peut être en retard sur `origin/main` tant que le premier promote n’est pas mergé.
 
 ---
 
@@ -27,10 +31,10 @@ Ces contrôles bloquent le push **depuis une machine configurée** ; ils ne remp
 
 | Mécanisme | Rôle |
 |-----------|------|
-| `scripts/guard-push-via-pr.sh` | Refuse un push dont la cible est `main` / `master` |
+| `scripts/guard-push-via-pr.sh` | Refuse un push dont la cible est `main` / `master` / **`prod`** |
 | `.githooks/pre-push` | Appelle le guard + lance la CI locale (`scripts/pre-push.sh`) |
-| `.cursor/hooks.json` | Bloque `git push` vers `main`/`master` depuis Cursor |
-| `.cursor/rules/pre-push-ci.mdc` | Règle agent : PR-first, jamais `git push origin main` |
+| `.cursor/hooks.json` | Bloque `git push` vers `main`/`master`/`prod` depuis Cursor |
+| `.cursor/rules/pre-push-ci.mdc` | Règle agent : PR-first, jamais `git push origin main` ni `origin prod` |
 
 Setup une fois par clone :
 
@@ -45,25 +49,29 @@ Contournement urgence uniquement : `SKIP_PREPUSH=1 git push` — à éviter sauf
 
 ## 3. Process équipe (obligatoire)
 
-1. **Pas de push direct sur** `main` — toujours une branche + **Pull Request**. Formats autorisés : `feat/*`, `fix/*`, `hotfix/*`, `wip/innovation`, ou le **`gitBranchName` Linear exact** (ex. `louisvedovato/axe-XX-…`).
-2. **Pas de force-push** sur `main`.
+1. **Pas de push direct sur** `main` **ni** `prod` — toujours une branche + **Pull Request**. Formats autorisés : `feat/*`, `fix/*`, `hotfix/*`, `wip/innovation`, ou le **`gitBranchName` Linear exact** (ex. `louisvedovato/axe-XX-…`).
+2. **Pas de force-push** sur `main` ni `prod`.
 3. CI locale verte avant push / PR :  
    `bash scripts/pre-push.sh --skip-extras --skip-gitleaks`
-4. Merge seulement si CI GitHub verte + review (ou validation explicite).
-5. Chantier long éditeur Beta : rester sur `wip/innovation` + [PR Draft #33](https://github.com/presidentaxel/Axeljob/pull/33) ; ne pas merger tant que non prêt.
+4. Merge feature seulement si CI GitHub verte + review (ou validation explicite) — **base = `main`**.
+5. Mise en production = PR **promote** `main` → `prod` ([runbook](ADR_MAIN_PROD.md)), pas un merge feature dans `prod`.
+6. Chantier long éditeur Beta : rester sur `wip/innovation` + [PR Draft #33](https://github.com/presidentaxel/Axeljob/pull/33) ; ne pas merger tant que non prêt.
 
 Hotfix prod cassée :
 
-1. Brancher depuis `main` : `git fetch origin && git checkout -b hotfix/<sujet> origin/main` (même famille `hotfix/*` que ci-dessus)
+1. Brancher depuis **`prod`** : `git fetch origin && git checkout -b hotfix/<sujet> origin/prod`
 2. Fix minimal + tests
-3. PR vers `main` → merge → redeploy serveur ([`deploy.md`](deploy.md))
-4. Documenter dans Linear ([`linear-github-workflow.md`](linear-github-workflow.md))
+3. PR vers **`prod`** → merge → deploy ([`deploy.md`](deploy.md) — CD ou fallback)
+4. **Backport** vers `main` (cherry-pick / PR)
+5. Documenter dans Linear ([`linear-github-workflow.md`](linear-github-workflow.md))
 
 ---
 
-## 4. Checklist branch protection `main` (à activer)
+## 4. Checklist branch protection (à activer — AXE-318)
 
-Settings → Branches → Add rule (`main`) — ou Rulesets équivalent :
+Settings → Branches → Add rule — ou Rulesets équivalent. **Deux règles** : `main` et `prod`.
+
+### 4.1 `main` (intégration)
 
 - [ ] Require a pull request before merging
 - [ ] Require approvals : **1** (défaut)
@@ -75,7 +83,14 @@ Settings → Branches → Add rule (`main`) — ou Rulesets équivalent :
 - [ ] Do not allow bypassing the above settings (recommandé : bloque aussi le bypass admin)
 - [ ] Restrict who can push → pas de push humain direct (admins seulement si besoin d’urgence **et** si le bypass n’est pas bloqué)
 
-Dès que c’est coché, un `git push origin main` est rejeté pour les acteurs couverts par la règle (même sans hooks locaux). Si le bypass admin reste autorisé, un admin peut encore pousser en urgence.
+### 4.2 `prod` (production)
+
+Même liste que §4.1, plus :
+
+- [ ] Require a pull request before merging — en pratique depuis `main` (promote) ou `hotfix/*`
+- [ ] Restrict who can push / merger (périmètre plus étroit que `main` si possible)
+
+Dès que c’est coché, un `git push origin main` ou `git push origin prod` est rejeté pour les acteurs couverts par la règle (même sans hooks locaux). Si le bypass admin reste autorisé, un admin peut encore pousser en urgence.
 
 ---
 
@@ -83,13 +98,14 @@ Dès que c’est coché, un `git push origin main` est rejeté pour les acteurs 
 
 | | Axel Job (ce repo) | CRM / WhatsApp Inbox |
 |--|--------------------|----------------------|
-| `main` | **Prod** | Staging / intégration |
-| Branche `prod` | Absente | Prod dédiée |
+| `main` | **Intégration** (Option C) | Staging / intégration |
+| Branche `prod` | **Présente** (`origin/prod`) | Prod dédiée |
 | Staging DO | Absent | Présent (WhatsApp) |
 | Visibilité repo | **Public** → branch protection possible sans Pro | Privé Free → Pro requis |
-| Garde-fous locaux | Hooks Git + Cursor | Discipline + env policies CD |
+| CD | **Pas encore** (AXE-317) — fallback `git pull origin prod` | `deploy-prod.yml` |
+| Garde-fous locaux | Hooks Git + Cursor (`main` + `prod`) | Discipline + env policies CD |
 
-Ne pas copier le flux `main` → `prod` ici : sur Axel Job, merger dans `main` met à jour la branche de prod Git ; le **déploiement serveur** reste une étape manuelle ([`deploy.md`](deploy.md)).
+Le flux `main` → `prod` **est** le modèle AxeL Job. Merger dans `main` met à jour l’intégration ; le **déploiement serveur** suit le merge dans `prod` ([`deploy.md`](deploy.md)).
 
 ---
 
@@ -97,8 +113,9 @@ Ne pas copier le flux `main` → `prod` ici : sur Axel Job, merger dans `main` m
 
 | Doc | Rôle |
 |-----|------|
+| [`ADR_MAIN_PROD.md`](ADR_MAIN_PROD.md) | Décision Option C + runbook promote / hotfix |
 | [`git-workflow.md`](git-workflow.md) | Branches, Draft #33, flux quotidien |
 | [`contributing.md`](contributing.md) | Quality gates, checklist PR |
 | [`linear-github-workflow.md`](linear-github-workflow.md) | Issues Linear ↔ PR |
-| [`deploy.md`](deploy.md) | Déploiement serveur après merge `main` |
+| [`deploy.md`](deploy.md) | Déploiement serveur depuis `prod` |
 | [`COMMANDS.md`](COMMANDS.md) | Aide-mémoire pre-push / hooks |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -22,7 +22,7 @@ Flux recommande pour produire des PR petites, lisibles et faciles a merger.
 > Branche = **exactement** le `gitBranchName` Linear (`louisvedovato/axe-XX-…`), titre PR `fix(AXE-XX): …` / `feat(AXE-XX): …`,
 > body avec `Fixes AXE-XX` + `Closes #N`, et attachments liens sur l'issue Linear.
 >
-> Workflow Git / PR-first (`main`, `wip/innovation`) : [`docs/git-workflow.md`](git-workflow.md).  
+> Workflow Git / PR-first (`main` = intégration, `prod` = production, `wip/innovation`) : [`docs/git-workflow.md`](git-workflow.md) · [`docs/ADR_MAIN_PROD.md`](ADR_MAIN_PROD.md).  
 > Protections branches : [`docs/branch-protections.md`](branch-protections.md).
 
 > [!TIP]

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -2,15 +2,19 @@
 
 Reference de deploiement `cv-bot` avec Docker.
 
+Branche Git de production : **`prod`**. `main` est l'integration — voir [`ADR_MAIN_PROD.md`](ADR_MAIN_PROD.md).
+
 ## Sommaire
 
 1. Prerequis
 2. Installation initiale
 3. Verification post-deploiement
-4. Mise a jour
-5. Configuration critique
-6. Checklist production
-7. Sentry (observabilite)
+4. Promote `main` → `prod`
+5. Mise a jour serveur (depuis `prod`)
+6. Configuration critique
+7. Checklist production
+8. Sentry (observabilite)
+9. Fallback CD (jusqu'a AXE-317)
 
 ## 1) Prerequis
 
@@ -22,10 +26,13 @@ Reference de deploiement `cv-bot` avec Docker.
 
 ## 2) Installation initiale
 
+Le clone par defaut GitHub pointe sur `main` (integration). En production, checkout **`prod`** avant le premier build.
+
 ```bash
 cd /opt
 git clone <repo-url> cv-bot
 cd cv-bot
+git checkout prod
 cp .env.example .env
 # renseigner les valeurs production dans .env
 docker compose build
@@ -46,16 +53,52 @@ Resultat attendu :
 - frontend actif ;
 - endpoint `/health` sur statut `ok`.
 
-## 4) Mise a jour
+## 4) Promote `main` → `prod`
+
+Rien n'arrive en production tant qu'une PR dont la **base** est `prod` n'est pas mergee.
+
+```bash
+gh pr create --base prod --head main \
+  --title "release: promote main → prod" \
+  --body "$(cat <<'EOF'
+## Summary
+Promote integration (`main`) vers production (`prod`).
+
+## Linear
+Fixes AXE-XX
+
+## Test plan
+- [ ] CI verte sur cette PR
+- [ ] Apres merge : CD (AXE-317) ou fallback §9
+- [ ] `curl …/health` → ok
+EOF
+)"
+```
+
+Hotfix urgence : brancher depuis `origin/prod`, PR vers `prod`, puis backport `main`. Detail : [`git-workflow.md`](git-workflow.md).
+
+> [!WARNING]
+> Ne pas merger une PR feature directement dans `prod` (sauf hotfix). Ne pas deployer depuis `main`.
+
+## 5) Mise a jour serveur (depuis `prod`)
+
+Apres merge de la PR promote (ou hotfix) dans `prod` :
 
 ```bash
 cd /opt/cv-bot
-git pull origin main
+git fetch origin
+git checkout prod
+git pull origin prod
 docker compose build
 docker compose up -d
 ```
 
-## 5) Configuration critique
+> [!WARNING]
+> Ne plus `git pull origin main` sur le serveur de production. `main` n'est plus la prod.
+
+Quand [AXE-317](https://linear.app/axel-project/issue/AXE-317) sera livre, un `push` sur `prod` declenchera le CD (`deploy-prod.yml`) et cette etape manuelle ne sera plus le chemin nominal — garder §9 si le CD est down.
+
+## 6) Configuration critique
 
 - Configurer un reverse proxy HTTPS (Caddy, nginx ou Cloudflare).
 - Definir un `METRICS_AUTH_TOKEN` robuste.
@@ -66,8 +109,10 @@ docker compose up -d
 > [!WARNING]
 > Ne pas deployer sans valider les variables d'environnement et le healthcheck.
 
-## 6) Checklist production
+## 7) Checklist production
 
+- [ ] PR promote (ou hotfix) mergee dans `prod` — pas un simple merge `main`.
+- [ ] Serveur sur la branche `prod` (`git rev-parse --abbrev-ref HEAD`).
 - [ ] Variables d'environnement completees et verifiees.
 - [ ] Build Docker ok.
 - [ ] Healthcheck valide.
@@ -76,7 +121,7 @@ docker compose up -d
 
 Pour les commandes d'exploitation quotidiennes, voir `docs/ops-commands.md`.
 
-## 7) Sentry (observabilite)
+## 8) Sentry (observabilite)
 
 Decisions figées : [`docs/observabilite.md`](observabilite.md) ([AXE-366](https://linear.app/axel-project/issue/AXE-366)).
 
@@ -86,3 +131,12 @@ Decisions figées : [`docs/observabilite.md`](observabilite.md) ([AXE-366](https
 - `SENTRY_AUTH_TOKEN` : secret de build uniquement, jamais dans l'image.
 - Session Replay : **off**. CV / annonce : **jamais** dans un event.
 - Recette post-deploy : [AXE-371](https://linear.app/axel-project/issue/AXE-371).
+
+## 9) Fallback CD (jusqu'a AXE-317)
+
+Le workflow GitHub `deploy-prod.yml` n'existe pas encore. Apres merge dans `prod` :
+
+1. Executer §5 a la main (toujours `prod`, jamais `main`).
+2. Verifier `/health`.
+
+Si le CD est down plus tard : **meme fallback**.

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -1,13 +1,18 @@
 # Workflow Git et Pull Requests
 
-Guide de référence pour ne pas se perdre entre **`main`** (prod), les branches de feature et le gros chantier **`wip/innovation`**.
+Guide de référence pour ne pas se perdre entre **`main`** (intégration), **`prod`** (production), les branches de feature et le gros chantier **`wip/innovation`**.
+
+Décision figée : [`ADR_MAIN_PROD.md`](ADR_MAIN_PROD.md) (Option C). Protections : [`branch-protections.md`](branch-protections.md). Serveur : [`deploy.md`](deploy.md).
 
 ## Vue d'ensemble
 
 ```mermaid
 flowchart LR
-  subgraph prod["Prod"]
+  subgraph integration["Intégration"]
     main["main"]
+  end
+  subgraph production["Production"]
+    prod["prod"]
   end
   subgraph dev["Développement"]
     wip["wip/innovation"]
@@ -15,16 +20,21 @@ flowchart LR
   end
   wip -->|"PR Draft #33"| main
   feat -->|"PR classique"| main
+  main -->|"PR promote"| prod
 ```
 
-| Branche | Rôle | Merge en prod |
+| Branche | Rôle | En production ? |
 | --- | --- | --- |
-| **`main`** | Production. Déployée. | - |
-| **`wip/innovation`** | Éditeur Beta, import PDF canvas, score ATS - **dev actif** | **Non** pour l'instant (PR en **Draft**) |
-| **`feat/*`**, **`fix/*`** | Petites évolutions ou correctifs isolés | Via PR quand prêt |
+| **`main`** | Intégration. Code revu, CI verte. | **Non.** Un merge dans `main` ne déploie pas. |
+| **`prod`** | Production. Cible du serveur / du CD. | **Oui**, après merge d’une PR dont la base est `prod`. |
+| **`wip/innovation`** | Éditeur Beta, import PDF canvas, score ATS — **dev actif** | **Non** (PR en **Draft**) |
+| **`feat/*`**, **`fix/*`**, `gitBranchName` Linear | Petites évolutions ou correctifs isolés | Via PR vers `main`, puis **promote** `main` → `prod` |
 
 > [!IMPORTANT]
-> **Ne jamais** `git push origin main`. Toute intégration passe par une **Pull Request**. Les hooks Git (`.githooks/pre-push`) et Cursor (`.cursor/hooks.json`) bloquent les push directs vers `main` / `master`.
+> **Ne jamais** `git push origin main` ni `git push origin prod`. Toute intégration **et** toute mise en production passent par une **Pull Request**. Les hooks Git (`.githooks/pre-push`) et Cursor (`.cursor/hooks.json`) bloquent les push directs vers `main` / `master` / `prod`.
+
+> [!WARNING]
+> Merger dans `main` **n’est pas** une mise en prod. Les agents ne doivent pas `git pull origin main` sur le serveur, ni traiter une PR vers `main` comme un déploiement.
 
 ---
 
@@ -33,15 +43,15 @@ flowchart LR
 Le chantier innovation est suivi par une **PR en brouillon (Draft)** :
 
 - **PR ouverte** : [#33 - WIP: éditeur Beta, import PDF canvas et score ATS](https://github.com/presidentaxel/Axeljob/pull/33)
-- **Statut** : Draft - **ne pas merger** tant que l'éditeur Beta / l'import PDF ne sont pas prêts pour la prod
-- **But** : visibilité (diff, CI GitHub, commentaires) **sans** risque de mise en prod accidentelle
+- **Statut** : Draft — **ne pas merger** tant que l'éditeur Beta / l'import PDF ne sont pas prêts pour l’intégration (`main`)
+- **But** : visibilité (diff, CI GitHub, commentaires) **sans** risque de promote accidentel vers `prod`
 
 ### Pourquoi une Draft PR et pas merge direct ?
 
 - Tu **continues à développer** sur `wip/innovation` : chaque `git push` **met à jour la PR automatiquement**
-- `main` reste stable (prod)
+- `main` reste l’intégration stable ; `prod` n’est pas touchée
 - La CI tourne sur la branche à chaque push
-- Quand ce sera prêt : passer la PR en **Ready for review** → review → merge
+- Quand ce sera prêt : passer la PR en **Ready for review** → review → merge dans **`main`** → **ensuite** un promote `main` → `prod` ([runbook](ADR_MAIN_PROD.md))
 
 ---
 
@@ -66,12 +76,12 @@ git push origin wip/innovation   # met à jour la PR Draft #33
 
 ## Petites évolutions (hors gros chantier innovation)
 
-Pour un correctif ou une feature **ciblée** et **mergeable rapidement** :
+Pour un correctif ou une feature **ciblée** et **mergeable rapidement dans `main`** :
 
 ```bash
 git checkout main
 git pull origin main
-git checkout -b fix/mon-sujet    # ou feat/mon-sujet
+git checkout -b fix/mon-sujet    # ou feat/mon-sujet, ou le gitBranchName Linear
 
 # … coder, commit …
 
@@ -80,10 +90,41 @@ git push -u origin HEAD
 gh pr create --base main --title "fix: …" --body "…"
 ```
 
-Merger la PR une fois la CI verte et la review OK.
+Merger la PR une fois la CI verte et la review OK. **Ça n’arrive pas en production** tant qu’on n’a pas ouvert / mergé une PR `main` → `prod`.
 
 > [!TIP]
-> Le hotfix PDF Safari a suivi ce flux (`hotfix/pdf-export` → PR/merge → branche supprimée). Réserver `wip/innovation` au chantier long.
+> Le hotfix PDF Safari a historiquement ciblé `main` quand `main` était encore la prod. Aujourd’hui : fix d’intégration → `main` ; **urgence prod** → brancher depuis `origin/prod` (section hotfix).
+
+---
+
+## Promote `main` → `prod`
+
+Quand l’intégration est prête à aller en production :
+
+```bash
+gh pr create --base prod --head main \
+  --title "release: promote main → prod" \
+  --body "…"
+```
+
+Détail (titre, body, fallback CD) : [`ADR_MAIN_PROD.md`](ADR_MAIN_PROD.md) et [`deploy.md`](deploy.md).
+
+Cette PR emporte **tout** `main` qui n’est pas déjà dans `prod`. Ne pas y coller un correctif isolé « par-dessus » : soit il est déjà dans `main`, soit c’est un hotfix depuis `prod`.
+
+Jusqu’à [AXE-317](https://linear.app/axel-project/issue/AXE-317) (CD), le merge dans `prod` **ne déploie pas tout seul** : enchaîner le fallback serveur (`git pull origin prod` + Docker) décrit dans [`deploy.md`](deploy.md).
+
+---
+
+## Hotfix production
+
+Prod cassée, le fix ne peut pas attendre le prochain promote :
+
+1. `git fetch origin && git checkout -b hotfix/<sujet> origin/prod`
+2. Fix minimal + tests
+3. PR **vers `prod`** → merge → deploy (CD ou fallback)
+4. **Backport** vers `main` (cherry-pick / PR) pour ne pas perdre le correctif au promote suivant
+
+Documenter dans Linear ([`linear-github-workflow.md`](linear-github-workflow.md)).
 
 ---
 
@@ -94,8 +135,9 @@ Quand le chantier est prêt :
 1. Vérifier que la CI est verte sur la PR #33
 2. Sur GitHub : **Ready for review** (retirer le statut Draft)
 3. Review + validation explicite
-4. **Merge** la PR dans `main`
-5. Déploiement selon `docs/deploy.md`
+4. **Merge** la PR dans **`main`** (intégration)
+5. **Promote** `main` → `prod` (runbook ci-dessus)
+6. Déploiement selon `docs/deploy.md`
 
 ---
 
@@ -126,25 +168,29 @@ Contournement urgence uniquement : `SKIP_PREPUSH=1 git push`.
 
 | Document | Contenu |
 | --- | --- |
+| [`ADR_MAIN_PROD.md`](ADR_MAIN_PROD.md) | Décision Option C (`main` ≠ prod) + runbook promote / hotfix |
 | `docs/COMMANDS.md` | Aide-mémoire commandes (section Git) |
 | `docs/contributing.md` | Quality gates, checklist PR |
 | `docs/branch-protections.md` | Garde-fous locaux + checklist branch protection GitHub |
 | `docs/linear-github-workflow.md` | Linear ↔ GitHub (projet `Axel Job`, issues `AxelJob`, 1 ticket = 1 PR) |
-| `.cursor/rules/pre-push-ci.mdc` | Règle agent Cursor (PR-first) |
-| `scripts/guard-push-via-pr.sh` | Blocage push direct vers `main` |
+| `.cursor/rules/pre-push-ci.mdc` | Règle agent Cursor (PR-first, `main` et `prod` protégés) |
+| `scripts/guard-push-via-pr.sh` | Blocage push direct vers `main` / `master` / `prod` |
 
 ---
 
 ## FAQ
 
 **Je suis sur `wip/innovation`, je push, est-ce que ça part en prod ?**  
-Non. Un push sur `wip/innovation` ne touche pas `main`. Même après **merge de la PR** vers `main` (ou un push direct interdit), le **déploiement serveur** reste une étape séparée ([`deploy.md`](deploy.md)). La PR #33 est en **Draft**.
+Non. Un push sur `wip/innovation` ne touche ni `main` ni `prod`. Même après **merge de la PR #33** vers `main`, il reste un **promote** `main` → `prod` puis le **déploiement serveur** ([`deploy.md`](deploy.md)). La PR #33 est en **Draft**.
 
 **Je dois ouvrir une nouvelle PR à chaque commit ?**  
 Non sur `wip/innovation` : la PR #33 existe déjà et se met à jour à chaque push.
 
 **Je veux merger un petit fix sans attendre innovation ?**  
-Branche `fix/*` depuis `main`, PR classique, merge indépendamment de #33.
+Branche `fix/*` depuis `main`, PR classique vers `main`, merge indépendamment de #33. Pour que ça arrive **en prod** : promote `main` → `prod` (ou hotfix depuis `prod` si urgence).
 
-**L'agent Cursor peut-il push sur `main` ?**  
-Non - règle `.cursor/rules/pre-push-ci.mdc` + hooks.
+**L'agent Cursor peut-il push sur `main` ou `prod` ?**  
+Non — règle `.cursor/rules/pre-push-ci.mdc` + hooks.
+
+**Un merge dans `main`, c’est la prod ?**  
+Non. `main` = intégration. La prod = branche `prod`.

--- a/docs/guide-bonnes-pratiques.md
+++ b/docs/guide-bonnes-pratiques.md
@@ -160,6 +160,7 @@ Contrat : `docs/design-system.md`. Tokens : `frontend/src/design/tokens.json` (`
 - **Description PR** : expliquer le pourquoi, l'impact utilisateur, les risques et le plan de test.
 - **Avant merge** : CI verte, checks securite verts, documentation mise a jour si comportement modifie.
 - **Chantier Linear (AxeL Job)** : maillage projet → issues Linear → issues GitHub → branche `gitBranchName` → draft PR + liens Linear. Voir [`docs/linear-github-workflow.md`](linear-github-workflow.md).
+- **Branches** : `main` = intégration, `prod` = production. Ne pas pusher `main`/`prod` ; ne pas déployer depuis `main`. [`docs/ADR_MAIN_PROD.md`](ADR_MAIN_PROD.md).
 
 ### 8.1 Verification locale recommandee avant PR
 
@@ -178,6 +179,7 @@ npm --prefix frontend run lint
 
 ## 9. Deploiement et configuration
 
+- Le serveur de production checkout **`prod`**, pas `main`. Runbook : [`docs/deploy.md`](deploy.md), [`docs/ADR_MAIN_PROD.md`](ADR_MAIN_PROD.md).
 - Ne pas casser le contrat de routage infra (`/api`, `/health`, assets frontend).
 - Maintenir la coherence des variables d'environnement entre `.env`, `docker-compose.yml` et documentation.
 - Toute nouvelle variable doit etre ajoutee a `.env.example` et documentee dans `README.md` (impact + securite).

--- a/docs/linear-github-workflow.md
+++ b/docs/linear-github-workflow.md
@@ -6,7 +6,7 @@
 
 Agents IA : lire ce fichier quand la demande concerne Linear, un chantier AxeL Job, ou « ouvrir un chantier / PR liée ».
 
-Compléments Git locaux : [`git-workflow.md`](git-workflow.md) · [`branch-protections.md`](branch-protections.md).
+Compléments Git locaux : [`git-workflow.md`](git-workflow.md) · [`branch-protections.md`](branch-protections.md) · ADR Option C : [`ADR_MAIN_PROD.md`](ADR_MAIN_PROD.md) (`main` = intégration, `prod` = production).
 
 > **Note famille produit.** Le workspace `Axel Project` héberge plusieurs familles dans **une seule team** (`AXE`). On les distingue par **label de projet + couleur**, pas par team. Les tickets restent donc `AXE-XX` pour tout le monde.
 >
@@ -182,7 +182,8 @@ Exemple MCP commentaire issue :
 
 ### F. Branche + draft PR
 
-1. Partir de `origin/main` pour une livraison isolée vers `main` (ne pas emporter le WIP de `wip/innovation`).  
+1. Partir de `origin/main` pour une livraison isolée vers **`main` (intégration)** (ne pas emporter le WIP de `wip/innovation`).  
+   Un merge dans `main` **n’est pas** un déploiement. La production = PR promote `main` → `prod` ([`ADR_MAIN_PROD.md`](ADR_MAIN_PROD.md)).  
    Si le code n’existe que sur `wip/innovation` : soit cherry-pick / extrait vers une branche basée sur `main`, soit PR empilée **vers `wip/innovation`** (pas vers `main`) — le noter dans le body PR / commentaire Linear.
 2. Branche = **exactement** le `gitBranchName` Linear.
 3. Commit scaffold vide OK au démarrage (`git commit --allow-empty`), puis vrais commits.
@@ -223,7 +224,7 @@ EOF
 
 1. PR prête → retirer le draft, CI verte, revue.
 2. Titre / body conservent `Fixes AXE-XX` et `Closes #N`.
-3. Après merge : vérifier que Linear est passé en `Done` (intégration GitHub) ; sinon le faire à la main.
+3. Après merge **dans `main`** : vérifier que Linear est passé en `Done` (intégration GitHub) ; sinon le faire à la main. Ça n’arrive **pas** en production tant qu’un promote `main` → `prod` n’est pas mergé ([`deploy.md`](deploy.md)).
 4. Mettre à jour le titre du lien Linear `Draft PR #N` → `PR #N` si besoin (nouveau link OK).
 5. Commentaire de clôture sur l'issue Linear (§E) + project update si fin de vague.
 
@@ -284,4 +285,5 @@ Quand une issue passe en livraison isolée : créer issue GitHub + branche `gitB
 - Plusieurs sujets unrelated dans une seule issue
 - Branche inventée au lieu du `gitBranchName` Linear
 - Critères d'acceptation non vérifiables (« ça marche mieux ») au lieu d'un test observable
-- Push direct sur `main` (interdit — voir [`git-workflow.md`](git-workflow.md) et [`branch-protections.md`](branch-protections.md))
+- Push direct sur `main` **ou** `prod` (interdit — voir [`git-workflow.md`](git-workflow.md), [`ADR_MAIN_PROD.md`](ADR_MAIN_PROD.md) et [`branch-protections.md`](branch-protections.md))
+- Traiter un merge dans `main` comme une mise en prod (faux : `main` = intégration)

--- a/scripts/guard-push-via-pr.sh
+++ b/scripts/guard-push-via-pr.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Refuse un push direct vers main/master - les changements passent par PR.
+# Refuse un push direct vers main/master/prod - les changements passent par PR.
 # Usage :
 #   guard-push-via-pr.sh --git-command "git push origin main"
 #   guard-push-via-pr.sh --pre-push-stdin   (lit les refs du hook pre-push)
 set -euo pipefail
 
-PROTECTED_RE='^(main|master)$'
-MSG='Push direct vers main/master interdit - créer une branche et ouvrir une PR (gh pr create).'
+PROTECTED_RE='^(main|master|prod)$'
+MSG='Push direct vers main/master/prod interdit - créer une branche et ouvrir une PR (gh pr create).'
 
 deny() {
   echo "$MSG" >&2
@@ -25,13 +25,13 @@ if [[ "${1:-}" == "--git-command" ]]; then
     exit 0
   fi
 
-  if printf '%s' "$command" | grep -qE '(HEAD:main|HEAD:master|:refs/heads/main|:refs/heads/master|\s(main|master)\s*$)'; then
+  if printf '%s' "$command" | grep -qE '(HEAD:main|HEAD:master|HEAD:prod|:refs/heads/main|:refs/heads/master|:refs/heads/prod|\s(main|master|prod)\s*$)'; then
     deny
   fi
 
   # git push / git push origin (sans branche explicite) : vérifier la branche courante
   if printf '%s' "$command" | grep -qE '^git[[:space:]]+push(\s|$)' \
-    && ! printf '%s' "$command" | grep -qE '(HEAD:|refs/heads/|\s(main|master)\s*$)'; then
+    && ! printf '%s' "$command" | grep -qE '(HEAD:|refs/heads/|\s(main|master|prod)\s*$)'; then
     current="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
     if [[ "$current" =~ $PROTECTED_RE ]]; then
       deny

--- a/tests/test_guard_push_via_pr.py
+++ b/tests/test_guard_push_via_pr.py
@@ -70,24 +70,18 @@ def test_non_push_command_is_ignored() -> None:
 
 
 def test_pre_push_stdin_denies_prod() -> None:
-    result = _pre_push_stdin(
-        "refs/heads/feat abc123 refs/heads/prod def456\n"
-    )
+    result = _pre_push_stdin("refs/heads/feat abc123 refs/heads/prod def456\n")
     assert result.returncode == 1
     assert "interdit" in result.stderr
 
 
 def test_pre_push_stdin_denies_main() -> None:
-    result = _pre_push_stdin(
-        "refs/heads/feat abc123 refs/heads/main def456\n"
-    )
+    result = _pre_push_stdin("refs/heads/feat abc123 refs/heads/main def456\n")
     assert result.returncode == 1
 
 
 def test_pre_push_stdin_allows_feature() -> None:
-    result = _pre_push_stdin(
-        "refs/heads/feat abc123 refs/heads/feat/x def456\n"
-    )
+    result = _pre_push_stdin("refs/heads/feat abc123 refs/heads/feat/x def456\n")
     assert result.returncode == 0, result.stderr
 
 

--- a/tests/test_guard_push_via_pr.py
+++ b/tests/test_guard_push_via_pr.py
@@ -1,0 +1,102 @@
+"""Garde-fous : pas de push direct vers main / master / prod (AXE-319)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "guard-push-via-pr.sh"
+
+
+def _git_command(cmd: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT), "--git-command", cmd],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _pre_push_stdin(line: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT), "--pre-push-stdin"],
+        input=line,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_allows_feature_branch_push() -> None:
+    result = _git_command("git push -u origin louisvedovato/axe-319-docs")
+    assert result.returncode == 0, result.stderr
+
+
+def test_allows_wip_innovation_push() -> None:
+    result = _git_command("git push origin wip/innovation")
+    assert result.returncode == 0, result.stderr
+
+
+def test_denies_push_origin_main() -> None:
+    result = _git_command("git push origin main")
+    assert result.returncode == 1
+    assert "interdit" in result.stderr
+
+
+def test_denies_push_origin_prod() -> None:
+    result = _git_command("git push origin prod")
+    assert result.returncode == 1
+    assert "prod" in result.stderr
+
+
+def test_denies_push_origin_master() -> None:
+    result = _git_command("git push origin master")
+    assert result.returncode == 1
+
+
+def test_denies_head_colon_prod() -> None:
+    result = _git_command("git push origin HEAD:prod")
+    assert result.returncode == 1
+
+
+def test_denies_refs_heads_prod() -> None:
+    result = _git_command("git push origin HEAD:refs/heads/prod")
+    assert result.returncode == 1
+
+
+def test_non_push_command_is_ignored() -> None:
+    result = _git_command("git status")
+    assert result.returncode == 0
+
+
+def test_pre_push_stdin_denies_prod() -> None:
+    result = _pre_push_stdin(
+        "refs/heads/feat abc123 refs/heads/prod def456\n"
+    )
+    assert result.returncode == 1
+    assert "interdit" in result.stderr
+
+
+def test_pre_push_stdin_denies_main() -> None:
+    result = _pre_push_stdin(
+        "refs/heads/feat abc123 refs/heads/main def456\n"
+    )
+    assert result.returncode == 1
+
+
+def test_pre_push_stdin_allows_feature() -> None:
+    result = _pre_push_stdin(
+        "refs/heads/feat abc123 refs/heads/feat/x def456\n"
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_usage_without_args_exits_2() -> None:
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert "Usage" in result.stderr


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

- ADR Option C figée : `main` = **intégration**, `prod` = **production** (`docs/ADR_MAIN_PROD.md`).
- Runbook promote `main` → `prod` (`gh pr create --base prod --head main`) + hotfix depuis `prod` + backport `main`.
- Docs alignées : `git-workflow`, `branch-protections`, `deploy`, hub `docs/README.md`, `COMMANDS`, Linear workflow, `contributing`, bonnes pratiques.
- Garde-fous locaux : `scripts/guard-push-via-pr.sh`, hooks Git/Cursor et règle `.cursor/rules/pre-push-ci.mdc` refusent aussi le push direct vers **`prod`**.
- Tests : `tests/test_guard_push_via_pr.py`.

## Why

Les agents et le serveur traitaient `main` comme la prod (`git pull origin main`). Le chantier déploiement aligne AxeL Job sur le modèle CRM : merger dans `main` n’est **pas** un déploiement.

## Linear

Fixes AXE-319

## Validation

- [x] Backend lint passes (`ruff`, `black`, `mypy`)
- [x] Backend tests pass (`pytest`)
- [x] Coverage threshold passes (backend >= 60%)
- [x] Frontend lint passes (`npm --prefix frontend run lint`) — via `pre-push.sh`
- [x] Docs updated if needed
- [x] No secrets committed
- [x] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks` → `OK - pre-push terminé sans erreur.`

## Test plan

- [x] `pytest tests/test_guard_push_via_pr.py` (refus `main` / `master` / `prod`, autorise feature / `wip/innovation`)
- [ ] Relire l’ADR : un agent ne traite plus `main` comme prod
- [ ] Premier promote `main` → `prod` : **pas** cette PR (AXE-320 / CD AXE-317)

## Notes chantier (hors scope)

- CI PR → `prod` : AXE-316, [PR #168](https://github.com/presidentaxel/Axeljob/pull/168) (In Review, pas mergée).
- CD `deploy-prod.yml` : AXE-317 Todo — fallback documenté : `git pull origin prod` + Docker.
- Branch protection GitHub Settings : AXE-318 (clics).

## Risk and rollback

- Risk: faible (docs + script de garde local). `origin/prod` existe déjà ; aucun deploy n’est déclenché par ce merge.
- Rollback: revert du commit ; le serveur continue de fonctionner. Ne pas réintroduire « main = prod » dans la doc.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

