### PR TITLE
feat(AXE-404): Button DS sur landing et pages contenu

### DIFF
--- a/frontend/src/components/ArticlesPages.jsx
+++ b/frontend/src/components/ArticlesPages.jsx
@@ -3,6 +3,7 @@ import { ARTICLE_SOURCE_URLS as U } from '../content/articleSources.js';
 import { analyticsAttrs } from '../lib/analyticsAttrs.js';
 import { persistLoginCta } from '../../public/signupAttribution.js';
 import ContentScrollToTop from './ContentScrollToTop';
+import Button from './ui/Button.jsx';
 import './ContentPages.css';
 
 function Out({ href, children }) {
@@ -107,7 +108,9 @@ function ArticleLayout({ title, lead, sections, onBack, prose, signupId }) {
         <div className="content-cta-inner">
           <h2>Un CV adapté à chaque offre, en un clic</h2>
           <p>Essaie AxeL Job gratuitement. 3 adaptations offertes, sans carte bancaire.</p>
-          <Link to="/login" className="button button-primary" onClick={() => persistLoginCta(signupId)} {...analyticsAttrs(signupId, 'content', 'primary', 'cta')}>Essayer gratuitement</Link>
+          <Button as={Link} to="/login" variant="primary" onClick={() => persistLoginCta(signupId)} {...analyticsAttrs(signupId, 'content', 'primary', 'cta')}>
+            Essayer gratuitement
+          </Button>
         </div>
       </section>
 

--- a/frontend/src/components/AtsPage.jsx
+++ b/frontend/src/components/AtsPage.jsx
@@ -3,6 +3,7 @@ import { ARTICLE_SOURCE_URLS as U } from '../content/articleSources.js';
 import { analyticsAttrs } from '../lib/analyticsAttrs.js';
 import { persistLoginCta } from '../../public/signupAttribution.js';
 import ContentScrollToTop from './ContentScrollToTop';
+import Button from './ui/Button.jsx';
 import './ContentPages.css';
 
 function Out({ href, children }) {
@@ -186,7 +187,9 @@ export default function AtsPage({ onBack }) {
         <div className="content-cta-inner">
           <h2>Passe les filtres ATS à chaque candidature</h2>
           <p>Adapte ton CV en un clic à chaque offre. Essai gratuit, sans carte bancaire.</p>
-          <Link to="/login" className="button button-primary" onClick={() => persistLoginCta('ats-cta-signup')} {...analyticsAttrs('ats-cta-signup', 'content', 'primary', 'cta')}>Essayer AxeL Job gratuitement</Link>
+          <Button as={Link} to="/login" variant="primary" onClick={() => persistLoginCta('ats-cta-signup')} {...analyticsAttrs('ats-cta-signup', 'content', 'primary', 'cta')}>
+            Essayer AxeL Job gratuitement
+          </Button>
         </div>
       </section>
 

--- a/frontend/src/components/FaqPage.jsx
+++ b/frontend/src/components/FaqPage.jsx
@@ -3,6 +3,7 @@ import { ARTICLE_SOURCE_URLS as U } from '../content/articleSources.js';
 import { analyticsAttrs } from '../lib/analyticsAttrs.js';
 import { persistLoginCta } from '../../public/signupAttribution.js';
 import ContentScrollToTop from './ContentScrollToTop';
+import Button from './ui/Button.jsx';
 import './ContentPages.css';
 
 function Out({ href, children }) {
@@ -130,7 +131,9 @@ export default function FaqPage({ onBack }) {
         <div className="content-cta-inner">
           <h2>Un CV adapté à chaque offre, en un clic</h2>
           <p>Essaie AxeL Job gratuitement. 3 adaptations offertes, sans carte bancaire.</p>
-          <Link to="/login" className="button button-primary" onClick={() => persistLoginCta('faq-cta-signup')} {...analyticsAttrs('faq-cta-signup', 'content', 'primary', 'cta')}>Essayer gratuitement</Link>
+          <Button as={Link} to="/login" variant="primary" onClick={() => persistLoginCta('faq-cta-signup')} {...analyticsAttrs('faq-cta-signup', 'content', 'primary', 'cta')}>
+            Essayer gratuitement
+          </Button>
         </div>
       </section>
 

--- a/frontend/src/components/LandingPage.jsx
+++ b/frontend/src/components/LandingPage.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { CONTACT_EMAIL } from '../constants';
 import { analyticsAttrs } from '../lib/analyticsAttrs.js';
 import { persistLoginCta } from '../../public/signupAttribution.js';
+import Button from './ui/Button.jsx';
 import './LandingPage.css';
 
 /** Liens articles / guides (menu mobile + cohérence avec le footer) */
@@ -135,9 +136,9 @@ export default function LandingPage({ onCtaClick, onProClick }) {
               <Link to="/faq" {...analyticsAttrs('nav-link-faq', 'header', 'tertiary', 'nav')}>FAQ</Link>
               <Link to="/modeles-cv" {...analyticsAttrs('nav-link-modeles', 'header', 'tertiary', 'nav')}>Modèles CV</Link>
               <Link to="/guide-cv" {...analyticsAttrs('nav-link-guide', 'header', 'tertiary', 'nav')}>Guide CV</Link>
-              <button type="button" className="button button-primary landing-cta-nav" onClick={() => goLogin('nav-cta-signup', onCtaClick)} {...analyticsAttrs('nav-cta-signup', 'header', 'primary', 'cta')}>
+              <Button type="button" variant="primary" className="landing-cta-nav" onClick={() => goLogin('nav-cta-signup', onCtaClick)} {...analyticsAttrs('nav-cta-signup', 'header', 'primary', 'cta')}>
                 Essayer gratuitement
-              </button>
+              </Button>
             </nav>
             <div className="landing-header-mobile-actions">
               <button
@@ -151,9 +152,9 @@ export default function LandingPage({ onCtaClick, onProClick }) {
               >
                 <BurgerIcon open={menuOpen} />
               </button>
-              <button type="button" className="landing-mobile-cta button button-primary" onClick={() => goLogin('nav-cta-start', onCtaClick)} {...analyticsAttrs('nav-cta-start', 'header', 'primary', 'cta')}>
+              <Button type="button" variant="primary" className="landing-mobile-cta" onClick={() => goLogin('nav-cta-start', onCtaClick)} {...analyticsAttrs('nav-cta-start', 'header', 'primary', 'cta')}>
                 Commencer
-              </button>
+              </Button>
             </div>
           </div>
         </div>
@@ -203,9 +204,9 @@ export default function LandingPage({ onCtaClick, onProClick }) {
                 <li><Link to="/cgu" onClick={closeMenu}>CGU</Link></li>
               </ul>
               <div className="landing-nav-drawer-cta">
-                <button type="button" className="button button-primary" onClick={() => { closeMenu(); goLogin('nav-cta-drawer', onCtaClick); }} {...analyticsAttrs('nav-cta-drawer', 'drawer', 'primary', 'cta')}>
+                <Button type="button" variant="primary" onClick={() => { closeMenu(); goLogin('nav-cta-drawer', onCtaClick); }} {...analyticsAttrs('nav-cta-drawer', 'drawer', 'primary', 'cta')}>
                   Essayer gratuitement
-                </button>
+                </Button>
               </div>
             </nav>
           </div>
@@ -224,9 +225,9 @@ export default function LandingPage({ onCtaClick, onProClick }) {
                 {"L'IA analyse l'offre d'emploi et adapte instantanément ton CV pour passer les filtres (ATS) et taper dans l'œil des recruteurs."}
               </p>
               <div className="landing-hero-ctas">
-                <button type="button" className="button button-primary landing-cta-hero" onClick={() => goLogin('home-hero-cta-signup', onCtaClick)} {...analyticsAttrs('home-hero-cta-signup', 'hero', 'primary', 'cta')}>
+                <Button type="button" variant="primary" className="landing-cta-hero" onClick={() => goLogin('home-hero-cta-signup', onCtaClick)} {...analyticsAttrs('home-hero-cta-signup', 'hero', 'primary', 'cta')}>
                   Essayer gratuitement
-                </button>
+                </Button>
                 <span className="landing-hero-hint">3 adaptations offertes</span>
               </div>
             </div>
@@ -313,9 +314,9 @@ export default function LandingPage({ onCtaClick, onProClick }) {
                   </li>
                 ))}
               </ul>
-              <button type="button" className="button button-secondary pricing-cta" onClick={() => goLogin('home-pricing-cta-free', onCtaClick)} {...analyticsAttrs('home-pricing-cta-free', 'pricing', 'secondary', 'cta')}>
+              <Button type="button" variant="secondary" className="pricing-cta" onClick={() => goLogin('home-pricing-cta-free', onCtaClick)} {...analyticsAttrs('home-pricing-cta-free', 'pricing', 'secondary', 'cta')}>
                 Commencer gratuitement
-              </button>
+              </Button>
             </div>
 
             <div className="pricing-card pricing-card--pro" {...analyticsAttrs('home-pricing-card-pro', 'pricing', 'tertiary')}>
@@ -335,9 +336,9 @@ export default function LandingPage({ onCtaClick, onProClick }) {
                   </li>
                 ))}
               </ul>
-              <button type="button" className="button button-primary pricing-cta" onClick={() => goLogin('home-pricing-cta-pro', onProClick || onCtaClick)} {...analyticsAttrs('home-pricing-cta-pro', 'pricing', 'primary', 'cta')}>
+              <Button type="button" variant="primary" className="pricing-cta" onClick={() => goLogin('home-pricing-cta-pro', onProClick || onCtaClick)} {...analyticsAttrs('home-pricing-cta-pro', 'pricing', 'primary', 'cta')}>
                 Passer Pro
-              </button>
+              </Button>
             </div>
           </div>
         </div>
@@ -378,9 +379,9 @@ export default function LandingPage({ onCtaClick, onProClick }) {
         <div className="landing-container">
           <h2>Prêt à décrocher le job de tes rêves ?</h2>
           <p>Crée ton compte gratuit et teste 3 adaptations de CV.</p>
-          <button type="button" className="button button-primary landing-cta-hero" onClick={() => goLogin('home-final-cta-signup', onCtaClick)} {...analyticsAttrs('home-final-cta-signup', 'final', 'primary', 'cta')}>
+          <Button type="button" variant="primary" className="landing-cta-hero" onClick={() => goLogin('home-final-cta-signup', onCtaClick)} {...analyticsAttrs('home-final-cta-signup', 'final', 'primary', 'cta')}>
             Essayer gratuitement
-          </button>
+          </Button>
         </div>
       </section>
       </main>

--- a/frontend/tests/unit/axe404LandingContentDsAdoption.test.js
+++ b/frontend/tests/unit/axe404LandingContentDsAdoption.test.js
@@ -1,0 +1,94 @@
+/**
+ * AXE-404 : landing et pages contenu n’utilisent plus le markup
+ * `button button-primary|secondary` — uniquement <Button> / <Button as={Link}>.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FRONTEND_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+const SRC = path.join(FRONTEND_ROOT, 'src');
+
+const LEGACY_BUTTON_CLASS_RE =
+  /(?:className|class)\s*=\s*(?:["'`][^"'`]*|\{\s*["'`][^"'`]*)\b(?:button|btn)-(?:primary|secondary|tertiary|ghost|success)\b/;
+
+const FILES = [
+  'components/LandingPage.jsx',
+  'components/FaqPage.jsx',
+  'components/AtsPage.jsx',
+  'components/ArticlesPages.jsx',
+];
+
+const CONTENT_PAGES = [
+  'components/FaqPage.jsx',
+  'components/AtsPage.jsx',
+  'components/ArticlesPages.jsx',
+];
+
+function lineHasLegacyButtonClass(line) {
+  return LEGACY_BUTTON_CLASS_RE.test(line);
+}
+
+test('Landing, FAQ, ATS et Articles n’ont plus de className button-*', async () => {
+  const offenders = [];
+  for (const rel of FILES) {
+    const text = await readFile(path.join(SRC, rel), 'utf8');
+    text.split('\n').forEach((line, idx) => {
+      if (lineHasLegacyButtonClass(line)) {
+        offenders.push(`${rel}:${idx + 1}:${line.trim()}`);
+      }
+    });
+  }
+  assert.deepEqual(offenders, []);
+});
+
+test('Les 4 fichiers importent Button', async () => {
+  for (const rel of FILES) {
+    const text = await readFile(path.join(SRC, rel), 'utf8');
+    assert.match(text, /import Button from '\.\/ui\/Button\.jsx'/, rel);
+  }
+});
+
+test('FAQ, ATS et Articles rendent le CTA via Button as={Link}', async () => {
+  for (const rel of CONTENT_PAGES) {
+    const text = await readFile(path.join(SRC, rel), 'utf8');
+    assert.match(text, /<Button as=\{Link\} to="\/login"/, rel);
+    assert.doesNotMatch(text, /className="button button-primary/, rel);
+    assert.doesNotMatch(text, /<Link to="\/login" className="button/, rel);
+  }
+});
+
+test('Landing conserve type="button", goLogin et les data-attr CTA', async () => {
+  const text = await readFile(path.join(SRC, 'components/LandingPage.jsx'), 'utf8');
+  assert.match(text, /variant="primary"/);
+  assert.match(text, /variant="secondary"/);
+  assert.match(text, /className="landing-cta-nav"/);
+  assert.match(text, /className="landing-mobile-cta"/);
+  assert.match(text, /className="landing-cta-hero"/);
+  assert.match(text, /className="pricing-cta"/);
+  assert.match(text, /goLogin\('nav-cta-signup'/);
+  assert.match(text, /goLogin\('nav-cta-start'/);
+  assert.match(text, /goLogin\('nav-cta-drawer'/);
+  assert.match(text, /goLogin\('home-hero-cta-signup'/);
+  assert.match(text, /goLogin\('home-pricing-cta-free'/);
+  assert.match(text, /goLogin\('home-pricing-cta-pro'/);
+  assert.match(text, /goLogin\('home-final-cta-signup'/);
+  assert.match(text, /analyticsAttrs\('nav-cta-signup', 'header', 'primary', 'cta'\)/);
+  assert.match(text, /analyticsAttrs\('home-hero-cta-signup', 'hero', 'primary', 'cta'\)/);
+  assert.doesNotMatch(text, /className="button button-primary/);
+  assert.doesNotMatch(text, /className="button button-secondary/);
+});
+
+test('FAQ / ATS conservent persistLoginCta et analyticsAttrs', async () => {
+  const faq = await readFile(path.join(SRC, 'components/FaqPage.jsx'), 'utf8');
+  const ats = await readFile(path.join(SRC, 'components/AtsPage.jsx'), 'utf8');
+  const articles = await readFile(path.join(SRC, 'components/ArticlesPages.jsx'), 'utf8');
+  assert.match(faq, /persistLoginCta\('faq-cta-signup'\)/);
+  assert.match(faq, /analyticsAttrs\('faq-cta-signup', 'content', 'primary', 'cta'\)/);
+  assert.match(ats, /persistLoginCta\('ats-cta-signup'\)/);
+  assert.match(ats, /analyticsAttrs\('ats-cta-signup', 'content', 'primary', 'cta'\)/);
+  assert.match(articles, /persistLoginCta\(signupId\)/);
+  assert.match(articles, /analyticsAttrs\(signupId, 'content', 'primary', 'cta'\)/);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes AXE-404

Parent : [AXE-354](https://linear.app/axel-project/issue/AXE-354) — adopter Button/Input (sortie des classes legacy).

## What changed

- Landing (`LandingPage.jsx`) : CTA nav, mobile, drawer, hero, pricing (primary + secondary) et CTA final passent par `<Button>`.
- FAQ, ATS, Articles : `<Link className="button button-primary">` → `<Button as={Link} to="/login">`.
- Test d’adoption `axe404LandingContentDsAdoption.test.js` (plus de markup `button-*`, `as={Link}`, `analyticsAttrs` / `persistLoginCta` / `goLogin` conservés).

Hors scope : HTML/CSS statiques (`public/*.html`, `landing-static.css`, `static-pages.css`), burger/close, `buttonClassName` aliases (AXE-406). En dev Vite, un GET direct sur `/faq` `/ats` `/modeles-cv` sert encore le HTML statique — la recette React se fait via navigation SPA depuis `/`.

## Why

Les CTA marketing React restaient en classes legacy alors que `Button` gère déjà `as` et les tokens DS. Même contrat visuel (alias `button` / `button-primary` encore émis) et mêmes `data-attr`.

## Validation

- [x] Backend lint passes (`ruff`, `black`, `mypy`) — pre-push local + CI
- [x] Backend tests pass (`pytest`) — pre-push local + CI
- [x] Coverage threshold passes (backend >= 60%)
- [x] Backend security checks pass (`bandit`, `pip-audit`)
- [x] Frontend lint passes (`npm --prefix frontend run lint`)
- [x] Docs updated if needed (n/a)
- [x] No secrets committed
- [x] Recette navigateur SPA : landing + FAQ/ATS/Articles, classes `ds-button`

## Critères AXE-404

- [x] Plus de markup `button button-primary|secondary` dans les 4 fichiers
- [x] CTA accessibles (boutons natifs landing, liens via `as={Link}` — pas de `<button>` autour d’un `<Link>`)
- [x] `data-attr` analytics inchangés

## Recette (DOM live)

Landing : `BUTTON.ds-button.ds-button--primary` (nav, mobile, drawer, hero, final) ; pricing free `ds-button--secondary`.
FAQ / ATS / Modèles (SPA) : `A.ds-button.ds-button--primary[href=/login]`.
Clics FAQ, ATS et hero → `/login`.

## Risk and rollback

- Risk: léger écart visuel si un sélecteur CSS ciblait uniquement `button.button-primary` sans passer par l’alias encore émis par `buttonClassName`.
- Rollback: revert de cette PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78ab1eb6-15ef-4ef0-bdc8-f8361cfbea14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78ab1eb6-15ef-4ef0-bdc8-f8361cfbea14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * Les appels à l’action des pages d’accueil, FAQ, ATS et Articles utilisent désormais un composant de bouton harmonisé.
  * Les libellés, destinations, suivis analytiques et comportements existants sont conservés.
  * Les boutons restent accessibles depuis les différents emplacements de navigation, notamment les sections mobiles, héros, tarifs et CTA finaux.

* **Tests**
  * Ajout de contrôles automatisés vérifiant l’utilisation cohérente des boutons et l’absence de l’ancien balisage visuel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->