### PR TITLE
feat(AXE-370): contextes et erreurs métier dans Sentry

### DIFF
--- a/backend/cv_pdf_chromium.py
+++ b/backend/cv_pdf_chromium.py
@@ -580,6 +580,12 @@ def html_to_cv_pdf_bytes_chromium(
     # sur le threadpool Starlette → thread variable ; le worker dédié évite l'erreur
     # « Cannot switch to a different thread ».
     jobs = _ensure_pool_started()
+    try:
+        from backend.sentry_business import maybe_capture_pdf_pool_saturated
+
+        maybe_capture_pdf_pool_saturated(jobs.qsize(), _chromium_pool_size())
+    except Exception:
+        pass
     fut: Future = Future()
     jobs.put((html_str, context_base, template_id, fut))
     return fut.result()

--- a/backend/cv_pdf_chromium.py
+++ b/backend/cv_pdf_chromium.py
@@ -580,12 +580,9 @@ def html_to_cv_pdf_bytes_chromium(
     # sur le threadpool Starlette → thread variable ; le worker dédié évite l'erreur
     # « Cannot switch to a different thread ».
     jobs = _ensure_pool_started()
-    try:
-        from backend.sentry_business import maybe_capture_pdf_pool_saturated
+    from backend.sentry_business import maybe_capture_pdf_pool_saturated
 
-        maybe_capture_pdf_pool_saturated(jobs.qsize(), _chromium_pool_size())
-    except Exception:
-        pass
+    maybe_capture_pdf_pool_saturated(jobs.qsize(), _chromium_pool_size())
     fut: Future = Future()
     jobs.put((html_str, context_base, template_id, fut))
     return fut.result()

--- a/backend/cv_pdf_dispatch.py
+++ b/backend/cv_pdf_dispatch.py
@@ -42,7 +42,7 @@ def html_to_cv_pdf_bytes(
         import sentry_sdk
 
         sentry_sdk.set_tag("pdf_engine", engine)
-        sentry_sdk.set_tag("flow", "pdf")
+        sentry_sdk.set_tag("flow", "export")
     except Exception:
         pass
     raw_env = (os.environ.get("CV_BOT_PDF_ENGINE") or "").strip() or "(default weasyprint)"
@@ -69,8 +69,14 @@ def html_to_cv_pdf_bytes(
                     html_str, base_resolved, template_id=template_id
                 )
                 _log.info("Export PDF CV - Chromium termine (%d octets PDF).", len(out))
-            except NotImplementedError:
+            except NotImplementedError as exc:
                 # Windows + asyncio (boucle sans subprocess) : voir _ensure_windows_playwright_asyncio.
+                try:
+                    from backend.sentry_business import capture_pdf_engine_failure
+
+                    capture_pdf_engine_failure(engine, exc)
+                except Exception:
+                    pass
                 _log.warning(
                     "Export PDF CV - Chromium impossible (NotImplementedError / asyncio), repli WeasyPrint.",
                     exc_info=True,
@@ -83,12 +89,22 @@ def html_to_cv_pdf_bytes(
 
                 out = _wp(html_str, base_resolved, template_id=template_id)
                 _log.info("Export PDF CV - WeasyPrint (repli) termine (%d octets PDF).", len(out))
-            return out
+            try:
+                from backend.sentry_business import note_pdf_bytes
+
+                return note_pdf_bytes(out, engine)
+            except Exception:
+                return out
         from backend.cv_pdf_weasyprint import html_to_cv_pdf_bytes as _wp
 
         out = _wp(html_str, base_resolved, template_id=template_id)
         _log.info("Export PDF CV - WeasyPrint termine (%d octets PDF).", len(out))
-        return out
+        try:
+            from backend.sentry_business import note_pdf_bytes
+
+            return note_pdf_bytes(out, engine)
+        except Exception:
+            return out
     finally:
         # Rend au noyau les arenas glibc libérés par WeasyPrint/Chromium (no-op hors Linux).
         # Évite la dérive de RSS qui ne redescend jamais après un pic PDF.

--- a/backend/cv_pdf_dispatch.py
+++ b/backend/cv_pdf_dispatch.py
@@ -59,6 +59,7 @@ def html_to_cv_pdf_bytes(
         flush=True,
     )
     from backend.mem_release import release_unused_memory
+    from backend.sentry_business import capture_pdf_engine_failure, note_pdf_bytes
 
     try:
         if engine == "chromium":
@@ -71,12 +72,7 @@ def html_to_cv_pdf_bytes(
                 _log.info("Export PDF CV - Chromium termine (%d octets PDF).", len(out))
             except NotImplementedError as exc:
                 # Windows + asyncio (boucle sans subprocess) : voir _ensure_windows_playwright_asyncio.
-                try:
-                    from backend.sentry_business import capture_pdf_engine_failure
-
-                    capture_pdf_engine_failure(engine, exc)
-                except Exception:
-                    pass
+                capture_pdf_engine_failure(engine, exc)
                 _log.warning(
                     "Export PDF CV - Chromium impossible (NotImplementedError / asyncio), repli WeasyPrint.",
                     exc_info=True,
@@ -89,22 +85,12 @@ def html_to_cv_pdf_bytes(
 
                 out = _wp(html_str, base_resolved, template_id=template_id)
                 _log.info("Export PDF CV - WeasyPrint (repli) termine (%d octets PDF).", len(out))
-            try:
-                from backend.sentry_business import note_pdf_bytes
-
-                return note_pdf_bytes(out, engine)
-            except Exception:
-                return out
+            return note_pdf_bytes(out, engine)
         from backend.cv_pdf_weasyprint import html_to_cv_pdf_bytes as _wp
 
         out = _wp(html_str, base_resolved, template_id=template_id)
         _log.info("Export PDF CV - WeasyPrint termine (%d octets PDF).", len(out))
-        try:
-            from backend.sentry_business import note_pdf_bytes
-
-            return note_pdf_bytes(out, engine)
-        except Exception:
-            return out
+        return note_pdf_bytes(out, engine)
     finally:
         # Rend au noyau les arenas glibc libérés par WeasyPrint/Chromium (no-op hors Linux).
         # Évite la dérive de RSS qui ne redescend jamais après un pic PDF.

--- a/backend/gemini_usage.py
+++ b/backend/gemini_usage.py
@@ -54,4 +54,10 @@ def ensure_budget(user_id: str | None) -> None:
     """
     allowed, _used_usd, _limit_usd = check_gemini_budget(user_id)
     if not allowed:
+        try:
+            from backend.sentry_business import capture_adapt_gemini_failure
+
+            capture_adapt_gemini_failure(kind="gemini_quota")
+        except Exception:
+            pass
         raise GeminiQuotaExceeded()

--- a/backend/gemini_usage.py
+++ b/backend/gemini_usage.py
@@ -54,10 +54,7 @@ def ensure_budget(user_id: str | None) -> None:
     """
     allowed, _used_usd, _limit_usd = check_gemini_budget(user_id)
     if not allowed:
-        try:
-            from backend.sentry_business import capture_adapt_gemini_failure
+        from backend.sentry_business import capture_adapt_gemini_failure
 
-            capture_adapt_gemini_failure(kind="gemini_quota")
-        except Exception:
-            pass
+        capture_adapt_gemini_failure(kind="gemini_quota")
         raise GeminiQuotaExceeded()

--- a/backend/main.py
+++ b/backend/main.py
@@ -661,6 +661,12 @@ def _resolve_jwt_payload_for_request(request: Request) -> dict | None:
                 if state is not None:
                     state._jwt_resolved = True
                     state._jwt_payload = None
+                try:
+                    from backend.sentry_business import record_jwt_reject
+
+                    record_jwt_reject()
+                except Exception:
+                    pass
                 raise
             except Exception as e:
                 hint = ""
@@ -674,6 +680,12 @@ def _resolve_jwt_payload_for_request(request: Request) -> dict | None:
                     hint,
                 )
                 payload = None
+                try:
+                    from backend.sentry_business import record_jwt_reject
+
+                    record_jwt_reject()
+                except Exception:
+                    pass
     if state is not None:
         state._jwt_resolved = True
         state._jwt_payload = payload
@@ -1423,6 +1435,18 @@ def _extract_text_from_pdf(file_bytes: bytes) -> str:
         return "\n\n".join(pages)
     except Exception as e:
         logger.warning("PDF extraction error: %s", e)
+        try:
+            from backend.sentry_business import capture_business_event
+
+            capture_business_event(
+                "import",
+                "PDF import illisible",
+                kind="pdf_unreadable",
+                size_bytes=len(file_bytes),
+                provider_code=type(e).__name__,
+            )
+        except Exception:
+            pass
         raise HTTPException(status_code=400, detail="Impossible de lire le PDF.")
 
 
@@ -1433,6 +1457,18 @@ def _extract_text_from_docx(file_bytes: bytes) -> str:
         return extract_text_from_docx_bytes(file_bytes)
     except Exception as e:
         logger.warning("DOCX extraction error: %s", e)
+        try:
+            from backend.sentry_business import capture_business_event
+
+            capture_business_event(
+                "import",
+                "DOCX import illisible",
+                kind="docx_unreadable",
+                size_bytes=len(file_bytes),
+                provider_code=type(e).__name__,
+            )
+        except Exception:
+            pass
         raise HTTPException(status_code=400, detail="Impossible de lire le fichier Word.")
 
 
@@ -2114,9 +2150,31 @@ async def api_stripe_webhook(request: Request):
 
         event = stripe.Webhook.construct_event(payload, sig, STRIPE_WEBHOOK_SECRET)
     except ValueError:
+        try:
+            from backend.sentry_business import capture_business_event
+
+            capture_business_event(
+                "billing",
+                "Webhook Stripe payload invalide",
+                kind="stripe_bad_payload",
+                size_bytes=len(payload),
+            )
+        except Exception:
+            pass
         raise HTTPException(status_code=400, detail="Payload invalide.")
     except Exception as e:
         if "signature" in str(e).lower():
+            try:
+                from backend.sentry_business import capture_business_event
+
+                capture_business_event(
+                    "billing",
+                    "Webhook Stripe signature invalide",
+                    kind="stripe_bad_signature",
+                    size_bytes=len(payload),
+                )
+            except Exception:
+                pass
             raise HTTPException(status_code=400, detail="Signature invalide.")
         raise
     # set_user_plan / find_user_id_by_stripe_subscription_id / _send_template_perso_email
@@ -2164,6 +2222,18 @@ async def api_stripe_webhook(request: Request):
                     if stripe_sub_id:
                         _STRIPE_SNAPSHOT_CACHE.invalidate(stripe_sub_id)
                     logger.info("User %s set to pro after Stripe checkout", user_id)
+                else:
+                    try:
+                        from backend.sentry_business import capture_business_event
+
+                        capture_business_event(
+                            "billing",
+                            "Abonnement Stripe sans utilisateur",
+                            kind="stripe_orphan_subscription",
+                            reason="checkout_no_user",
+                        )
+                    except Exception:
+                        pass
         except Exception as e:
             logger.exception(
                 "Stripe webhook checkout.session.completed failed: %s (event_id=%s)",
@@ -2190,6 +2260,18 @@ async def api_stripe_webhook(request: Request):
                 if deleted_sub_id:
                     _STRIPE_SNAPSHOT_CACHE.invalidate(deleted_sub_id)
                 logger.info("User %s set to free after Stripe subscription deleted", uid)
+            else:
+                try:
+                    from backend.sentry_business import capture_business_event
+
+                    capture_business_event(
+                        "billing",
+                        "Abonnement Stripe sans utilisateur",
+                        kind="stripe_orphan_subscription",
+                        reason="subscription_deleted_no_user",
+                    )
+                except Exception:
+                    pass
         except Exception as e:
             logger.exception(
                 "Stripe webhook customer.subscription.deleted failed: %s (event_id=%s)",

--- a/backend/main.py
+++ b/backend/main.py
@@ -110,6 +110,7 @@ from backend.gemini_usage import (
 )
 from backend.promo_codes import redeem_promo_code
 from backend.security import check_user_input_for_injection
+from backend.sentry_business import capture_business_event, record_jwt_reject
 from backend.sentry_config import bind_sentry_user, init_sentry
 from backend.services import billing_notifications, template_access
 
@@ -661,12 +662,7 @@ def _resolve_jwt_payload_for_request(request: Request) -> dict | None:
                 if state is not None:
                     state._jwt_resolved = True
                     state._jwt_payload = None
-                try:
-                    from backend.sentry_business import record_jwt_reject
-
-                    record_jwt_reject()
-                except Exception:
-                    pass
+                record_jwt_reject()
                 raise
             except Exception as e:
                 hint = ""
@@ -680,12 +676,7 @@ def _resolve_jwt_payload_for_request(request: Request) -> dict | None:
                     hint,
                 )
                 payload = None
-                try:
-                    from backend.sentry_business import record_jwt_reject
-
-                    record_jwt_reject()
-                except Exception:
-                    pass
+                record_jwt_reject()
     if state is not None:
         state._jwt_resolved = True
         state._jwt_payload = payload
@@ -1435,18 +1426,13 @@ def _extract_text_from_pdf(file_bytes: bytes) -> str:
         return "\n\n".join(pages)
     except Exception as e:
         logger.warning("PDF extraction error: %s", e)
-        try:
-            from backend.sentry_business import capture_business_event
-
-            capture_business_event(
-                "import",
-                "PDF import illisible",
-                kind="pdf_unreadable",
-                size_bytes=len(file_bytes),
-                provider_code=type(e).__name__,
-            )
-        except Exception:
-            pass
+        capture_business_event(
+            "import",
+            "PDF import illisible",
+            kind="pdf_unreadable",
+            size_bytes=len(file_bytes),
+            provider_code=type(e).__name__,
+        )
         raise HTTPException(status_code=400, detail="Impossible de lire le PDF.")
 
 
@@ -1457,18 +1443,13 @@ def _extract_text_from_docx(file_bytes: bytes) -> str:
         return extract_text_from_docx_bytes(file_bytes)
     except Exception as e:
         logger.warning("DOCX extraction error: %s", e)
-        try:
-            from backend.sentry_business import capture_business_event
-
-            capture_business_event(
-                "import",
-                "DOCX import illisible",
-                kind="docx_unreadable",
-                size_bytes=len(file_bytes),
-                provider_code=type(e).__name__,
-            )
-        except Exception:
-            pass
+        capture_business_event(
+            "import",
+            "DOCX import illisible",
+            kind="docx_unreadable",
+            size_bytes=len(file_bytes),
+            provider_code=type(e).__name__,
+        )
         raise HTTPException(status_code=400, detail="Impossible de lire le fichier Word.")
 
 
@@ -2150,31 +2131,21 @@ async def api_stripe_webhook(request: Request):
 
         event = stripe.Webhook.construct_event(payload, sig, STRIPE_WEBHOOK_SECRET)
     except ValueError:
-        try:
-            from backend.sentry_business import capture_business_event
-
-            capture_business_event(
-                "billing",
-                "Webhook Stripe payload invalide",
-                kind="stripe_bad_payload",
-                size_bytes=len(payload),
-            )
-        except Exception:
-            pass
+        capture_business_event(
+            "billing",
+            "Webhook Stripe payload invalide",
+            kind="stripe_bad_payload",
+            size_bytes=len(payload),
+        )
         raise HTTPException(status_code=400, detail="Payload invalide.")
     except Exception as e:
         if "signature" in str(e).lower():
-            try:
-                from backend.sentry_business import capture_business_event
-
-                capture_business_event(
-                    "billing",
-                    "Webhook Stripe signature invalide",
-                    kind="stripe_bad_signature",
-                    size_bytes=len(payload),
-                )
-            except Exception:
-                pass
+            capture_business_event(
+                "billing",
+                "Webhook Stripe signature invalide",
+                kind="stripe_bad_signature",
+                size_bytes=len(payload),
+            )
             raise HTTPException(status_code=400, detail="Signature invalide.")
         raise
     # set_user_plan / find_user_id_by_stripe_subscription_id / _send_template_perso_email
@@ -2223,17 +2194,12 @@ async def api_stripe_webhook(request: Request):
                         _STRIPE_SNAPSHOT_CACHE.invalidate(stripe_sub_id)
                     logger.info("User %s set to pro after Stripe checkout", user_id)
                 else:
-                    try:
-                        from backend.sentry_business import capture_business_event
-
-                        capture_business_event(
-                            "billing",
-                            "Abonnement Stripe sans utilisateur",
-                            kind="stripe_orphan_subscription",
-                            reason="checkout_no_user",
-                        )
-                    except Exception:
-                        pass
+                    capture_business_event(
+                        "billing",
+                        "Abonnement Stripe sans utilisateur",
+                        kind="stripe_orphan_subscription",
+                        reason="checkout_no_user",
+                    )
         except Exception as e:
             logger.exception(
                 "Stripe webhook checkout.session.completed failed: %s (event_id=%s)",
@@ -2261,17 +2227,12 @@ async def api_stripe_webhook(request: Request):
                     _STRIPE_SNAPSHOT_CACHE.invalidate(deleted_sub_id)
                 logger.info("User %s set to free after Stripe subscription deleted", uid)
             else:
-                try:
-                    from backend.sentry_business import capture_business_event
-
-                    capture_business_event(
-                        "billing",
-                        "Abonnement Stripe sans utilisateur",
-                        kind="stripe_orphan_subscription",
-                        reason="subscription_deleted_no_user",
-                    )
-                except Exception:
-                    pass
+                capture_business_event(
+                    "billing",
+                    "Abonnement Stripe sans utilisateur",
+                    kind="stripe_orphan_subscription",
+                    reason="subscription_deleted_no_user",
+                )
         except Exception as e:
             logger.exception(
                 "Stripe webhook customer.subscription.deleted failed: %s (event_id=%s)",

--- a/backend/sentry_business.py
+++ b/backend/sentry_business.py
@@ -89,6 +89,7 @@ _KIND_MESSAGES = {
 }
 
 _DEBOUNCE_SEC = {
+    "gemini_quota": 60.0,
     "pdf_pool_saturated": 60.0,
     "pg_pool": 60.0,
     "stripe_bad_signature": 30.0,
@@ -187,14 +188,14 @@ def capture_business_event(
     fingerprint: list[str] | None = None,
     **context: object,
 ) -> None:
-    """Envoie un warning Sentry tagué ``flow`` / ``kind``. No-op si DSN vide."""
+    """Envoie un warning Sentry tagué ``flow`` / ``kind``. No-op si DSN vide.
+
+    Ne lève jamais : une panne Sentry ne doit pas casser le parcours métier.
+    """
     if not _dsn_configured():
         return
     flow_tag = flow if flow in ALLOWED_FLOWS else "unknown"
     kind_tag = str(kind).strip()[:80] if kind else ""
-    if kind_tag and kind_tag not in BUSINESS_KINDS:
-        # Kinds hors liste : on envoie quand même, fingerprint isolé, pas de PII.
-        kind_tag = kind_tag[:80]
     if kind_tag and not _should_emit(flow_tag, kind_tag):
         return
 
@@ -213,6 +214,9 @@ def capture_business_event(
             for extra_key, extra_val in extras.items():
                 scope.set_extra(extra_key, extra_val)
             scope.fingerprint = fp
+            clearer = getattr(scope, "clear_breadcrumbs", None)
+            if callable(clearer):
+                clearer()
             sentry_sdk.capture_message(text, level=level)
     except Exception:
         logger.debug("sentry business event skipped", exc_info=True)

--- a/backend/sentry_business.py
+++ b/backend/sentry_business.py
@@ -1,0 +1,325 @@
+"""Échecs métier Sentry (AXE-370) : capture_message warning, tags flow/kind, sans PII.
+
+Les 4xx FastAPI sont droppés par ``before_send`` (AXE-367). Les échecs convertis
+en 429/401/400 (quota Gemini, JWT, webhook Stripe, PDF illisible) n'apparaissent
+donc jamais comme exceptions : il faut un ``capture_message`` **avant** la
+conversion HTTP. DSN vide = no-op (même contrat que ``init_sentry``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from collections import deque
+from collections.abc import Mapping
+
+logger = logging.getLogger(__name__)
+
+ALLOWED_FLOWS = frozenset({"adapt", "export", "import", "billing", "auth"})
+
+BUSINESS_KINDS = frozenset(
+    {
+        "gemini_quota",
+        "gemini_timeout",
+        "gemini_unparseable",
+        "gemini_empty",
+        "gemini_api_error",
+        "empty_pdf",
+        "pdf_engine_fail",
+        "pdf_timeout",
+        "pdf_pool_saturated",
+        "pdf_unreadable",
+        "docx_unreadable",
+        "pymupdf_fail",
+        "stripe_bad_signature",
+        "stripe_bad_payload",
+        "stripe_orphan_subscription",
+        "jwt_burst",
+        "pg_pool",
+    }
+)
+
+_ALLOWED_CONTEXT_KEYS = frozenset(
+    {
+        "engine",
+        "size_bytes",
+        "duration_ms",
+        "provider_code",
+        "http_status",
+        "timeout",
+        "reason",
+        "pool_wait_ms",
+        "burst_count",
+        "qsize",
+        "pool_size",
+    }
+)
+
+_INT_CONTEXT_KEYS = frozenset(
+    {
+        "size_bytes",
+        "duration_ms",
+        "http_status",
+        "pool_wait_ms",
+        "burst_count",
+        "qsize",
+        "pool_size",
+    }
+)
+
+_KIND_MESSAGES = {
+    "gemini_quota": "Quota Gemini dépassé",
+    "gemini_timeout": "Timeout Gemini",
+    "gemini_unparseable": "Réponse Gemini non parsable",
+    "gemini_empty": "Réponse Gemini vide",
+    "gemini_api_error": "Erreur API Gemini",
+    "empty_pdf": "Export PDF vide",
+    "pdf_engine_fail": "Échec moteur PDF",
+    "pdf_timeout": "Timeout moteur PDF",
+    "pdf_pool_saturated": "Pool PDF Chromium saturé",
+    "pdf_unreadable": "PDF import illisible",
+    "docx_unreadable": "DOCX import illisible",
+    "pymupdf_fail": "PyMuPDF import en échec",
+    "stripe_bad_signature": "Webhook Stripe signature invalide",
+    "stripe_bad_payload": "Webhook Stripe payload invalide",
+    "stripe_orphan_subscription": "Abonnement Stripe sans utilisateur",
+    "jwt_burst": "Rejets JWT en rafale",
+    "pg_pool": "Pool Supabase PG saturé",
+}
+
+_DEBOUNCE_SEC = {
+    "pdf_pool_saturated": 60.0,
+    "pg_pool": 60.0,
+    "stripe_bad_signature": 30.0,
+    "stripe_bad_payload": 30.0,
+}
+
+_last_emit_at: dict[tuple[str, str], float] = {}
+_jwt_fail_ts: deque[float] = deque()
+_jwt_burst_emitted_at = 0.0
+
+
+def is_business_kind(kind: object) -> bool:
+    return str(kind or "") in BUSINESS_KINDS
+
+
+def classify_gemini_exc(exc: BaseException) -> str:
+    blob = f"{type(exc).__name__} {exc}".lower()
+    if any(token in blob for token in ("timeout", "timed out", "deadline", "deadlineexceeded")):
+        return "gemini_timeout"
+    return "gemini_api_error"
+
+
+def reset_business_event_state() -> None:
+    """Tests : remet les debounce / rafales à zéro."""
+    _last_emit_at.clear()
+    _jwt_fail_ts.clear()
+    global _jwt_burst_emitted_at
+    _jwt_burst_emitted_at = 0.0
+
+
+def _dsn_configured() -> bool:
+    try:
+        from backend.sentry_config import sentry_dsn
+
+        return bool(sentry_dsn())
+    except Exception:
+        return bool((os.environ.get("SENTRY_DSN") or "").strip())
+
+
+def _coerce_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _sanitize_context(context: Mapping[str, object]) -> dict[str, object]:
+    extras: dict[str, object] = {}
+    for key, raw in context.items():
+        if key not in _ALLOWED_CONTEXT_KEYS:
+            continue
+        if raw is None:
+            continue
+        if key in _INT_CONTEXT_KEYS:
+            parsed = _coerce_int(raw)
+            if parsed is None:
+                continue
+            extras[key] = parsed
+            continue
+        if key == "timeout":
+            extras[key] = bool(raw)
+            continue
+        text = str(raw).strip()
+        if text:
+            extras[key] = text[:80]
+    return extras
+
+
+def _should_emit(flow: str, kind: str) -> bool:
+    wait = _DEBOUNCE_SEC.get(kind, 0.0)
+    if wait <= 0:
+        return True
+    key = (flow, kind)
+    now = time.monotonic()
+    last = _last_emit_at.get(key, 0.0)
+    if now - last < wait:
+        return False
+    _last_emit_at[key] = now
+    return True
+
+
+def capture_business_event(
+    flow: str,
+    message: str,
+    *,
+    level: str = "warning",
+    kind: str | None = None,
+    fingerprint: list[str] | None = None,
+    **context: object,
+) -> None:
+    """Envoie un warning Sentry tagué ``flow`` / ``kind``. No-op si DSN vide."""
+    if not _dsn_configured():
+        return
+    flow_tag = flow if flow in ALLOWED_FLOWS else "unknown"
+    kind_tag = str(kind).strip()[:80] if kind else ""
+    if kind_tag and kind_tag not in BUSINESS_KINDS:
+        # Kinds hors liste : on envoie quand même, fingerprint isolé, pas de PII.
+        kind_tag = kind_tag[:80]
+    if kind_tag and not _should_emit(flow_tag, kind_tag):
+        return
+
+    extras = _sanitize_context(context)
+    text = (message or "").strip() or _KIND_MESSAGES.get(kind_tag, "Échec métier")
+    text = text[:200]
+    fp = fingerprint or ["axel-job", flow_tag, kind_tag or text[:80]]
+
+    try:
+        import sentry_sdk
+
+        with sentry_sdk.new_scope() as scope:
+            scope.set_tag("flow", flow_tag)
+            if kind_tag:
+                scope.set_tag("kind", kind_tag)
+            for extra_key, extra_val in extras.items():
+                scope.set_extra(extra_key, extra_val)
+            scope.fingerprint = fp
+            sentry_sdk.capture_message(text, level=level)
+    except Exception:
+        logger.debug("sentry business event skipped", exc_info=True)
+
+
+def capture_adapt_gemini_failure(
+    kind: str | None = None,
+    exc: BaseException | None = None,
+    **context: object,
+) -> None:
+    resolved = kind or (classify_gemini_exc(exc) if exc is not None else "gemini_api_error")
+    extras: dict[str, object] = dict(context)
+    if exc is not None and "provider_code" not in extras:
+        extras["provider_code"] = type(exc).__name__[:80]
+    capture_business_event(
+        "adapt",
+        _KIND_MESSAGES.get(resolved, "Échec adaptation IA"),
+        kind=resolved,
+        **extras,
+    )
+
+
+def capture_empty_pdf_if_needed(pdf_bytes: bytes | None, engine: str) -> None:
+    if pdf_bytes:
+        return
+    capture_business_event(
+        "export",
+        _KIND_MESSAGES["empty_pdf"],
+        kind="empty_pdf",
+        engine=str(engine or "unknown")[:40],
+        size_bytes=0,
+    )
+
+
+def capture_pdf_engine_failure(engine: str, exc: BaseException) -> None:
+    name = type(exc).__name__
+    blob = f"{name} {exc}".lower()
+    kind = "pdf_timeout" if "timeout" in blob else "pdf_engine_fail"
+    capture_business_event(
+        "export",
+        _KIND_MESSAGES[kind],
+        kind=kind,
+        engine=str(engine or "unknown")[:40],
+        provider_code=name[:80],
+    )
+
+
+def maybe_capture_pdf_pool_saturated(qsize: int, pool_size: int, engine: str = "chromium") -> None:
+    workers = max(int(pool_size or 1), 1)
+    waiting = int(qsize or 0)
+    if waiting < max(workers, 2):
+        return
+    capture_business_event(
+        "export",
+        _KIND_MESSAGES["pdf_pool_saturated"],
+        kind="pdf_pool_saturated",
+        engine=str(engine or "chromium")[:40],
+        qsize=waiting,
+        pool_size=workers,
+    )
+
+
+def capture_pg_pool_exhausted(exc: BaseException) -> None:
+    capture_business_event(
+        "auth",
+        _KIND_MESSAGES["pg_pool"],
+        kind="pg_pool",
+        provider_code=type(exc).__name__[:80],
+    )
+
+
+def record_jwt_reject() -> None:
+    """Compte les JWT invalides. N'émet un event que si le seuil (rafale) est atteint."""
+    if not _dsn_configured():
+        return
+    try:
+        window = float(os.environ.get("SENTRY_JWT_BURST_WINDOW_SEC", "60") or "60")
+    except ValueError:
+        window = 60.0
+    try:
+        threshold = int(os.environ.get("SENTRY_JWT_BURST_THRESHOLD", "20") or "20")
+    except ValueError:
+        threshold = 20
+    window = max(window, 1.0)
+    threshold = max(threshold, 2)
+
+    now = time.monotonic()
+    _jwt_fail_ts.append(now)
+    cutoff = now - window
+    while _jwt_fail_ts and _jwt_fail_ts[0] < cutoff:
+        _jwt_fail_ts.popleft()
+    count = len(_jwt_fail_ts)
+    if count < threshold:
+        return
+    global _jwt_burst_emitted_at
+    if now - _jwt_burst_emitted_at < window:
+        return
+    _jwt_burst_emitted_at = now
+    capture_business_event(
+        "auth",
+        _KIND_MESSAGES["jwt_burst"],
+        kind="jwt_burst",
+        burst_count=count,
+    )
+
+
+def note_pdf_bytes(pdf_bytes: bytes | None, engine: str) -> bytes:
+    """Filet dispatch : event si PDF vide, puis renvoie les bytes (éventuellement vides)."""
+    capture_empty_pdf_if_needed(pdf_bytes, engine)
+    return pdf_bytes or b""

--- a/backend/sentry_config.py
+++ b/backend/sentry_config.py
@@ -145,6 +145,19 @@ def _scrub_free_text_fields(event: dict[str, Any]) -> None:
             data.pop("data", None)
 
 
+def _is_business_event(event: dict[str, Any]) -> bool:
+    """Messages métier AXE-370 : ne pas écraser le libellé contrôlé sur /api/adapt*."""
+    tags = event.get("tags")
+    if not isinstance(tags, dict):
+        return False
+    try:
+        from backend.sentry_business import is_business_kind
+
+        return is_business_kind(tags.get("kind"))
+    except Exception:
+        return False
+
+
 def _drop_http_noise(hint: dict[str, Any]) -> bool:
     exc_info = hint.get("exc_info")
     if not exc_info or len(exc_info) < 2:
@@ -182,6 +195,7 @@ def scrub_event(event: dict[str, Any], hint: dict[str, Any] | None = None) -> di
         return event
 
     request = event.get("request")
+    wipe_free_text = _is_sensitive_route(event) and not _is_business_event(event)
     if isinstance(request, dict):
         if _is_sensitive_route(event):
             request.pop("data", None)
@@ -191,9 +205,10 @@ def scrub_event(event: dict[str, Any], hint: dict[str, Any] | None = None) -> di
                 request["headers"] = {
                     k: _FILTERED if _is_sensitive_key(str(k)) else v for k, v in headers.items()
                 }
-            _scrub_free_text_fields(event)
+            if wipe_free_text:
+                _scrub_free_text_fields(event)
         event["request"] = request
-    elif _is_sensitive_route(event):
+    elif wipe_free_text:
         _scrub_free_text_fields(event)
 
     tags = event.setdefault("tags", {})
@@ -205,9 +220,9 @@ def scrub_event(event: dict[str, Any], hint: dict[str, Any] | None = None) -> di
             name = type(exc).__name__
             module = getattr(type(exc), "__module__", "") or ""
             if "Gemini" in name or "gemini" in module:
-                tags.setdefault("flow", "gemini")
+                tags.setdefault("flow", "adapt")
             elif "pdf" in name.lower() or "playwright" in module.lower():
-                tags.setdefault("flow", "pdf")
+                tags.setdefault("flow", "export")
 
     raw_user = event.get("user")
     if isinstance(raw_user, dict):

--- a/backend/sentry_config.py
+++ b/backend/sentry_config.py
@@ -109,12 +109,16 @@ def _is_sensitive_route(event: dict[str, Any]) -> bool:
     return bool(_SENSITIVE_PATH_RE.search(url) or _SENSITIVE_PATH_RE.search(transaction))
 
 
-def _scrub_free_text_fields(event: dict[str, Any]) -> None:
-    """Routes sensibles : message / exception / breadcrumbs ne doivent pas porter de CV."""
-    event["message"] = _FILTERED
-    logentry = event.get("logentry")
-    if isinstance(logentry, dict) and "message" in logentry:
-        logentry["message"] = _FILTERED
+def _scrub_free_text_fields(event: dict[str, Any], *, keep_message: bool = False) -> None:
+    """Routes sensibles : exception / breadcrumbs ne doivent pas porter de CV.
+
+    ``keep_message`` : events métier AXE-370 — conserver le libellé contrôlé.
+    """
+    if not keep_message:
+        event["message"] = _FILTERED
+        logentry = event.get("logentry")
+        if isinstance(logentry, dict) and "message" in logentry:
+            logentry["message"] = _FILTERED
     exception = event.get("exception")
     values: list[Any] = []
     if isinstance(exception, dict):
@@ -195,9 +199,10 @@ def scrub_event(event: dict[str, Any], hint: dict[str, Any] | None = None) -> di
         return event
 
     request = event.get("request")
-    wipe_free_text = _is_sensitive_route(event) and not _is_business_event(event)
+    business = _is_business_event(event)
+    sensitive = _is_sensitive_route(event)
     if isinstance(request, dict):
-        if _is_sensitive_route(event):
+        if sensitive:
             request.pop("data", None)
             request.pop("cookies", None)
             headers = request.get("headers")
@@ -205,11 +210,10 @@ def scrub_event(event: dict[str, Any], hint: dict[str, Any] | None = None) -> di
                 request["headers"] = {
                     k: _FILTERED if _is_sensitive_key(str(k)) else v for k, v in headers.items()
                 }
-            if wipe_free_text:
-                _scrub_free_text_fields(event)
+            _scrub_free_text_fields(event, keep_message=business)
         event["request"] = request
-    elif wipe_free_text:
-        _scrub_free_text_fields(event)
+    elif sensitive:
+        _scrub_free_text_fields(event, keep_message=business)
 
     tags = event.setdefault("tags", {})
     if isinstance(tags, dict):

--- a/backend/services/adapter.py
+++ b/backend/services/adapter.py
@@ -271,12 +271,9 @@ def _gemini_usage_guard():
 
 
 def _capture_adapt_failure(kind: str | None = None, exc: BaseException | None = None) -> None:
-    try:
-        from backend.sentry_business import capture_adapt_gemini_failure
+    from backend.sentry_business import capture_adapt_gemini_failure
 
-        capture_adapt_gemini_failure(kind=kind, exc=exc)
-    except Exception:
-        pass
+    capture_adapt_gemini_failure(kind=kind, exc=exc)
 
 
 def adapter_cv(

--- a/backend/services/adapter.py
+++ b/backend/services/adapter.py
@@ -270,6 +270,15 @@ def _gemini_usage_guard():
         return lambda uid: None, lambda uid, op, r: None
 
 
+def _capture_adapt_failure(kind: str | None = None, exc: BaseException | None = None) -> None:
+    try:
+        from backend.sentry_business import capture_adapt_gemini_failure
+
+        capture_adapt_gemini_failure(kind=kind, exc=exc)
+    except Exception:
+        pass
+
+
 def adapter_cv(
     cv_base: dict,
     offre: dict,
@@ -305,12 +314,17 @@ def adapter_cv(
 
     def _call(prompt: str) -> tuple[str, object]:
         full_prompt = SYSTEM_PROMPT.strip() + "\n\n---\n\n" + prompt
-        r = client.models.generate_content(
-            model=model_id,
-            contents=full_prompt,
-            config=config,
-        )
+        try:
+            r = client.models.generate_content(
+                model=model_id,
+                contents=full_prompt,
+                config=config,
+            )
+        except Exception as exc:
+            _capture_adapt_failure(exc=exc)
+            raise
         if not r or not getattr(r, "text", None):
+            _capture_adapt_failure(kind="gemini_empty")
             raise ValueError("Réponse Gemini vide")
         return r.text, r
 
@@ -327,6 +341,7 @@ def adapter_cv(
         tweaks = _extract_json(raw or "")
 
     if tweaks is None:
+        _capture_adapt_failure(kind="gemini_unparseable")
         raise ValueError("Impossible d'extraire un JSON valide de la réponse Gemini.")
 
     _sanitize_tweaks_text(tweaks)
@@ -451,12 +466,17 @@ def _adapt_gemini_json(system: str, user: str, user_id: str | None, operation: s
 
     def _call(prompt: str) -> tuple[str, object]:
         full_prompt = system.strip() + "\n\n---\n\n" + prompt
-        r = client.models.generate_content(
-            model=GEMINI_MODEL_DEFAULT,
-            contents=full_prompt,
-            config=config,
-        )
+        try:
+            r = client.models.generate_content(
+                model=GEMINI_MODEL_DEFAULT,
+                contents=full_prompt,
+                config=config,
+            )
+        except Exception as exc:
+            _capture_adapt_failure(exc=exc)
+            raise
         if not r or not getattr(r, "text", None):
+            _capture_adapt_failure(kind="gemini_empty")
             raise ValueError("Réponse Gemini vide")
         return r.text, r
 
@@ -471,6 +491,7 @@ def _adapt_gemini_json(system: str, user: str, user_id: str | None, operation: s
         record_and_check(user_id, operation, resp2)
         data = _extract_json(raw2 or "")
     if data is None:
+        _capture_adapt_failure(kind="gemini_unparseable")
         raise ValueError("Impossible d'extraire un JSON valide de la réponse Gemini.")
     return data
 

--- a/backend/services/pdf_structural_extract.py
+++ b/backend/services/pdf_structural_extract.py
@@ -1213,18 +1213,15 @@ def extract_layout_from_pdf(file_bytes: bytes, max_pages: int = MAX_PAGES) -> di
         doc = fitz.open(stream=file_bytes, filetype="pdf")
     except Exception as exc:
         logger.warning("pdf_structural_extract: ouverture PDF échouée: %s", exc)
-        try:
-            from backend.sentry_business import capture_business_event
+        from backend.sentry_business import capture_business_event
 
-            capture_business_event(
-                "import",
-                "PyMuPDF import en échec",
-                kind="pymupdf_fail",
-                size_bytes=len(file_bytes),
-                provider_code=type(exc).__name__,
-            )
-        except Exception:
-            pass
+        capture_business_event(
+            "import",
+            "PyMuPDF import en échec",
+            kind="pymupdf_fail",
+            size_bytes=len(file_bytes),
+            provider_code=type(exc).__name__,
+        )
         return None
 
     try:

--- a/backend/services/pdf_structural_extract.py
+++ b/backend/services/pdf_structural_extract.py
@@ -1213,6 +1213,18 @@ def extract_layout_from_pdf(file_bytes: bytes, max_pages: int = MAX_PAGES) -> di
         doc = fitz.open(stream=file_bytes, filetype="pdf")
     except Exception as exc:
         logger.warning("pdf_structural_extract: ouverture PDF échouée: %s", exc)
+        try:
+            from backend.sentry_business import capture_business_event
+
+            capture_business_event(
+                "import",
+                "PyMuPDF import en échec",
+                kind="pymupdf_fail",
+                size_bytes=len(file_bytes),
+                provider_code=type(exc).__name__,
+            )
+        except Exception:
+            pass
         return None
 
     try:

--- a/backend/supabase_pg.py
+++ b/backend/supabase_pg.py
@@ -20,6 +20,30 @@ logger = logging.getLogger(__name__)
 _pool = None
 
 
+class _SentryAwarePool:
+    """Relais ConnectionPool : signale un PoolTimeout sans changer l'API."""
+
+    def __init__(self, pool: Any) -> None:
+        self._pool = pool
+
+    def connection(self, *args: Any, **kwargs: Any) -> Any:
+        try:
+            return self._pool.connection(*args, **kwargs)
+        except Exception as exc:
+            name = type(exc).__name__
+            if name in {"PoolTimeout", "PoolClosed"} or "pooltimeout" in name.lower():
+                try:
+                    from backend.sentry_business import capture_pg_pool_exhausted
+
+                    capture_pg_pool_exhausted(exc)
+                except Exception:
+                    pass
+            raise
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._pool, name)
+
+
 def is_configured() -> bool:
     from backend.config import SUPABASE_DATABASE_URL, USE_SUPABASE
 
@@ -37,16 +61,18 @@ def get_pool():
 
     from backend.config import SUPABASE_DATABASE_URL, supabase_pg_pool_max
 
-    _pool = ConnectionPool(
-        conninfo=SUPABASE_DATABASE_URL,
-        min_size=1,
-        max_size=supabase_pg_pool_max(),
-        kwargs={
-            "connect_timeout": int(os.environ.get("SUPABASE_PG_CONNECT_TIMEOUT", "10")),
-            "options": "-c statement_timeout=30000",  # 30s max par statement
-        },
-        open=True,
-        name="cv_bot_supabase",
+    _pool = _SentryAwarePool(
+        ConnectionPool(
+            conninfo=SUPABASE_DATABASE_URL,
+            min_size=1,
+            max_size=supabase_pg_pool_max(),
+            kwargs={
+                "connect_timeout": int(os.environ.get("SUPABASE_PG_CONNECT_TIMEOUT", "10")),
+                "options": "-c statement_timeout=30000",  # 30s max par statement
+            },
+            open=True,
+            name="cv_bot_supabase",
+        )
     )
     return _pool
 

--- a/backend/supabase_pg.py
+++ b/backend/supabase_pg.py
@@ -32,13 +32,22 @@ class _SentryAwarePool:
         except Exception as exc:
             name = type(exc).__name__
             if name in {"PoolTimeout", "PoolClosed"} or "pooltimeout" in name.lower():
-                try:
-                    from backend.sentry_business import capture_pg_pool_exhausted
+                from backend.sentry_business import capture_pg_pool_exhausted
 
-                    capture_pg_pool_exhausted(exc)
-                except Exception:
-                    pass
+                capture_pg_pool_exhausted(exc)
             raise
+
+    def __enter__(self) -> _SentryAwarePool:
+        enter = getattr(self._pool, "__enter__", None)
+        if callable(enter):
+            enter()
+        return self
+
+    def __exit__(self, *args: Any) -> Any:
+        leave = getattr(self._pool, "__exit__", None)
+        if callable(leave):
+            return leave(*args)
+        return None
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._pool, name)

--- a/docs/observabilite.md
+++ b/docs/observabilite.md
@@ -13,7 +13,7 @@ Consentement : même logique que [AXE-363](https://linear.app/axel-project/issue
 **Go Sentry** pour le diagnostic d’erreurs (front React + back FastAPI).  
 **Pas** un outil analytics. **Pas** de Session Replay. **Pas** derrière la CMP.
 
-État `main` (août 2026) : SDK backend [AXE-367](https://linear.app/axel-project/issue/AXE-367) (`sentry-sdk`, DSN vide = no-op). Frontend : [AXE-368](https://linear.app/axel-project/issue/AXE-368). Prometheus reste (`monitoring_ops.py` / `/metrics`) = volume ; Sentry = stack + contexte.
+État `main` (août 2026) : SDK backend [AXE-367](https://linear.app/axel-project/issue/AXE-367) (`sentry-sdk`, DSN vide = no-op). Frontend : [AXE-368](https://linear.app/axel-project/issue/AXE-368). Contextes métier : [AXE-370](https://linear.app/axel-project/issue/AXE-370) (`backend/sentry_business.py`). Prometheus reste (`monitoring_ops.py` / `/metrics`) = volume ; Sentry = diagnostic.
 
 ---
 
@@ -55,7 +55,7 @@ Backend : `SENTRY_ENVIRONMENT` sinon `ENVIRONMENT`. Frontend : `VITE_SENTRY_ENVI
 | Chemins fichiers utilisateur | uploads locaux |
 | `setUser` | **pas d’email**. `id` = UUID Supabase (opaque) + tag `plan` = `free` \| `pro` |
 
-OK : route, status HTTP, `flow`, moteur PDF, durée, taille fichier, code d’erreur fournisseur, `release`, `environment`.
+OK : route, status HTTP, `flow`, `kind`, moteur PDF, durée, taille fichier, code d’erreur fournisseur, `release`, `environment`.
 
 ### Consentement (RGPD)
 
@@ -105,6 +105,24 @@ Aucune n’est à committer en dur. DSN vide = no-op (dev + CI).
 
 ---
 
+## Events métier (AXE-370)
+
+Helper : `backend/sentry_business.py` → `capture_business_event(flow, message, kind=...)`.
+
+Les 4xx FastAPI sont ignorés par `before_send` (AXE-367). Un quota Gemini (429), un JWT invalide (401) ou un webhook Stripe rejeté (400) **ne lèvent donc pas** d’issue Sentry tout seuls : le helper envoie un `capture_message` **warning** avant la conversion HTTP. DSN vide = no-op.
+
+| `flow` | `kind` (exemples) | Quand |
+|---|---|---|
+| `adapt` | `gemini_quota` / `gemini_timeout` / `gemini_api_error` / `gemini_unparseable` / `gemini_empty` | Budget `ensure_budget`, timeout/API Gemini, JSON illisible |
+| `export` | `empty_pdf` / `pdf_timeout` / `pdf_engine_fail` / `pdf_pool_saturated` | PDF 0 octet, Chromium indisponible (repli), file d’attente saturée |
+| `import` | `pdf_unreadable` / `docx_unreadable` / `pymupdf_fail` | pdfplumber / docx / ouverture PyMuPDF |
+| `billing` | `stripe_bad_signature` / `stripe_bad_payload` / `stripe_orphan_subscription` | Webhook rejeté ou checkout sans `user_id` |
+| `auth` | `jwt_burst` / `pg_pool` | Rafale de JWT invalides (seuil, pas un 401 isolé) ; `PoolTimeout` psycopg |
+
+Fingerprint : `["axel-job", flow, kind]` — quota ≠ erreur API. Extras autorisés : `size_bytes`, `engine`, `duration_ms`, `provider_code`, `burst_count`, `qsize`… Jamais CV / annonce / e-mail. Ce n’est **pas** un doublon des compteurs Prometheus (`/metrics`) : Sentry = un incident identifiable, Prometheus = volume.
+
+---
+
 ## Mention `/confidentialite` (posée dans ce spike)
 
 À garder alignée HTML (`frontend/public/confidentialite.html`) **et** React (`LegalPages.jsx`) :
@@ -121,7 +139,7 @@ Aucune n’est à committer en dur. DSN vide = no-op (dev + CI).
 1. **Ops** : créer `axel-job-frontend` + `axel-job-backend` dans l’org `axel-project` (Louis / admin Sentry).
 2. [AXE-369](https://linear.app/axel-project/issue/AXE-369) env/secrets (peut chevaucher 367/368).
 3. [AXE-367](https://linear.app/axel-project/issue/AXE-367) + [AXE-368](https://linear.app/axel-project/issue/AXE-368) en parallèle.
-4. [AXE-370](https://linear.app/axel-project/issue/AXE-370) contextes métier.
+4. [AXE-370](https://linear.app/axel-project/issue/AXE-370) contextes métier — code livré, recette DSN = 371.
 5. [AXE-371](https://linear.app/axel-project/issue/AXE-371) smoke + alertes email high-priority (même recette que CRM AXE-269 : pas Slack v1).
 
 ---

--- a/tests/test_sentry_backend.py
+++ b/tests/test_sentry_backend.py
@@ -108,6 +108,21 @@ def test_before_send_scrubs_exception_and_breadcrumb_on_adapt() -> None:
     assert out["breadcrumbs"]["values"][0]["message"] == "[Filtered]"
 
 
+def test_before_send_keeps_business_message_on_adapt() -> None:
+    event = {
+        "transaction": "/api/adapt",
+        "message": "Quota Gemini dépassé",
+        "level": "warning",
+        "tags": {"kind": "gemini_quota", "flow": "adapt"},
+        "request": {"url": "https://api.example/api/adapt"},
+    }
+    out = scrub_event(event, {})
+    assert out is not None
+    assert out["message"] == "Quota Gemini dépassé"
+    assert out["tags"]["kind"] == "gemini_quota"
+    assert out["tags"]["flow"] == "adapt"
+
+
 def test_before_send_keeps_500_and_tags_gemini() -> None:
     exc = GeminiQuotaExceeded()
     out = scrub_event(
@@ -115,7 +130,7 @@ def test_before_send_keeps_500_and_tags_gemini() -> None:
         {"exc_info": (GeminiQuotaExceeded, exc, None)},
     )
     assert out is not None
-    assert out["tags"]["flow"] == "gemini"
+    assert out["tags"]["flow"] == "adapt"
 
 
 def test_bind_sentry_user_skips_without_dsn(monkeypatch) -> None:

--- a/tests/test_sentry_backend.py
+++ b/tests/test_sentry_backend.py
@@ -112,13 +112,29 @@ def test_before_send_keeps_business_message_on_adapt() -> None:
     event = {
         "transaction": "/api/adapt",
         "message": "Quota Gemini dépassé",
+        "logentry": {"message": "Quota Gemini dépassé"},
         "level": "warning",
         "tags": {"kind": "gemini_quota", "flow": "adapt"},
-        "request": {"url": "https://api.example/api/adapt"},
+        "exception": {
+            "values": [{"type": "ValueError", "value": "CV payload: Jean Dupont CV secret"}]
+        },
+        "breadcrumbs": {
+            "values": [{"message": "annonce Offre secrète Dev", "data": {"body": "Jean Dupont"}}]
+        },
+        "request": {
+            "url": "https://api.example/api/adapt",
+            "data": {"cv": "Jean Dupont CV secret"},
+        },
     }
     out = scrub_event(event, {})
     assert out is not None
+    blob = json.dumps(out)
+    assert "Jean Dupont" not in blob
+    assert "Offre secrète" not in blob
     assert out["message"] == "Quota Gemini dépassé"
+    assert out["logentry"]["message"] == "Quota Gemini dépassé"
+    assert out["exception"]["values"][0]["value"] == "[Filtered]"
+    assert out["breadcrumbs"]["values"][0]["message"] == "[Filtered]"
     assert out["tags"]["kind"] == "gemini_quota"
     assert out["tags"]["flow"] == "adapt"
 

--- a/tests/test_sentry_business.py
+++ b/tests/test_sentry_business.py
@@ -144,6 +144,29 @@ def test_ensure_budget_emits_quota_event(monkeypatch) -> None:
     assert scope.tags["kind"] == "gemini_quota"
 
 
+def test_gemini_quota_is_debounced(monkeypatch) -> None:
+    scope = _FakeScope()
+    captured = _patch_sentry(monkeypatch, scope)
+    capture_adapt_gemini_failure(kind="gemini_quota")
+    capture_adapt_gemini_failure(kind="gemini_quota")
+    assert captured == [("Quota Gemini dépassé", "warning")]
+
+
+def test_sentry_aware_pool_is_context_manager() -> None:
+    from backend.supabase_pg import _SentryAwarePool
+
+    class _Inner:
+        def __enter__(self) -> _Inner:
+            return self
+
+        def __exit__(self, *args: object) -> bool:
+            return False
+
+    wrap = _SentryAwarePool(_Inner())
+    with wrap as pool:
+        assert pool is wrap
+
+
 def test_empty_pdf_emits_export_event(monkeypatch) -> None:
     scope = _FakeScope()
     captured = _patch_sentry(monkeypatch, scope)

--- a/tests/test_sentry_business.py
+++ b/tests/test_sentry_business.py
@@ -1,0 +1,215 @@
+"""AXE-370 : events métier Sentry — no-op DSN vide, fingerprint, pas de PII."""
+
+from __future__ import annotations
+
+from backend.gemini_usage import GeminiQuotaExceeded, ensure_budget
+from backend.sentry_business import (
+    capture_adapt_gemini_failure,
+    capture_business_event,
+    capture_empty_pdf_if_needed,
+    capture_pdf_engine_failure,
+    classify_gemini_exc,
+    maybe_capture_pdf_pool_saturated,
+    record_jwt_reject,
+    reset_business_event_state,
+)
+
+
+class _FakeScope:
+    def __init__(self) -> None:
+        self.tags: dict[str, object] = {}
+        self.extras: dict[str, object] = {}
+        self.fingerprint: list[str] | None = None
+
+    def set_tag(self, key: str, value: object) -> None:
+        self.tags[key] = value
+
+    def set_extra(self, key: str, value: object) -> None:
+        self.extras[key] = value
+
+    def __enter__(self) -> _FakeScope:
+        return self
+
+    def __exit__(self, *args: object) -> bool:
+        return False
+
+
+def _patch_sentry(monkeypatch, scope: _FakeScope) -> list[tuple[str, str]]:
+    captured: list[tuple[str, str]] = []
+
+    def fake_capture_message(message: str, level: str = "info") -> None:
+        captured.append((message, level))
+
+    monkeypatch.setenv("SENTRY_DSN", "https://examplePublicKey@o0.ingest.sentry.io/0")
+    import sentry_sdk
+
+    monkeypatch.setattr(sentry_sdk, "new_scope", lambda: scope)
+    monkeypatch.setattr(sentry_sdk, "capture_message", fake_capture_message)
+    reset_business_event_state()
+    return captured
+
+
+def test_capture_business_event_noop_without_dsn(monkeypatch) -> None:
+    monkeypatch.setenv("SENTRY_DSN", "")
+    reset_business_event_state()
+    called: list[int] = []
+    import sentry_sdk
+
+    monkeypatch.setattr(sentry_sdk, "capture_message", lambda *args, **kwargs: called.append(1))
+    capture_business_event("adapt", "Quota Gemini dépassé", kind="gemini_quota")
+    assert called == []
+
+
+def test_capture_business_event_tags_flow_and_fingerprint(monkeypatch) -> None:
+    scope = _FakeScope()
+    captured = _patch_sentry(monkeypatch, scope)
+    capture_business_event(
+        "adapt",
+        "Quota Gemini dépassé",
+        kind="gemini_quota",
+        size_bytes=2048,
+        engine="n/a",
+    )
+    assert captured == [("Quota Gemini dépassé", "warning")]
+    assert scope.tags["flow"] == "adapt"
+    assert scope.tags["kind"] == "gemini_quota"
+    assert scope.fingerprint == ["axel-job", "adapt", "gemini_quota"]
+    assert scope.extras["size_bytes"] == 2048
+
+
+def test_capture_business_event_drops_pii_extras(monkeypatch) -> None:
+    scope = _FakeScope()
+    captured = _patch_sentry(monkeypatch, scope)
+    capture_business_event(
+        "adapt",
+        "Erreur API Gemini",
+        kind="gemini_api_error",
+        cv_text="Jean Dupont CV secret",
+        email="jean@example.com",
+        annonce="Offre secrète Dev",
+        html="<p>CV</p>",
+        size_bytes=512,
+        provider_code="ClientError",
+    )
+    assert captured
+    blob = str(scope.extras)
+    assert "Jean Dupont" not in blob
+    assert "jean@example.com" not in blob
+    assert "Offre secrète" not in blob
+    assert "cv_text" not in scope.extras
+    assert "email" not in scope.extras
+    assert "annonce" not in scope.extras
+    assert scope.extras["size_bytes"] == 512
+    assert scope.extras["provider_code"] == "ClientError"
+
+
+def test_quota_fingerprint_differs_from_api_error(monkeypatch) -> None:
+    scope_quota = _FakeScope()
+    _patch_sentry(monkeypatch, scope_quota)
+    capture_adapt_gemini_failure(kind="gemini_quota")
+    fp_quota = list(scope_quota.fingerprint or [])
+
+    scope_api = _FakeScope()
+    _patch_sentry(monkeypatch, scope_api)
+    capture_adapt_gemini_failure(kind="gemini_api_error", exc=RuntimeError("GOOGLE 500"))
+    fp_api = list(scope_api.fingerprint or [])
+
+    assert fp_quota == ["axel-job", "adapt", "gemini_quota"]
+    assert fp_api == ["axel-job", "adapt", "gemini_api_error"]
+    assert fp_quota != fp_api
+
+
+def test_classify_gemini_timeout() -> None:
+    class TimeoutErrorLike(Exception):
+        pass
+
+    assert classify_gemini_exc(TimeoutErrorLike("deadline exceeded")) == "gemini_timeout"
+    assert classify_gemini_exc(RuntimeError("RESOURCE_EXHAUSTED")) == "gemini_api_error"
+
+
+def test_ensure_budget_emits_quota_event(monkeypatch) -> None:
+    scope = _FakeScope()
+    captured = _patch_sentry(monkeypatch, scope)
+    monkeypatch.setattr(
+        "backend.gemini_usage.check_gemini_budget",
+        lambda _uid: (False, 12.0, 10.0),
+    )
+    try:
+        ensure_budget("user-1")
+        raise AssertionError("expected GeminiQuotaExceeded")
+    except GeminiQuotaExceeded:
+        pass
+    assert captured == [("Quota Gemini dépassé", "warning")]
+    assert scope.tags["flow"] == "adapt"
+    assert scope.tags["kind"] == "gemini_quota"
+
+
+def test_empty_pdf_emits_export_event(monkeypatch) -> None:
+    scope = _FakeScope()
+    captured = _patch_sentry(monkeypatch, scope)
+    capture_empty_pdf_if_needed(b"", "chromium")
+    assert captured == [("Export PDF vide", "warning")]
+    assert scope.tags["flow"] == "export"
+    assert scope.tags["kind"] == "empty_pdf"
+    assert scope.extras["size_bytes"] == 0
+    assert scope.fingerprint == ["axel-job", "export", "empty_pdf"]
+
+    captured.clear()
+    capture_empty_pdf_if_needed(b"%PDF-1.4 dummy", "chromium")
+    assert captured == []
+
+
+def test_pdf_engine_timeout_kind(monkeypatch) -> None:
+    scope = _FakeScope()
+    captured = _patch_sentry(monkeypatch, scope)
+    capture_pdf_engine_failure("chromium", TimeoutError("page.set_content timeout"))
+    assert captured
+    assert scope.tags["flow"] == "export"
+    assert scope.tags["kind"] == "pdf_timeout"
+    assert scope.extras["provider_code"] == "TimeoutError"
+
+
+def test_pdf_pool_saturated_threshold(monkeypatch) -> None:
+    scope = _FakeScope()
+    captured = _patch_sentry(monkeypatch, scope)
+    maybe_capture_pdf_pool_saturated(0, 1)
+    assert captured == []
+    maybe_capture_pdf_pool_saturated(2, 1)
+    assert captured
+    assert scope.tags["kind"] == "pdf_pool_saturated"
+    assert scope.tags["flow"] == "export"
+
+
+def test_jwt_burst_only_after_threshold(monkeypatch) -> None:
+    scope = _FakeScope()
+    captured = _patch_sentry(monkeypatch, scope)
+    monkeypatch.setenv("SENTRY_JWT_BURST_THRESHOLD", "3")
+    monkeypatch.setenv("SENTRY_JWT_BURST_WINDOW_SEC", "60")
+    record_jwt_reject()
+    record_jwt_reject()
+    assert captured == []
+    record_jwt_reject()
+    assert captured == [("Rejets JWT en rafale", "warning")]
+    assert scope.tags["flow"] == "auth"
+    assert scope.tags["kind"] == "jwt_burst"
+    assert scope.extras["burst_count"] == 3
+    captured.clear()
+    record_jwt_reject()
+    assert captured == []
+
+
+def test_each_flow_has_identifiable_tag(monkeypatch) -> None:
+    for flow, kind, message in (
+        ("adapt", "gemini_unparseable", "Réponse Gemini non parsable"),
+        ("export", "empty_pdf", "Export PDF vide"),
+        ("import", "pdf_unreadable", "PDF import illisible"),
+        ("billing", "stripe_bad_signature", "Webhook Stripe signature invalide"),
+        ("auth", "pg_pool", "Pool Supabase PG saturé"),
+    ):
+        scope = _FakeScope()
+        captured = _patch_sentry(monkeypatch, scope)
+        capture_business_event(flow, message, kind=kind)
+        assert captured, flow
+        assert scope.tags["flow"] == flow
+        assert scope.tags["kind"] == kind
+        assert scope.fingerprint == ["axel-job", flow, kind]

--- a/tests/test_sentry_env_placeholders.py
+++ b/tests/test_sentry_env_placeholders.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -137,10 +138,17 @@ def test_compose_config_blanks_probe_auth_token(tmp_path: Path) -> None:
         "SENTRY_DSN=keep-dsn\nSENTRY_AUTH_TOKEN=probe\n",
         encoding="utf-8",
     )
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("SENTRY") and not key.startswith("VITE_SENTRY")
+    }
     result = subprocess.run(
         [
             "docker",
             "compose",
+            "--env-file",
+            str(tmp_path / ".env"),
             "-f",
             str(tmp_path / "docker-compose.yml"),
             "config",
@@ -148,6 +156,7 @@ def test_compose_config_blanks_probe_auth_token(tmp_path: Path) -> None:
             "json",
         ],
         cwd=tmp_path,
+        env=env,
         capture_output=True,
         text=True,
         check=False,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

- Helper `backend/sentry_business.py` : `capture_message` warning tagué `flow` / `kind`, fingerprint `["axel-job", flow, kind]`, extras allowlist (pas de CV / annonce / e-mail). DSN vide = no-op.
- Instrumentation `adapt` (quota Gemini, timeout/API, JSON illisible), `export` (PDF vide, Chromium indisponible, pool saturé), `import` (PDF/DOCX/PyMuPDF), `billing` (webhook Stripe), `auth` (JWT en rafale, pool PG).
- `before_send` conserve le libellé métier mais **continue de scrubber** exception + breadcrumbs (revue CodeRabbit). Debounce `gemini_quota`. Le wrapper pool PG délègue `__enter__` / `__exit__`.

## Why

Les 4xx FastAPI sont droppés par `before_send` (AXE-367). Quota Gemini, webhook Stripe rejeté, PDF illisible et JWT invalide ne remontaient jamais. Un PDF 0 octet ne lève pas d’exception.

## Linear

Fixes AXE-370

## Validation

- [x] Backend lint passes (`ruff`, `black`, `mypy`)
- [x] Backend tests pass (`pytest`)
- [x] Coverage threshold passes (backend >= 60%)
- [ ] Backend security checks pass (`bandit`, `pip-audit`) — CI Security workflow
- [x] Frontend lint passes (`npm --prefix frontend run lint`)
- [x] Docs updated if needed (`docs/observabilite.md`)
- [x] No secrets committed

## Risk and rollback

- Risk: volume Sentry si un compte est en quota persistante (mitigé : debounce 60s). Fuite PII si `before_send` rate : crumbs/exception restent filtrés sur `/api/adapt*`.
- Rollback: revert du merge ; DSN vide = no-op immédiat sans revert.

## Test plan

- [x] `tests/test_sentry_business.py` + `test_sentry_backend.py` (message métier conservé, crumbs CV filtrés, quota debounce, pool `with`)
- [x] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks` → OK
- [ ] Recette DSN réel = AXE-371 (ne pas coller le DSN ici)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc0ae4e0-6a26-4a87-86b5-88ca53fceec2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * Amélioration du suivi des exports PDF, notamment en cas d’échec, de document vide ou de forte charge.
  * Meilleure détection des erreurs lors de l’adaptation de contenu et des dépassements de quota.
  * Signalement renforcé des problèmes d’authentification, d’import de fichiers, de paiements et d’accès aux données.

* **Documentation**
  * Documentation mise à jour sur la supervision, les diagnostics et les données collectées.

* **Tests**
  * Couverture étendue des scénarios d’erreur et des événements de supervision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->