### PR TITLE
fix: tests guard-push verts quand la CI est sur main

### DIFF
--- a/scripts/guard-push-via-pr.sh
+++ b/scripts/guard-push-via-pr.sh
@@ -29,14 +29,18 @@ if [[ "${1:-}" == "--git-command" ]]; then
     deny
   fi
 
-  # git push / git push origin (sans branche explicite) : vérifier la branche courante
-  if printf '%s' "$command" | grep -qE '^git[[:space:]]+push(\s|$)' \
-    && ! printf '%s' "$command" | grep -qE '(HEAD:|refs/heads/|\s(main|master|prod)\s*$)'; then
-    current="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
-    if [[ "$current" =~ $PROTECTED_RE ]]; then
-      deny
-    fi
-  fi
+  # Destination explicite autre que HEAD (ex. git push origin feat/x) : autoriser
+  # même si le checkout local est main — sinon la CI GitHub sur main refuse à tort
+  # un --git-command de test / un push vers une branche feature.
+  last="${command##* }"
+  case "$last" in
+    push|origin|upstream|-u|--set-upstream|--force|-f|HEAD)
+      current="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+      if [[ "$current" =~ $PROTECTED_RE ]]; then
+        deny
+      fi
+      ;;
+  esac
   exit 0
 fi
 

--- a/tests/test_guard_push_via_pr.py
+++ b/tests/test_guard_push_via_pr.py
@@ -32,6 +32,47 @@ def test_allows_feature_branch_push() -> None:
     assert result.returncode == 0, result.stderr
 
 
+def test_explicit_feature_refspec_allowed_when_cwd_is_main(tmp_path: Path) -> None:
+    """CI GitHub checkout ``main`` : un push explicite vers une feature doit passer."""
+    subprocess.run(
+        ["git", "init", "-b", "main", str(tmp_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    result = subprocess.run(
+        [
+            "bash",
+            str(SCRIPT),
+            "--git-command",
+            "git push -u origin louisvedovato/axe-319-docs",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_bare_push_origin_denied_when_cwd_is_main(tmp_path: Path) -> None:
+    subprocess.run(
+        ["git", "init", "-b", "main", str(tmp_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "--git-command", "git push origin"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1
+    assert "interdit" in result.stderr
+
+
 def test_allows_wip_innovation_push() -> None:
     result = _git_command("git push origin wip/innovation")
     assert result.returncode == 0, result.stderr

--- a/tests/test_guard_push_via_pr.py
+++ b/tests/test_guard_push_via_pr.py
@@ -62,6 +62,29 @@ def test_bare_push_origin_denied_when_cwd_is_main(tmp_path: Path) -> None:
         capture_output=True,
         text=True,
     )
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.email", "ci@example.test"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.name", "ci"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(tmp_path),
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
+        ],
+        check=True,
+        capture_output=True,
+    )
     result = subprocess.run(
         ["bash", str(SCRIPT), "--git-command", "git push origin"],
         cwd=tmp_path,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

- `scripts/guard-push-via-pr.sh` : si le refspec est explicite (`origin feat/…`), on ne relit plus `HEAD` local.
- Tests : checkout temporaire sur `main` — un envoi vers une feature passe ; `origin` sans branche reste refusé.

## Why

Après AXE-319, la CI **`push` sur `main`** (merge #168) faisait échouer `test_guard_push_via_pr` : le runner est sur `main`, donc un `--git-command` vers une feature était traité comme un push protégé.

## Linear

Suite AXE-319 / smoke AXE-316. Pas un promote `prod`.

## Validation

- [x] `pytest tests/test_guard_push_via_pr.py` (14 tests)
- [x] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks`

## Risk and rollback

- Risk: faible (script de garde local + tests).
- Rollback: revert. Les push directs vers main/prod restent bloqués.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

