### PR TITLE
feat(AXE-317): CD deploy-prod.yml sur push prod uniquement

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,78 @@
+# CD production (AXE-317).
+# Un merge dans `prod` (promote main→prod ou hotfix) déclenche ce workflow.
+# Un push sur `main` / une feature / une PR ne déploie pas.
+#
+# Prérequis GitHub (clics humains, une fois) :
+#   Settings → Environments → `production`
+#     - Deployment branches : Restricted → `prod` uniquement
+#     - Secrets : DEPLOY_HOST, DEPLOY_USER, DEPLOY_SSH_KEY
+#     - Optionnel : DEPLOY_PORT (défaut 22), DEPLOY_PATH (/opt/cv-bot),
+#       DEPLOY_HEALTH_URL (http://127.0.0.1/health)
+# Doc : docs/deploy.md §5 et §9.
+
+name: Deploy production
+
+on:
+  push:
+    branches: [prod]
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy /opt/cv-bot
+    if: github.ref == 'refs/heads/prod'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    environment: production
+    steps:
+      - name: Fail if required secrets are missing
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in DEPLOY_HOST DEPLOY_USER DEPLOY_SSH_KEY; do
+            if [ -z "${!name}" ]; then
+              echo "::error::Secret $name manquant sur l'environment GitHub production."
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "Settings → Environments → production → Environment secrets. Voir docs/deploy.md §5."
+            exit 1
+          fi
+
+      - name: SSH git pull + docker compose + smoke /health
+        uses: appleboy/ssh-action@v1.2.5
+        env:
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          DEPLOY_HEALTH_URL: ${{ secrets.DEPLOY_HEALTH_URL }}
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_PORT || 22 }}
+          command_timeout: 30m
+          script_stop: true
+          envs: DEPLOY_PATH,DEPLOY_HEALTH_URL
+          script: |
+            set -euo pipefail
+            DEPLOY_DIR="${DEPLOY_PATH:-/opt/cv-bot}"
+            cd "$DEPLOY_DIR"
+            git fetch origin
+            git checkout -B prod origin/prod
+            branch="$(git rev-parse --abbrev-ref HEAD)"
+            if [ "$branch" != "prod" ]; then
+              echo "Refuse: HEAD=$branch (attendu prod)" >&2
+              exit 1
+            fi
+            export SENTRY_RELEASE="$(git rev-parse HEAD)"
+            bash scripts/deploy-prod.sh --skip-pull

--- a/docs/ADR_MAIN_PROD.md
+++ b/docs/ADR_MAIN_PROD.md
@@ -85,31 +85,33 @@ Pour les **agents** :
 - La prod se met à jour uniquement après merge d’une PR dont la base est `prod`.
 - Push direct vers `main` **et** `prod` : interdit (hooks + `scripts/guard-push-via-pr.sh`).
 
-Pour le **serveur** : checkout `prod`, `git pull origin prod`. Plus de `git pull origin main` en production. Détail : [`deploy.md`](deploy.md).
+Pour le **serveur** : checkout `prod`, déployé par le CD (`deploy-prod.yml`) ou le fallback `scripts/deploy-prod.sh`. Plus de `git pull origin main` en production. Détail : [`deploy.md`](deploy.md).
 
-Pour le **chantier** : cette ADR fige **Option C**. Les tickets suivants livrent le câblage GitHub ; tant qu’ils ne sont pas mergés, le **comportement Git reste Option C**, le **déploiement auto** pas encore.
+Pour le **chantier** : cette ADR fige **Option C**. CI `prod` (AXE-316) et rulesets (AXE-318) sont en place. Le CD (AXE-317) est le workflow `deploy-prod.yml` — coller les secrets de l’environment GitHub `production` avant le premier promote.
 
 | Ticket | Rôle | État au moment de l’ADR |
 | --- | --- | --- |
 | [AXE-316](https://linear.app/axel-project/issue/AXE-316) | CI sur les PR vers `prod` | In Review — [PR #168](https://github.com/presidentaxel/Axeljob/pull/168) |
-| [AXE-317](https://linear.app/axel-project/issue/AXE-317) | CD `deploy-prod.yml` sur `push` à `prod` seulement | Todo |
+| [AXE-317](https://linear.app/axel-project/issue/AXE-317) | CD `deploy-prod.yml` sur `push` à `prod` seulement | Workflow + script ; secrets GitHub environment `production` à coller |
 | [AXE-318](https://linear.app/axel-project/issue/AXE-318) | Branch protection GitHub `main` + `prod` (Settings) | Todo — clics humains |
 | [AXE-319](https://linear.app/axel-project/issue/AXE-319) | Cette ADR + runbook + garde-fous locaux | Ce document |
 | [AXE-320](https://linear.app/axel-project/issue/AXE-320) | Smoke E2E promote + hotfix/backport | Backlog — bloqué par 316–319 |
 
-### Fallback jusqu’à AXE-317
+### Fallback si le CD est down
 
-Le workflow CD n’existe pas encore. Après merge de la PR promote dans `prod` :
+Chemin nominal : merge dans `prod` → [`.github/workflows/deploy-prod.yml`](../.github/workflows/deploy-prod.yml) → SSH → `scripts/deploy-prod.sh`.
 
-1. Sur le serveur : `git fetch origin && git checkout prod && git pull origin prod`
-2. `docker compose build && docker compose up -d`
+Si Actions est down / secrets absents :
+
+1. Sur le serveur : `cd /opt/cv-bot && git fetch origin && git checkout -B prod origin/prod`
+2. `bash scripts/deploy-prod.sh --skip-pull`
 3. Vérifier `/health`
 
-Si le CD est down plus tard : **même fallback**, toujours depuis `prod`, jamais depuis `main`.
+Toujours depuis `prod`, jamais depuis `main`. Détail : [`deploy.md`](deploy.md) §9.
 
 ### Protections GitHub (AXE-318)
 
-Les hooks locaux bloquent déjà `main` / `master` / `prod` sur une machine configurée. GitHub Settings n’est **pas** encore coché : un admin peut encore pousser en urgence. Checklist : [`branch-protections.md`](branch-protections.md).
+Les hooks locaux bloquent déjà `main` / `master` / `prod` sur une machine configurée. Rulesets GitHub `main` et `prod` : **actifs** (AXE-318). Checklist : [`branch-protections.md`](branch-protections.md).
 
 ---
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -213,7 +213,7 @@ gh pr create --base main --title "fix: …" --body "…"
 > [!WARNING]
 > Ne pas committer de secrets (`.env`, cles API, tokens).
 >
-> **Ne jamais** `git push origin main` ni `git push origin prod` — intégration **et** mise en prod passent par PR.
+> **Ne jamais** `git push origin main` ni `git push origin prod` — intégration **et** mise en prod passent par PR. Merge dans `prod` → CD (`.github/workflows/deploy-prod.yml`) ; fallback : `docs/deploy.md` §9.
 
 ## 8) Pre-push (CI + security locale)
 

--- a/docs/branch-protections.md
+++ b/docs/branch-protections.md
@@ -11,15 +11,15 @@
 
 | Contrôle | Statut | Notes |
 |----------|--------|-------|
-| Branch protection `main` | **Non activée** | Repo public → disponible sans GitHub Pro ; **pas encore configurée** (API 404). Ticket [AXE-318](https://linear.app/axel-project/issue/AXE-318) |
-| Branch protection `prod` | **Non activée** | Même ticket AXE-318 — clics Settings |
-| Repository rulesets | **Non activés** | Disponibles sur repo public ; à activer si on préfère rulesets aux classic rules |
+| Branch protection `main` | **Ruleset actif** | [AXE-318](https://linear.app/axel-project/issue/AXE-318) — ruleset `main` (PR + status checks CI) |
+| Branch protection `prod` | **Ruleset actif** | Même ticket — ruleset `prod` |
+| Repository rulesets | **Actifs** | `main` (id 21561178) et `prod` (id 21561319), enforcement Active |
 | CI sur PR vers `main` | **Actif** | [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) + [`security.yml`](../.github/workflows/security.yml) |
-| CI sur PR vers `prod` | **En cours** | [AXE-316](https://linear.app/axel-project/issue/AXE-316) — [PR #168](https://github.com/presidentaxel/Axeljob/pull/168) (In Review). Sur `main` aujourd’hui, `pull_request` ne liste pas encore `prod` |
-| CD auto sur `prod` | **Pas encore** | [AXE-317](https://linear.app/axel-project/issue/AXE-317) (`deploy-prod.yml`). **Fallback :** `git pull origin prod` + Docker — [`deploy.md`](deploy.md) |
+| CI sur PR vers `prod` | **Actif** | [AXE-316](https://linear.app/axel-project/issue/AXE-316) — `pull_request` vers `prod` (smoke PR #208 fermée sans merge) |
+| CD auto sur `prod` | **Workflow livré** | [AXE-317](https://linear.app/axel-project/issue/AXE-317) — [`.github/workflows/deploy-prod.yml`](../.github/workflows/deploy-prod.yml). **Secrets** environment `production` à coller ; fallback [`deploy.md`](deploy.md) §9 |
 | Garde-fous locaux | **Actifs** | Hooks Git + Cursor (voir §2) — `main` / `master` / **`prod`** |
 
-**Conséquence :** GitHub n’empêche pas encore un admin de pousser direct sur `main` ou `prod`. La discipline équipe + les hooks locaux + la CI sur les PR vers `main` sont les garde-fous effectifs aujourd’hui. **À faire :** activer la branch protection §4 (repo public → pas besoin de Pro).
+**Conséquence :** les rulesets GitHub refusent un push direct (hors bypass admin). Les hooks locaux + la CI sur les PR vers `main` **et** `prod` restent le filet quotidien. CD : workflow livré, secrets environment `production` à coller ([`deploy.md`](deploy.md) §10).
 
 `origin/prod` **existe**. Elle peut être en retard sur `origin/main` tant que le premier promote n’est pas mergé.
 
@@ -102,7 +102,7 @@ Dès que c’est coché, un `git push origin main` ou `git push origin prod` est
 | Branche `prod` | **Présente** (`origin/prod`) | Prod dédiée |
 | Staging DO | Absent | Présent (WhatsApp) |
 | Visibilité repo | **Public** → branch protection possible sans Pro | Privé Free → Pro requis |
-| CD | **Pas encore** (AXE-317) — fallback `git pull origin prod` | `deploy-prod.yml` |
+| CD | `deploy-prod.yml` (AXE-317) — secrets environment `production` | `deploy-prod.yml` |
 | Garde-fous locaux | Hooks Git + Cursor (`main` + `prod`) | Discipline + env policies CD |
 
 Le flux `main` → `prod` **est** le modèle AxeL Job. Merger dans `main` met à jour l’intégration ; le **déploiement serveur** suit le merge dans `prod` ([`deploy.md`](deploy.md)).

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -14,7 +14,8 @@ Branche Git de production : **`prod`**. `main` est l'integration — voir [`ADR_
 6. Configuration critique
 7. Checklist production
 8. Sentry (observabilite)
-9. Fallback CD (jusqu'a AXE-317)
+9. Fallback CD (si le workflow GitHub est down)
+10. Environment GitHub `production` (secrets CD)
 
 ## 1) Prerequis
 
@@ -71,7 +72,7 @@ Fixes AXE-XX
 
 ## Test plan
 - [ ] CI verte sur cette PR
-- [ ] Apres merge : CD (AXE-317) ou fallback §9
+- [ ] Apres merge : CD `deploy-prod.yml` part ; sinon fallback §9
 - [ ] `curl …/health` → ok
 EOF
 )"
@@ -84,21 +85,16 @@ Hotfix urgence : brancher depuis `origin/prod`, PR vers `prod`, puis backport `m
 
 ## 5) Mise a jour serveur (depuis `prod`)
 
-Apres merge de la PR promote (ou hotfix) dans `prod` :
+Chemin **nominal** ([AXE-317](https://linear.app/axel-project/issue/AXE-317)) : un merge dans `prod` (PR promote `main` → `prod`, ou hotfix) pousse `origin/prod` et GitHub Actions lance [`.github/workflows/deploy-prod.yml`](../.github/workflows/deploy-prod.yml). Le job SSH dans `/opt/cv-bot`, aligne `prod`, puis exécute `scripts/deploy-prod.sh` (build Compose + smoke `/health`).
 
-```bash
-cd /opt/cv-bot
-git fetch origin
-git checkout prod
-git pull origin prod
-docker compose build
-docker compose up -d
-```
+Un push sur `main`, une feature, ou une PR **ne déclenche pas** ce workflow (`on.push.branches: [prod]` + `if: github.ref == 'refs/heads/prod'`).
+
+Prérequis une fois (clics GitHub, pas dans Git) : §10 — environment `production` + secrets SSH.
 
 > [!WARNING]
 > Ne plus `git pull origin main` sur le serveur de production. `main` n'est plus la prod.
 
-Quand [AXE-317](https://linear.app/axel-project/issue/AXE-317) sera livre, un `push` sur `prod` declenchera le CD (`deploy-prod.yml`) et cette etape manuelle ne sera plus le chemin nominal — garder §9 si le CD est down.
+Si le CD est down ou les secrets manquent : fallback §9 (même script, à la main).
 
 ## 6) Configuration critique
 
@@ -114,6 +110,7 @@ Quand [AXE-317](https://linear.app/axel-project/issue/AXE-317) sera livre, un `p
 ## 7) Checklist production
 
 - [ ] PR promote (ou hotfix) mergee dans `prod` — pas un simple merge `main`.
+- [ ] Run GitHub **Deploy production** vert (ou fallback §9 documenté).
 - [ ] Serveur sur la branche `prod` (`git rev-parse --abbrev-ref HEAD`).
 - [ ] Variables d'environnement completees et verifiees.
 - [ ] Build Docker ok.
@@ -161,11 +158,42 @@ Recuperer les DSN : Sentry → projet → Settings → Client Keys (DSN). Un DSN
 Session Replay : **off**. CV / annonce : **jamais** dans un event.
 Recette post-deploy : [AXE-371](https://linear.app/axel-project/issue/AXE-371).
 
-## 9) Fallback CD (jusqu'a AXE-317)
+## 9) Fallback CD (si le workflow GitHub est down)
 
-Le workflow GitHub `deploy-prod.yml` n'existe pas encore. Apres merge dans `prod` :
+Le chemin nominal est le workflow `deploy-prod.yml`. Si Actions est rouge, timeout, ou secrets absents, **même déploiement**, toujours depuis `prod` :
 
-1. Executer §5 a la main (toujours `prod`, jamais `main`).
-2. Verifier `/health`.
+```bash
+cd /opt/cv-bot
+git fetch origin
+git checkout -B prod origin/prod
+bash scripts/deploy-prod.sh --skip-pull
+```
 
-Si le CD est down plus tard : **meme fallback**.
+(`deploy-prod.sh` refuse de tourner si HEAD n'est pas `prod`. Smoke `/health` inclus.)
+
+Équivalent historique (sans le script) :
+
+```bash
+cd /opt/cv-bot
+git fetch origin
+git checkout prod
+git pull --ff-only origin prod
+docker compose build
+docker compose up -d
+curl http://localhost/health
+```
+
+## 10) Environment GitHub `production` (secrets CD)
+
+Repo → **Settings → Environments → New environment** → nom exact `production`.
+
+| Réglage | Valeur |
+| --- | --- |
+| Deployment branches | Restricted → `prod` uniquement |
+| Required reviewers | optionnel (solo : 0) |
+| Secrets (obligatoires) | `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_KEY` |
+| Secrets (optionnels) | `DEPLOY_PORT` (défaut `22`), `DEPLOY_PATH` (défaut `/opt/cv-bot`), `DEPLOY_HEALTH_URL` (défaut `http://127.0.0.1/health`) |
+
+`DEPLOY_SSH_KEY` = clé **privée** dont la publique est dans `~/.ssh/authorized_keys` du user deploy sur le droplet. Le user SSH doit pouvoir `docker compose` (groupe `docker`). Pas Docker Hub : le build Compose se fait **sur le serveur**, comme aujourd'hui.
+
+Sans ces secrets, le workflow échoue tout de suite (« Secret DEPLOY_* manquant ») et n'ouvre pas de session SSH. Le fallback §9 reste valable.

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -111,7 +111,7 @@ Détail (titre, body, fallback CD) : [`ADR_MAIN_PROD.md`](ADR_MAIN_PROD.md) et [
 
 Cette PR emporte **tout** `main` qui n’est pas déjà dans `prod`. Ne pas y coller un correctif isolé « par-dessus » : soit il est déjà dans `main`, soit c’est un hotfix depuis `prod`.
 
-Jusqu’à [AXE-317](https://linear.app/axel-project/issue/AXE-317) (CD), le merge dans `prod` **ne déploie pas tout seul** : enchaîner le fallback serveur (`git pull origin prod` + Docker) décrit dans [`deploy.md`](deploy.md).
+Après merge dans `prod`, le CD [`.github/workflows/deploy-prod.yml`](../.github/workflows/deploy-prod.yml) déploie tout seul (SSH + `scripts/deploy-prod.sh`). Si Actions est down : fallback [`deploy.md`](deploy.md) §9.
 
 ---
 

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Déploiement production AxeL Job depuis la branche `prod`.
+#
+# Chemin nominal : appelé par .github/workflows/deploy-prod.yml (SSH après
+# `git checkout -B prod origin/prod`).
+# Fallback si le CD GitHub est down :
+#   cd /opt/cv-bot && git fetch origin && git checkout -B prod origin/prod
+#   bash scripts/deploy-prod.sh --skip-pull
+#
+# Ne jamais lancer ce script sur `main` ni une feature.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+SKIP_PULL=0
+DRY_RUN=0
+HEALTH_URL="${DEPLOY_HEALTH_URL:-http://127.0.0.1/health}"
+HEALTH_RETRIES="${DEPLOY_HEALTH_RETRIES:-30}"
+HEALTH_INTERVAL_SEC="${DEPLOY_HEALTH_INTERVAL_SEC:-5}"
+
+usage() {
+  cat <<'EOF'
+Usage: bash scripts/deploy-prod.sh [--skip-pull] [--dry-run] [--health-url URL]
+
+  --skip-pull     Ne pas git fetch/pull (le CD a déjà aligné HEAD sur origin/prod).
+  --dry-run       Vérifie que HEAD est `prod`, n'exécute ni Docker ni curl.
+  --health-url    Override DEPLOY_HEALTH_URL (défaut: http://127.0.0.1/health).
+EOF
+}
+
+die() {
+  echo "deploy-prod.sh: $*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-pull) SKIP_PULL=1 ;;
+    --dry-run) DRY_RUN=1 ;;
+    --health-url)
+      [[ $# -ge 2 ]] || die "--health-url attend une URL"
+      HEALTH_URL="$2"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      die "argument inconnu: $1"
+      ;;
+  esac
+  shift
+done
+
+branch="$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+[[ "$branch" == "prod" ]] || die "refuse (HEAD=${branch:-?}, besoin prod)"
+
+if [[ "$SKIP_PULL" -eq 0 ]]; then
+  git fetch origin
+  git pull --ff-only origin prod
+  branch="$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --abbrev-ref HEAD)"
+  [[ "$branch" == "prod" ]] || die "refuse après pull (HEAD=$branch, besoin prod)"
+fi
+
+dirty="$(git status --porcelain --untracked-files=no || true)"
+if [[ -n "$dirty" ]]; then
+  echo "$dirty" >&2
+  die "working tree tracked dirty — refuser un deploy ambigu"
+fi
+
+export SENTRY_RELEASE="${SENTRY_RELEASE:-$(git rev-parse HEAD)}"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "dry-run: HEAD=prod SHA=$SENTRY_RELEASE smoke=$HEALTH_URL"
+  echo "dry-run: docker compose build && docker compose up -d"
+  exit 0
+fi
+
+echo "deploy-prod: SHA=$SENTRY_RELEASE health=$HEALTH_URL"
+docker compose build
+docker compose up -d
+
+health_ok() {
+  local body
+  body="$(curl -fsS --max-time 5 "$HEALTH_URL" 2>/dev/null || true)"
+  [[ "$body" == *'"status":"ok"'* || "$body" == *'"status": "ok"'* ]]
+}
+
+i=1
+while [[ "$i" -le "$HEALTH_RETRIES" ]]; do
+  if health_ok; then
+    echo "deploy-prod: smoke OK ($HEALTH_URL) SHA=$SENTRY_RELEASE"
+    exit 0
+  fi
+  echo "deploy-prod: health pas encore ok ($i/$HEALTH_RETRIES), retry ${HEALTH_INTERVAL_SEC}s"
+  sleep "$HEALTH_INTERVAL_SEC"
+  i=$((i + 1))
+done
+
+die "smoke /health KO après ${HEALTH_RETRIES} essais ($HEALTH_URL)"

--- a/tests/test_deploy_prod_cd.py
+++ b/tests/test_deploy_prod_cd.py
@@ -1,0 +1,132 @@
+"""AXE-317 : CD uniquement sur `prod`, script de deploy + fallback documenté."""
+
+from __future__ import annotations
+
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "deploy-prod.yml"
+SCRIPT = ROOT / "scripts" / "deploy-prod.sh"
+
+
+def _read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def _prepare_repo(tmp_path: Path, branch: str) -> Path:
+    subprocess.run(
+        ["git", "init", "-b", branch, str(tmp_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.email", "ci@example.com"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.name", "ci"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    (tmp_path / "README").write_text("deploy-prod test\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "add", "README"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "commit", "-m", "init"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    dest = scripts / "deploy-prod.sh"
+    shutil.copy(SCRIPT, dest)
+    dest.chmod(dest.stat().st_mode | stat.S_IEXEC)
+    return tmp_path
+
+
+def _run_script(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(cwd / "scripts" / "deploy-prod.sh"), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_workflow_file_exists() -> None:
+    assert WORKFLOW.is_file()
+
+
+def test_workflow_triggers_only_on_prod_push() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "branches: [prod]" in text
+    assert "pull_request" not in text
+    assert "workflow_dispatch" not in text
+    on_idx = text.index("\non:")
+    jobs_idx = text.index("\njobs:")
+    on_block = text[on_idx:jobs_idx]
+    assert "main" not in on_block
+    assert "wip/innovation" not in on_block
+    assert "prod" in on_block
+
+
+def test_workflow_uses_production_environment_and_keeps_inflight_deploys() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "environment: production" in text
+    assert "cancel-in-progress: false" in text
+    assert "github.ref == 'refs/heads/prod'" in text
+    assert "appleboy/ssh-action@v1.2.5" in text
+    assert "scripts/deploy-prod.sh --skip-pull" in text
+    assert "DEPLOY_HOST" in text
+    assert "DEPLOY_USER" in text
+    assert "DEPLOY_SSH_KEY" in text
+
+
+def test_script_refuses_non_prod_branch(tmp_path: Path) -> None:
+    repo = _prepare_repo(tmp_path, "main")
+    result = _run_script(repo, "--dry-run")
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "besoin prod" in result.stderr
+
+
+def test_script_dry_run_ok_on_prod(tmp_path: Path) -> None:
+    repo = _prepare_repo(tmp_path, "prod")
+    result = _run_script(repo, "--dry-run", "--skip-pull")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "HEAD=prod" in result.stdout
+    assert "docker compose" in result.stdout
+
+
+def test_script_unknown_arg_exits_error(tmp_path: Path) -> None:
+    repo = _prepare_repo(tmp_path, "prod")
+    result = _run_script(repo, "--nope")
+    assert result.returncode == 1
+    assert "argument inconnu" in result.stderr
+
+
+def test_deploy_docs_describe_cd_and_fallback() -> None:
+    deploy = _read("docs/deploy.md")
+    assert "deploy-prod.yml" in deploy
+    assert "scripts/deploy-prod.sh" in deploy
+    assert "DEPLOY_HOST" in deploy
+    assert "DEPLOY_SSH_KEY" in deploy
+    assert "Environment GitHub `production`" in deploy
+    adr = _read("docs/ADR_MAIN_PROD.md")
+    assert "AXE-317" in adr
+    git_wf = _read("docs/git-workflow.md")
+    assert "deploy-prod.yml" in git_wf
+    protections = _read("docs/branch-protections.md")
+    assert "deploy-prod.yml" in protections


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

- Workflow GitHub [`.github/workflows/deploy-prod.yml`](.github/workflows/deploy-prod.yml) : `on.push.branches: [prod]` uniquement, `environment: production`, SSH (`appleboy/ssh-action@v1.2.5`) → `/opt/cv-bot` → `git checkout -B prod origin/prod` → `scripts/deploy-prod.sh`.
- Script [`scripts/deploy-prod.sh`](scripts/deploy-prod.sh) : refuse si HEAD ≠ `prod`, `docker compose build && up -d`, smoke `/health` (`"status":"ok"`). Même script = fallback manuel.
- Docs : `deploy.md` §5 / §9 / §10 (secrets), ADR, git-workflow, branch-protections, COMMANDS.
- Tests : `tests/test_deploy_prod_cd.py` (trigger YAML, environment, script refuse `main`).

## Why

Remplacer le deploy manuel par un CD déclenché **uniquement** au merge sur `prod`. Un push `main` / feature ne déploie pas.

## Linear
Fixes AXE-317

## GitHub issue
Closes #217

## Validation

- [x] Backend lint passes (`ruff`, `black`, `mypy`)
- [x] Backend tests pass (`pytest`)
- [x] Coverage threshold passes (backend >= 60%)
- [ ] Backend security checks pass (`bandit`, `pip-audit`) — `--skip-extras` local
- [x] Frontend lint passes (`npm --prefix frontend run lint`) via `pre-push.sh`
- [x] Docs updated if needed
- [x] No secrets committed
- [x] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks` OK

## Test plan

- [x] `pytest tests/test_deploy_prod_cd.py` (trigger `prod` only, refuse `main`, dry-run `prod`)
- [ ] **Toi** : Settings → Environments → `production` (branches = `prod` only) + secrets `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_KEY`
- [ ] Premier vrai run = après promote `main` → `prod` (AXE-320) — ne pas merger cette PR dans `prod` directement
- [ ] Vérifier qu’un push sur cette branche feature n’a **pas** lancé « Deploy production »

## Risk and rollback

- Risk: secrets absents → le workflow échoue avant SSH (voulu). Premier promote emporte 124 commits de `main` (hors scope). SSH user doit pouvoir `docker compose`.
- Rollback: supprimer/désactiver le workflow ; fallback `docs/deploy.md` §9 (`bash scripts/deploy-prod.sh --skip-pull`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2b81278-e211-447e-a7f2-f6557a7687b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2b81278-e211-447e-a7f2-f6557a7687b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - Déploiement automatique en production après un changement sur `prod`.
  - Ajout d’un déploiement manuel de secours avec vérification de branche et de l’état du service.
  - Prise en charge des modes simulation et déploiement sans synchronisation préalable.
  - Vérification automatique de la disponibilité de l’application après déploiement.

- **Documentation**
  - Mise à jour des procédures de déploiement, du workflow Git et des protections de branches.
  - Documentation des paramètres et secrets requis pour l’environnement de production.

- **Tests**
  - Ajout de tests couvrant le workflow, les restrictions de branche, les options de déploiement et la documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->