### PR TITLE
feat(AXE-402): Button/Input dans les modales applicatives

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -29,6 +29,7 @@ import CompanyLogo from './components/CompanyLogo';
 import CandidatureBoardCard from './components/CandidatureBoardCard';
 import { NotFoundPage } from './components/ErrorPages';
 import Button from './components/ui/Button.jsx';
+import Input from './components/ui/Input.jsx';
 import AdaptLanguageChoiceDialog from './components/ui/AdaptLanguageChoiceDialog.jsx';
 import { CONTACT_EMAIL, STORAGE_EXPORT_DIR, STORAGE_EXPORT_ATS_BLOCK_SNOOZE, STORAGE_PRE_EXPORT_TEMPLATE_OPTIONS_DONE, STORAGE_PDF_EXPORT_FILENAME_PATTERN, STATUT_LABELS, KANBAN_COLUMNS, getExportFolderName } from './constants';
 import { buildAdaptedPdfFilename } from './lib/pdfExportFilename';
@@ -271,7 +272,7 @@ function CvEditPanel({ cv, onSave, onClose }) {
         </div>
         <div className="cv-edit-body">
           <label className="input-label">Titre professionnel</label>
-          <input type="text" className="input-field" value={edited.titre_professionnel || ''} onChange={(e) => update('titre_professionnel', e.target.value)} />
+          <Input type="text" value={edited.titre_professionnel || ''} onChange={(e) => update('titre_professionnel', e.target.value)} />
           <label className="input-label">Résumé / Accroche</label>
           <textarea className="input-field" rows={4} value={edited.resume || ''} onChange={(e) => update('resume', e.target.value)} />
           {(edited.experiences || []).map((exp, i) => (
@@ -284,8 +285,8 @@ function CvEditPanel({ cv, onSave, onClose }) {
           ))}
         </div>
         <div className="cv-edit-actions">
-          <button type="button" className="button button-primary" onClick={handleSave}>Enregistrer les modifications</button>
-          <button type="button" className="button button-secondary" onClick={onClose}>Annuler</button>
+          <Button type="button" variant="primary" onClick={handleSave}>Enregistrer les modifications</Button>
+          <Button type="button" variant="secondary" onClick={onClose}>Annuler</Button>
         </div>
       </div>
     </div>
@@ -3406,18 +3407,18 @@ export default function App() {
               Pour adapter ton CV, l’aperçu et le suivi des candidatures, ça fonctionne <strong>beaucoup mieux sur ordinateur</strong> - repasse depuis un PC ou une grande tablette.
             </p>
             <div className="app-mobile-gate-actions">
-              <button type="button" className="button button-primary" onClick={() => navigate('/faq')}>
+              <Button type="button" variant="primary" onClick={() => navigate('/faq')}>
                 Voir le site (FAQ, guides…)
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
-                className="button button-secondary"
+                variant="secondary"
                 onClick={async () => {
                   if (supabase) await supabase.auth.signOut();
                 }}
               >
                 Se déconnecter
-              </button>
+              </Button>
             </div>
           </div>
         </div>
@@ -3428,18 +3429,18 @@ export default function App() {
             <h1 id="profile-load-err-title">Profil inaccessible</h1>
             <p className="app-mobile-gate-lead">{profileCvLoadError}</p>
             <div className="app-mobile-gate-actions">
-              <button type="button" className="button button-primary" onClick={() => setProfileRefreshKey((k) => k + 1)}>
+              <Button type="button" variant="primary" onClick={() => setProfileRefreshKey((k) => k + 1)}>
                 Réessayer
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
-                className="button button-secondary"
+                variant="secondary"
                 onClick={async () => {
                   if (supabase) await supabase.auth.signOut();
                 }}
               >
                 Se déconnecter
-              </button>
+              </Button>
             </div>
           </div>
         </div>
@@ -4554,18 +4555,18 @@ export default function App() {
               <p className="setup-modal-intro">Renseigne l&apos;entreprise et la fiche de poste. L&apos;IA adaptera ton CV dans l&apos;espace de travail.</p>
               <label className="setup-field">
                 <span>Nom de l&apos;entreprise</span>
-                <input type="text" value={setupEntreprise} onChange={(e) => setSetupEntreprise(e.target.value)} placeholder="ex. Société Dupont" />
+                <Input type="text" value={setupEntreprise} onChange={(e) => setSetupEntreprise(e.target.value)} placeholder="ex. Société Dupont" />
               </label>
               <label className="setup-field">
                 <span>Intitulé du poste (optionnel, améliore le score ATS)</span>
-                <input type="text" value={setupPoste} onChange={(e) => setSetupPoste(e.target.value)} placeholder="ex. Analyste Risk & Contrôle" />
+                <Input type="text" value={setupPoste} onChange={(e) => setSetupPoste(e.target.value)} placeholder="ex. Analyste Risk & Contrôle" />
               </label>
               <label className="setup-field">
                 <span>Lien ou texte de la fiche de poste</span>
                 <textarea value={setupFiche} onChange={(e) => setSetupFiche(e.target.value)} placeholder="Colle le lien de l'annonce ou le texte de l'offre…" rows={6} />
               </label>
               <div className="setup-modal-actions">
-                <button type="button" className="button button-primary" onClick={async () => {
+                <Button type="button" variant="primary" onClick={async () => {
                   const fiche = setupFiche.trim();
                   const ent = setupEntreprise.trim();
                   const pos = setupPoste.trim();
@@ -4637,8 +4638,8 @@ export default function App() {
                   }
                 }} disabled={!setupFiche.trim()}>
                   Démarrer l&apos;adaptation
-                </button>
-                <button type="button" className="button button-secondary" onClick={() => setSetupModalOpen(false)}>Annuler</button>
+                </Button>
+                <Button type="button" variant="secondary" onClick={() => setSetupModalOpen(false)}>Annuler</Button>
               </div>
             </div>
           </div>
@@ -4763,15 +4764,15 @@ export default function App() {
               <label className="input-label">Précisions (texte libre)</label>
               <textarea className="input-field" value={refusRaison} onChange={(e) => setRefusRaison(e.target.value)} rows={3} placeholder="Optionnel" />
               <div className="linkedin-sync-actions" style={{ marginTop: '1rem' }}>
-                <button type="button" className="button button-primary" onClick={() => submitRefusModal(false)} disabled={statutModalSubmitting}>
+                <Button type="button" variant="primary" onClick={() => submitRefusModal(false)} disabled={statutModalSubmitting} loading={statutModalSubmitting}>
                   {statutModalSubmitting ? 'Enregistrement…' : 'Enregistrer'}
-                </button>
-                <button type="button" className="button button-secondary" onClick={() => submitRefusModal(true)} disabled={statutModalSubmitting}>
+                </Button>
+                <Button type="button" variant="secondary" onClick={() => submitRefusModal(true)} disabled={statutModalSubmitting}>
                   Passer (refus sans détail)
-                </button>
-                <button type="button" className="button button-secondary" onClick={() => { setStatutModalType(null); setStatutModalAppId(null); setStatutModalApp(null); }}>
+                </Button>
+                <Button type="button" variant="secondary" onClick={() => { setStatutModalType(null); setStatutModalAppId(null); setStatutModalApp(null); }}>
                   Annuler
-                </button>
+                </Button>
               </div>
             </div>
           </div>
@@ -4799,12 +4800,12 @@ export default function App() {
                 <li>Lettre de motivation ciblée</li>
               </ul>
               <div className="linkedin-sync-actions" style={{ marginTop: '1rem' }}>
-                <button type="button" className="button button-primary" onClick={() => { setUpgradeModalVisible(false); handleStartCheckout(); }} disabled={checkoutLoading}>
+                <Button type="button" variant="primary" onClick={() => { setUpgradeModalVisible(false); handleStartCheckout(); }} disabled={checkoutLoading} loading={checkoutLoading}>
                   {checkoutLoading ? 'Redirection…' : 'Passer en Pro - 10€/mois'}
-                </button>
-                <button type="button" className="button button-secondary" onClick={() => setUpgradeModalVisible(false)}>
+                </Button>
+                <Button type="button" variant="secondary" onClick={() => setUpgradeModalVisible(false)}>
                   Plus tard
-                </button>
+                </Button>
               </div>
             </div>
           </div>
@@ -4826,12 +4827,12 @@ export default function App() {
                     <li><span className="pro-check"><HiCheck size={14} strokeWidth={2.5} /></span>Lettre de motivation ciblée</li>
                   </ul>
                   <div className="linkedin-sync-actions" style={{ marginTop: '1rem', flexDirection: 'column', gap: '0.5rem' }}>
-                    <button type="button" className="button button-secondary" onClick={() => { setProModalVisible(false); handleManageSubscriptionClick(); }} disabled={checkoutLoading}>
+                    <Button type="button" variant="secondary" onClick={() => { setProModalVisible(false); handleManageSubscriptionClick(); }} disabled={checkoutLoading} loading={checkoutLoading}>
                       {checkoutLoading ? 'Redirection…' : 'Gérer mon abonnement / Annuler'}
-                    </button>
-                    <button type="button" className="button button-ghost" onClick={() => setProModalVisible(false)}>
+                    </Button>
+                    <Button type="button" variant="ghost" onClick={() => setProModalVisible(false)}>
                       Fermer
-                    </button>
+                    </Button>
                   </div>
                 </>
               ) : (
@@ -4860,12 +4861,12 @@ export default function App() {
                     </div>
                   </div>
                   <div className="linkedin-sync-actions" style={{ marginTop: '1rem' }}>
-                    <button type="button" className="button button-primary" onClick={() => { setProModalVisible(false); handleStartCheckout(); }} disabled={checkoutLoading}>
+                    <Button type="button" variant="primary" onClick={() => { setProModalVisible(false); handleStartCheckout(); }} disabled={checkoutLoading} loading={checkoutLoading}>
                       {checkoutLoading ? 'Redirection…' : 'Passer en Pro - 10€/mois'}
-                    </button>
-                    <button type="button" className="button button-secondary" onClick={() => setProModalVisible(false)}>
+                    </Button>
+                    <Button type="button" variant="secondary" onClick={() => setProModalVisible(false)}>
                       Plus tard
-                    </button>
+                    </Button>
                   </div>
                 </>
               )}
@@ -4879,8 +4880,8 @@ export default function App() {
               <h3 id="signout-confirm-title">Déconnexion</h3>
               <p className="profile-subtitle" style={{ marginTop: 0 }}>Tu es sûr de vouloir te déconnecter ?</p>
               <div className="linkedin-sync-actions" style={{ marginTop: '1rem' }}>
-                <button type="button" className="button button-primary" onClick={handleSignOut}>Oui, me déconnecter</button>
-                <button type="button" className="button button-secondary" onClick={() => setSignOutConfirmOpen(false)}>Annuler</button>
+                <Button type="button" variant="primary" onClick={handleSignOut}>Oui, me déconnecter</Button>
+                <Button type="button" variant="secondary" onClick={() => setSignOutConfirmOpen(false)}>Annuler</Button>
               </div>
             </div>
           </div>
@@ -4894,9 +4895,9 @@ export default function App() {
                 C’est l’étape qui adapte ton CV à un poste réel. Va sur « Adapter un CV », colle le texte de l’annonce (ou le lien) dans le champ en bas, puis envoie.
               </p>
               <div className="linkedin-sync-actions" style={{ marginTop: '1rem' }}>
-                <button
+                <Button
                   type="button"
-                  className="button button-primary"
+                  variant="primary"
                   onClick={() => {
                     setFirstOfferNudgeOpen(false);
                     navigate('/app/cv');
@@ -4906,10 +4907,10 @@ export default function App() {
                   {...analyticsAttrs('cv-nudge-cta-go', 'nudge', 'primary', 'cta')}
                 >
                   Coller une offre
-                </button>
-                <button
+                </Button>
+                <Button
                   type="button"
-                  className="button button-secondary"
+                  variant="secondary"
                   onClick={() => {
                     setFirstOfferNudgeOpen(false);
                     try {
@@ -4920,7 +4921,7 @@ export default function App() {
                   {...analyticsAttrs('cv-nudge-cta-dismiss', 'nudge', 'secondary', 'cta')}
                 >
                   Plus tard
-                </button>
+                </Button>
               </div>
             </div>
           </div>
@@ -4941,8 +4942,8 @@ export default function App() {
               <label className="input-label" style={{ display: 'block', marginTop: '0.75rem' }}>Commentaire (optionnel)</label>
               <textarea className="input-field" value={cancelReasonText} onChange={(e) => setCancelReasonText(e.target.value)} placeholder="Ton avis nous aide à nous améliorer…" rows={2} style={{ width: '100%', marginTop: '0.25rem', resize: 'vertical' }} />
               <div className="linkedin-sync-actions" style={{ marginTop: '1rem' }}>
-                <button type="button" className="button button-primary" onClick={handleManageSubscriptionConfirm} disabled={checkoutLoading}>{checkoutLoading ? 'Redirection…' : 'Accéder au portail'}</button>
-                <button type="button" className="button button-secondary" onClick={() => setManageSubscriptionModalOpen(false)}>Annuler</button>
+                <Button type="button" variant="primary" onClick={handleManageSubscriptionConfirm} disabled={checkoutLoading} loading={checkoutLoading}>{checkoutLoading ? 'Redirection…' : 'Accéder au portail'}</Button>
+                <Button type="button" variant="secondary" onClick={() => setManageSubscriptionModalOpen(false)}>Annuler</Button>
               </div>
             </div>
           </div>
@@ -4965,14 +4966,14 @@ export default function App() {
               <label className="input-label">Comment s’est passé l’entretien ? (texte libre)</label>
               <textarea className="input-field" value={interviewFeedback} onChange={(e) => setInterviewFeedback(e.target.value)} rows={3} placeholder="Optionnel" />
               <label className="input-label">Date de l’entretien (optionnel)</label>
-              <input type="date" className="input-field" value={interviewDate} onChange={(e) => setInterviewDate(e.target.value)} />
+              <Input type="date" value={interviewDate} onChange={(e) => setInterviewDate(e.target.value)} />
               <div className="linkedin-sync-actions" style={{ marginTop: '1rem' }}>
-                <button type="button" className="button button-primary" onClick={submitInterviewModal} disabled={statutModalSubmitting}>
+                <Button type="button" variant="primary" onClick={submitInterviewModal} disabled={statutModalSubmitting} loading={statutModalSubmitting}>
                   {statutModalSubmitting ? 'Enregistrement…' : 'Enregistrer'}
-                </button>
-                <button type="button" className="button button-secondary" onClick={() => { setStatutModalType(null); setStatutModalAppId(null); setStatutModalApp(null); }}>
+                </Button>
+                <Button type="button" variant="secondary" onClick={() => { setStatutModalType(null); setStatutModalAppId(null); setStatutModalApp(null); }}>
                   Annuler
-                </button>
+                </Button>
               </div>
             </div>
           </div>
@@ -5063,12 +5064,12 @@ export default function App() {
                 </label>
               </fieldset>
               <div className="linkedin-sync-actions export-ats-block-actions">
-                <button type="button" className="button button-primary" onClick={confirmExportAtsBlockModal}>
+                <Button type="button" variant="primary" onClick={confirmExportAtsBlockModal}>
                   Valider et continuer
-                </button>
-                <button type="button" className="button button-secondary" onClick={closeExportAtsBlockModal}>
+                </Button>
+                <Button type="button" variant="secondary" onClick={closeExportAtsBlockModal}>
                   Annuler
-                </button>
+                </Button>
               </div>
             </div>
           </div>
@@ -5084,9 +5085,8 @@ export default function App() {
               </p>
               <label className="setup-field" style={{ marginTop: '1rem', display: 'block' }}>
                 <span>Entreprise</span>
-                <input
+                <Input
                   type="text"
-                  className="input-field"
                   value={pdfEntrepriseModalValue}
                   onChange={(e) => setPdfEntrepriseModalValue(e.target.value)}
                   placeholder="ex. Société recruteuse"
@@ -5094,12 +5094,12 @@ export default function App() {
                 />
               </label>
               <div className="linkedin-sync-actions export-ats-block-actions" style={{ marginTop: '1.25rem' }}>
-                <button type="button" className="button button-primary" onClick={() => void confirmPdfEntrepriseModal()}>
+                <Button type="button" variant="primary" onClick={() => void confirmPdfEntrepriseModal()}>
                   Télécharger le PDF
-                </button>
-                <button type="button" className="button button-secondary" onClick={closePdfEntrepriseModal}>
+                </Button>
+                <Button type="button" variant="secondary" onClick={closePdfEntrepriseModal}>
                   Annuler
-                </button>
+                </Button>
               </div>
             </div>
           </div>
@@ -5121,7 +5121,7 @@ export default function App() {
                 ou du résultat de vos candidatures.
               </p>
               <div className="linkedin-sync-actions" style={{ marginTop: '1rem' }}>
-                <button type="button" className="button button-primary" onClick={() => {
+                <Button type="button" variant="primary" onClick={() => {
                   setAtsDisclaimerVisible(false);
                   if (pendingPdfAction === 'pdf') {
                     const o = pendingExportTemplateOptionsRef.current;
@@ -5131,10 +5131,10 @@ export default function App() {
                   setPendingPdfAction(null);
                 }}>
                   J'ai compris, télécharger
-                </button>
-                <button type="button" className="button button-secondary" onClick={() => { setAtsDisclaimerVisible(false); setPendingPdfAction(null); pendingExportTemplateOptionsRef.current = null; }}>
+                </Button>
+                <Button type="button" variant="secondary" onClick={() => { setAtsDisclaimerVisible(false); setPendingPdfAction(null); pendingExportTemplateOptionsRef.current = null; }}>
                   Annuler
-                </button>
+                </Button>
               </div>
             </div>
           </div>

--- a/frontend/src/components/ApplicationDetailModal.jsx
+++ b/frontend/src/components/ApplicationDetailModal.jsx
@@ -4,6 +4,8 @@ import { HiPencil, HiCheck, HiChevronDown } from 'react-icons/hi2';
 import { apiGet, apiPost, apiPatch, apiGetBlob, apiPostFormData, prepareAppleDownloadWindow, saveBlobWithPreferredMethod, getDownloadPermissionHint } from '../api';
 import CompanyLogo from './CompanyLogo';
 import { formatApplicationDateLabel } from '../lib/applicationDates';
+import Button from './ui/Button.jsx';
+import Input from './ui/Input.jsx';
 
 const DOC_LABELS = { lettre: 'Lettre de motivation', cv: 'CV', fiche: 'Fiche de poste' };
 
@@ -163,9 +165,9 @@ export default function ApplicationDetailModal({ applicationDetailId, applicatio
             <span className="detail-entreprise">{applicationDetail.entreprise || ''}</span>
             {editingPoste ? (
               <div className="detail-header-title-edit-wrap">
-                <input
+                <Input
                   type="text"
-                  className="input-field detail-header-poste-input"
+                  className="detail-header-poste-input"
                   style={posteInputWidthStyle}
                   value={posteDraft}
                   onChange={(e) => setPosteDraft(e.target.value)}
@@ -309,14 +311,14 @@ export default function ApplicationDetailModal({ applicationDetailId, applicatio
                 <div className="detail-lettre-empty">
                   <p>Aucune lettre pour cette candidature.</p>
                   {letterGenEnabled ? (
-                    <button type="button" className="button button-primary" onClick={handleGenerateLetter} disabled={!applicationDetail.full_cv}>Générer la lettre</button>
+                    <Button type="button" variant="primary" onClick={handleGenerateLetter} disabled={!applicationDetail.full_cv}>Générer la lettre</Button>
                   ) : (
                     <div>
                       <p style={{ fontSize: '0.9rem', color: 'var(--muted)', marginTop: '0.5rem' }}>La génération de lettre par IA est réservée au plan Pro.</p>
                       {typeof onUpgradeClick === 'function' && (
-                        <button type="button" className="button button-primary" style={{ marginTop: '0.75rem' }} onClick={onUpgradeClick}>
+                        <Button type="button" variant="primary" style={{ marginTop: '0.75rem' }} onClick={onUpgradeClick}>
                           Passer en Pro
-                        </button>
+                        </Button>
                       )}
                     </div>
                   )}

--- a/frontend/src/components/CvImportMergeModal.jsx
+++ b/frontend/src/components/CvImportMergeModal.jsx
@@ -3,6 +3,7 @@ import {
   CV_IMPORT_SECTION_KEYS,
   formatScalarPreviewForPrivacy,
 } from '../lib/cvImportUtils.js';
+import Button from './ui/Button.jsx';
 import '../styles/ProfileView.css';
 
 export default function CvImportMergeModal({
@@ -161,10 +162,10 @@ export default function CvImportMergeModal({
           })}
         </ul>
         <div className="linkedin-sync-actions import-merge-actions">
-          <button type="button" className="button button-primary" onClick={onConfirm} disabled={confirming}>
+          <Button type="button" variant="primary" onClick={onConfirm} disabled={confirming} loading={confirming}>
             {confirming ? 'Application…' : 'Appliquer et générer le canvas'}
-          </button>
-          <button type="button" className="button button-secondary" onClick={onCancel}>Annuler</button>
+          </Button>
+          <Button type="button" variant="secondary" onClick={onCancel}>Annuler</Button>
         </div>
       </div>
     </div>

--- a/frontend/tests/unit/axe402ModalDsAdoption.test.js
+++ b/frontend/tests/unit/axe402ModalDsAdoption.test.js
@@ -1,0 +1,75 @@
+/**
+ * AXE-402 : les modales applicatives n’utilisent plus le markup legacy
+ * `button button-primary` — uniquement <Button> / <Input>.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FRONTEND_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+const SRC = path.join(FRONTEND_ROOT, 'src');
+
+const LEGACY_BUTTON_CLASS_RE =
+  /(?:className|class)\s*=\s*(?:["'`][^"'`]*|\{\s*["'`][^"'`]*)\bbutton-(?:primary|secondary|tertiary|ghost|success)\b/;
+
+const MODAL_COMPONENT_FILES = [
+  'components/CvImportMergeModal.jsx',
+  'components/ApplicationDetailModal.jsx',
+];
+
+const APP_MODAL_MARKERS = [
+  'cv-edit-actions',
+  'setup-modal-actions',
+  'app-mobile-gate-actions',
+  'linkedin-sync-modal',
+  'upgrade-modal',
+  'export-ats-block-actions',
+  'ats-disclaimer-modal',
+  'quali-modal',
+];
+
+function lineHasLegacyButtonClass(line) {
+  return LEGACY_BUTTON_CLASS_RE.test(line);
+}
+
+test('CvImportMergeModal et ApplicationDetailModal n’ont plus de className button-*', async () => {
+  const offenders = [];
+  for (const rel of MODAL_COMPONENT_FILES) {
+    const text = await readFile(path.join(SRC, rel), 'utf8');
+    text.split('\n').forEach((line, idx) => {
+      if (lineHasLegacyButtonClass(line)) {
+        offenders.push(`${rel}:${idx + 1}:${line.trim()}`);
+      }
+    });
+  }
+  assert.deepEqual(offenders, []);
+});
+
+test('ApplicationDetailModal et App importent Input pour les champs texte des modales', async () => {
+  const app = await readFile(path.join(SRC, 'App.jsx'), 'utf8');
+  const detail = await readFile(path.join(SRC, 'components/ApplicationDetailModal.jsx'), 'utf8');
+  assert.match(app, /import Input from '\.\/components\/ui\/Input\.jsx'/);
+  assert.match(detail, /import Input from '\.\/ui\/Input\.jsx'/);
+  assert.match(app, /<Input type="text"/);
+  assert.match(app, /<Input type="date"/);
+  assert.match(detail, /<Input\s+type="text"/);
+});
+
+test('App.jsx : plus de markup button-* dans les footers de modales', async () => {
+  const text = await readFile(path.join(SRC, 'App.jsx'), 'utf8');
+  const lines = text.split('\n');
+  const offenders = [];
+  lines.forEach((line, idx) => {
+    if (!lineHasLegacyButtonClass(line)) return;
+    const from = Math.max(0, idx - 25);
+    const to = Math.min(lines.length, idx + 8);
+    const windowText = lines.slice(from, to).join('\n');
+    const inModal = APP_MODAL_MARKERS.some((marker) => windowText.includes(marker));
+    if (inModal) {
+      offenders.push(`App.jsx:${idx + 1}:${line.trim()}`);
+    }
+  });
+  assert.deepEqual(offenders, []);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

- Première tranche d’[AXE-354](https://linear.app/axel-project/issue/AXE-354) : adoption DS dans les **modales applicatives**.
- CTA `className="button button-primary|secondary|ghost"` remplacés par `<Button>` dans :
  - `CvImportMergeModal`
  - `ApplicationDetailModal` (lettre / upgrade Pro)
  - `App.jsx` : édition CV, setup candidature, gate mobile, refus, upgrade, Pro, déconnexion, nudge, abonnement, entretien, export ATS, nom entreprise PDF, disclaimer ATS
- Champs texte/date migrés vers `<Input>` : titre CV, entreprise/poste setup, date entretien, nom entreprise PDF, intitulé poste (détail candidature).
- Test unitaire de non-régression markup legacy (`axe402ModalDsAdoption.test.js`).

## Why

Le DS (`Button` / `Input`) existait mais n’était pas consommé dans les dialogues. Cette PR isole une zone (modales) comme demandé par AXE-354 — pas une migration géante.

Hors scope (tickets suivants) : auth/profil ([AXE-403](https://linear.app/axel-project/issue/AXE-403)), landing ([AXE-404](https://linear.app/axel-project/issue/AXE-404)), support/export/editor ([AXE-405](https://linear.app/axel-project/issue/AXE-405)), alias `buttonClassName` ([AXE-406](https://linear.app/axel-project/issue/AXE-406)).

## Linear

Fixes AXE-402

Parent : AXE-354

Branche Linear suggérée : `louisvedovato/axe-402-improve-buttoninput-dans-les-modales-applicatives`

## Validation

- [x] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks` OK
- [x] Tests unitaires `axe402ModalDsAdoption` + `buttonClassName`
- [ ] Recette visuelle footers de modales (primary / secondary / loading)
- [ ] `analyticsAttrs` conservés (nudge)

## Risk and rollback

- Risk : léger décalage visuel (`ds-input` vs champs nus du setup) ; les CTA gardent les alias `button-primary` via `buttonClassName` donc le look bouton reste.
- Rollback : revert du commit.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78ab1eb6-15ef-4ef0-bdc8-f8361cfbea14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78ab1eb6-15ef-4ef0-bdc8-f8361cfbea14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Améliorations de l’interface**
  - Les champs de saisie et boutons des écrans, modales et parcours d’abonnement utilisent désormais une présentation plus cohérente.
  - Les actions de confirmation, d’annulation, d’édition, d’export et de génération de lettres bénéficient d’un style harmonisé.
  - Les boutons de confirmation affichent mieux leur état de chargement lors des opérations en cours.

- **Qualité**
  - Ajout de vérifications automatisées pour garantir l’utilisation cohérente des composants d’interface dans les modales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->