### PR TITLE
fix(canvas): l’import structurel Beta ne recouvre plus le PDF

### DIFF
--- a/frontend/src/components/editor/CvEditorBetaView.jsx
+++ b/frontend/src/components/editor/CvEditorBetaView.jsx
@@ -803,7 +803,10 @@ function CvEditorBeta({
     let importSource;
 
     if (chosenVariant?.layout) {
-      finalLayout = ensureImportLayoutHasContent(chosenVariant.layout, nextCv);
+      finalLayout = cleanupCanvasHeaderOverlays(
+        ensureImportLayoutHasContent(chosenVariant.layout, nextCv),
+        nextCv,
+      );
       recommendedTemplateId = chosenVariant.recommendedTemplateId || '';
       contentBlockCount = countContentBlocks(finalLayout);
       blockCount = chosenVariant.blockCount
@@ -823,7 +826,10 @@ function CvEditorBeta({
         visionMeta,
         annotations,
       }));
-      finalLayout = ensureImportLayoutHasContent(finalLayout, nextCv);
+      finalLayout = cleanupCanvasHeaderOverlays(
+        ensureImportLayoutHasContent(finalLayout, nextCv),
+        nextCv,
+      );
       contentBlockCount = countContentBlocks(finalLayout);
     }
 

--- a/frontend/src/lib/canvasHeaderOverlayCleanup.js
+++ b/frontend/src/lib/canvasHeaderOverlayCleanup.js
@@ -716,11 +716,9 @@ export function repairExplodedFreeformSemanticOverlays(layout) {
       if (block.style?.lock_height || block.style?.lock_geometry) return block;
       const box = asBox(block);
       const beside = leftoverTextBesideSemantic(block, leftovers);
-      // Widget déjà locké = bind heading+corps. Titre PDF seul (étroit, ou
-      // déjà explosé) à côté de la copie : on le ramène en titre.
-      const pageTall = box.h >= 140;
-      const skinnyUnlocked = box.w < 55;
-      if (beside.length < 1 || !(pageTall || skinnyUnlocked)) return block;
+      // Titre PDF seul = colonne étroite. Un vrai heading+corps (large, même
+      // déverrouillé et haut) à côté d’une sidebar ne doit pas perdre son bind.
+      if (beside.length < 1 || box.w >= 55) return block;
       changed = true;
       const label = block.style?.section_label
         || DEFAULT_SECTION_TITLE[block.type]
@@ -766,16 +764,16 @@ export function removeTextDuplicatingContact(layout, cv = {}) {
         || (sameHeaderRow(box, cb, 16) && Math.abs(box.x - cb.x) < 80)
       ));
       if (!near) return true;
-      const text = normalizeIdentityText(block.content);
+      const raw = stripTagsToText(block.content).toLowerCase();
       const digits = String(block.content || '').replace(/\D/g, '');
-      const emailHit = Boolean(emailNeedle && text.includes(emailNeedle));
+      const emailHit = Boolean(emailNeedle && raw.includes(emailNeedle));
       const phoneHit = Boolean(
         phoneNeedle.length >= 8
         && digits.length >= 8
         && digits.includes(phoneNeedle.slice(-8)),
       );
-      const leftoverOnlyContact = text.length <= 40 && (
-        /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/i.test(text)
+      const leftoverOnlyContact = raw.length <= 64 && (
+        /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/i.test(raw)
         || (digits.length >= 10 && /^[\d\s+().-]+$/.test(String(block.content || '').trim()))
       );
       return !(emailHit || phoneHit || leftoverOnlyContact);

--- a/frontend/src/lib/canvasHeaderOverlayCleanup.js
+++ b/frontend/src/lib/canvasHeaderOverlayCleanup.js
@@ -772,11 +772,7 @@ export function removeTextDuplicatingContact(layout, cv = {}) {
         && digits.length >= 8
         && digits.includes(phoneNeedle.slice(-8)),
       );
-      const leftoverOnlyContact = raw.length <= 64 && (
-        /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/i.test(raw)
-        || (digits.length >= 10 && /^[\d\s+().-]+$/.test(String(block.content || '').trim()))
-      );
-      return !(emailHit || phoneHit || leftoverOnlyContact);
+      return !(emailHit || phoneHit);
     });
     return nextBlocks.length === blocks.length ? page : { ...page, blocks: nextBlocks };
   });

--- a/frontend/src/lib/canvasHeaderOverlayCleanup.js
+++ b/frontend/src/lib/canvasHeaderOverlayCleanup.js
@@ -664,11 +664,6 @@ export function allowWrapOnParagraphText(layout) {
   return { ...layout, pages };
 }
 
-/**
- * @param {object} layout
- * @param {object} [cv]
- * @returns {object}
- */
 const EXPLODABLE_SEMANTIC_TYPES = new Set([
   'experiences',
   'formations',

--- a/frontend/src/lib/canvasHeaderOverlayCleanup.js
+++ b/frontend/src/lib/canvasHeaderOverlayCleanup.js
@@ -669,10 +669,126 @@ export function allowWrapOnParagraphText(layout) {
  * @param {object} [cv]
  * @returns {object}
  */
+const EXPLODABLE_SEMANTIC_TYPES = new Set([
+  'experiences',
+  'formations',
+  'skills',
+  'languages',
+  'certifications',
+  'projets',
+  'resume',
+]);
+
+const DEFAULT_SECTION_TITLE = Object.freeze({
+  experiences: 'EXPÉRIENCE PROFESSIONNELLE',
+  formations: 'FORMATION',
+  skills: 'COMPÉTENCES',
+  languages: 'LANGUES',
+  certifications: 'CERTIFICATIONS',
+  projets: 'PROJETS',
+  resume: 'PROFIL',
+});
+
+function leftoverTextBesideSemantic(block, leftovers) {
+  const box = asBox(block);
+  return leftovers.filter((other) => {
+    if (!other || other === block) return false;
+    if (other.type !== 'text' && other.type !== 'title') return false;
+    const bb = asBox(other);
+    const yOverlap = Math.max(
+      0,
+      Math.min(box.y + box.h, bb.y + bb.h) - Math.max(box.y, bb.y),
+    );
+    if (yOverlap < 2) return false;
+    return Math.abs(bb.x - box.x) > 20;
+  });
+}
+
+/**
+ * Import structurel déjà persisté : un titre PDF seul a été bindé en widget
+ * sémantique, puis l’auto-height l’a étiré sur toute la page. On le ramène
+ * à un titre verrouillé pour laisser la copie PDF visible.
+ */
+export function repairExplodedFreeformSemanticOverlays(layout) {
+  if (!layout?.pages?.length || layout.freeform !== true) return layout;
+  if (isLockedReplicaLayout(layout)) return layout;
+  const pages = layout.pages.map((page) => {
+    const blocks = Array.isArray(page?.blocks) ? page.blocks : [];
+    const leftovers = blocks.filter((b) => b?.type === 'text' || b?.type === 'title');
+    let changed = false;
+    const nextBlocks = blocks.map((block) => {
+      if (!EXPLODABLE_SEMANTIC_TYPES.has(block?.type)) return block;
+      const box = asBox(block);
+      const beside = leftoverTextBesideSemantic(block, leftovers);
+      const narrowOrTall = box.w < 55 || box.h > 24;
+      if (beside.length < 1 || !narrowOrTall) return block;
+      if (beside.length < 2 && box.h <= 40) return block;
+      changed = true;
+      const label = block.style?.section_label
+        || DEFAULT_SECTION_TITLE[block.type]
+        || 'SECTION';
+      return {
+        id: block.id,
+        type: 'title',
+        x: box.x,
+        y: box.y,
+        w: box.w,
+        h: round1(Math.min(Math.max(box.h, 6), 10)),
+        z: block.z,
+        content: label,
+        style: {
+          role: 'heading',
+          bold: true,
+          lock_height: true,
+          color: block.style?.color,
+          font_family: block.style?.font_family,
+        },
+      };
+    });
+    return changed ? { ...page, blocks: nextBlocks } : page;
+  });
+  return { ...layout, pages };
+}
+
+export function removeTextDuplicatingContact(layout, cv = {}) {
+  if (!layout?.pages?.length) return layout;
+  const phoneNeedle = String(cv.telephone || cv.phone || '')
+    .replace(/\D/g, '');
+  const emailNeedle = String(cv.email || '').trim().toLowerCase();
+  const pages = layout.pages.map((page) => {
+    const blocks = Array.isArray(page?.blocks) ? page.blocks : [];
+    const contacts = blocks.filter((b) => b?.type === 'contact').map(asBox);
+    if (!contacts.length) return page;
+    const nextBlocks = blocks.filter((block) => {
+      if (block?.type !== 'text') return true;
+      const box = asBox(block);
+      if (box.y > 48) return true;
+      const near = contacts.some((cb) => (
+        overlapRatio(box, cb) >= 0.05
+        || (sameHeaderRow(box, cb, 16) && Math.abs(box.x - cb.x) < 80)
+      ));
+      if (!near) return true;
+      const text = normalizeIdentityText(block.content);
+      const digits = String(block.content || '').replace(/\D/g, '');
+      const emailHit = Boolean(emailNeedle && text.includes(emailNeedle));
+      const phoneHit = Boolean(
+        phoneNeedle.length >= 8
+        && digits.length >= 8
+        && digits.includes(phoneNeedle.slice(-8)),
+      );
+      return !(emailHit || phoneHit);
+    });
+    return nextBlocks.length === blocks.length ? page : { ...page, blocks: nextBlocks };
+  });
+  return { ...layout, pages };
+}
+
 export function cleanupCanvasHeaderOverlays(layout, cv = {}) {
   if (!layout?.pages?.length) return layout;
-  let next = dedupeOverlappingIdentities(layout);
+  let next = repairExplodedFreeformSemanticOverlays(layout);
+  next = dedupeOverlappingIdentities(next);
   next = removeTextDuplicatingIdentity(next, cv);
+  next = removeTextDuplicatingContact(next, cv);
   next = insertMissingSpaceAfterColonLabels(next);
   next = wrapAtsColonLabels(next);
   next = allowWrapOnParagraphText(next);

--- a/frontend/src/lib/canvasHeaderOverlayCleanup.js
+++ b/frontend/src/lib/canvasHeaderOverlayCleanup.js
@@ -718,11 +718,14 @@ export function repairExplodedFreeformSemanticOverlays(layout) {
     let changed = false;
     const nextBlocks = blocks.map((block) => {
       if (!EXPLODABLE_SEMANTIC_TYPES.has(block?.type)) return block;
+      if (block.style?.lock_height || block.style?.lock_geometry) return block;
       const box = asBox(block);
       const beside = leftoverTextBesideSemantic(block, leftovers);
-      const narrowOrTall = box.w < 55 || box.h > 24;
-      if (beside.length < 1 || !narrowOrTall) return block;
-      if (beside.length < 2 && box.h <= 40) return block;
+      // Widget déjà locké = bind heading+corps. Titre PDF seul (étroit, ou
+      // déjà explosé) à côté de la copie : on le ramène en titre.
+      const pageTall = box.h >= 140;
+      const skinnyUnlocked = box.w < 55;
+      if (beside.length < 1 || !(pageTall || skinnyUnlocked)) return block;
       changed = true;
       const label = block.style?.section_label
         || DEFAULT_SECTION_TITLE[block.type]
@@ -776,7 +779,11 @@ export function removeTextDuplicatingContact(layout, cv = {}) {
         && digits.length >= 8
         && digits.includes(phoneNeedle.slice(-8)),
       );
-      return !(emailHit || phoneHit);
+      const leftoverOnlyContact = text.length <= 40 && (
+        /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/i.test(text)
+        || (digits.length >= 10 && /^[\d\s+().-]+$/.test(String(block.content || '').trim()))
+      );
+      return !(emailHit || phoneHit || leftoverOnlyContact);
     });
     return nextBlocks.length === blocks.length ? page : { ...page, blocks: nextBlocks };
   });

--- a/frontend/src/lib/structuralSemanticBind.js
+++ b/frontend/src/lib/structuralSemanticBind.js
@@ -227,8 +227,12 @@ function toSemanticBlock(baseBlock, classification, regionBlocks) {
       font_family: baseBlock.style.font_family,
       align: baseBlock.style.align || preset.style?.align,
     } : {}),
-    lock_height: true,
   };
+  // Sections : figer la bbox freeform. Identity / contact gardent l’auto-height
+  // pour révéler titre / lignes après nettoyage des leftover PDF.
+  if (HEADING_ONLY_TITLE_TYPES.has(classification.type)) {
+    style.lock_height = true;
+  }
   if (classification.sectionLabel) {
     style.section_label = classification.sectionLabel;
   }

--- a/frontend/src/lib/structuralSemanticBind.js
+++ b/frontend/src/lib/structuralSemanticBind.js
@@ -175,10 +175,51 @@ export function classifyStructuralTextBlock(block, cv = {}, { pageHeightMm = 297
   return null;
 }
 
+const HEADING_ONLY_TITLE_TYPES = new Set([
+  'experiences',
+  'formations',
+  'skills',
+  'languages',
+  'certifications',
+  'projets',
+  'resume',
+]);
+
+function headingAsLockedTitle(baseBlock, classification) {
+  const label = classification.sectionLabel
+    || decodeStructuralText(baseBlock.content);
+  return {
+    id: baseBlock.id,
+    type: 'title',
+    x: Number(baseBlock.x) || 0,
+    y: Number(baseBlock.y) || 0,
+    w: Math.max(8, Number(baseBlock.w) || 0),
+    h: Math.max(6, Number(baseBlock.h) || 0),
+    z: Number(baseBlock.z) || 1,
+    content: label,
+    style: {
+      ...(baseBlock.style && typeof baseBlock.style === 'object' ? baseBlock.style : {}),
+      role: 'heading',
+      bold: true,
+      lock_height: true,
+    },
+  };
+}
+
 function toSemanticBlock(baseBlock, classification, regionBlocks) {
+  const region = regionBlocks.length ? regionBlocks : [baseBlock];
+  // Titre PDF seul (corps dans une autre colonne) : ne pas poser un widget
+  // sémantique qui s’auto-agrandit et recouvre la copie PDF.
+  if (
+    classification.kind === 'heading'
+    && region.length <= 1
+    && HEADING_ONLY_TITLE_TYPES.has(classification.type)
+  ) {
+    return headingAsLockedTitle(baseBlock, classification);
+  }
   const preset = createCvSectionBlockPreset(classification.type);
   if (!preset) return null;
-  const box = unionBox(regionBlocks.length ? regionBlocks : [baseBlock]);
+  const box = unionBox(region);
   const style = {
     ...(preset.style || {}),
     ...(baseBlock.style && typeof baseBlock.style === 'object' ? {
@@ -186,6 +227,7 @@ function toSemanticBlock(baseBlock, classification, regionBlocks) {
       font_family: baseBlock.style.font_family,
       align: baseBlock.style.align || preset.style?.align,
     } : {}),
+    lock_height: true,
   };
   if (classification.sectionLabel) {
     style.section_label = classification.sectionLabel;

--- a/frontend/tests/unit/canvasHeaderOverlayCleanup.test.js
+++ b/frontend/tests/unit/canvasHeaderOverlayCleanup.test.js
@@ -19,6 +19,8 @@ import {
   tagBlocksOnHeaderBand,
   textDuplicatesIdentityContent,
   wrapAtsColonLabels,
+  repairExplodedFreeformSemanticOverlays,
+  removeTextDuplicatingContact,
 } from '../../src/lib/canvasHeaderOverlayCleanup.js';
 import { sanitizeLayoutV3 } from '../../src/lib/cvLayoutModelV3.js';
 import { bindStructuralTextToSemanticBlocks } from '../../src/lib/structuralSemanticBind.js';
@@ -979,4 +981,78 @@ test('bindStructuralTextToSemanticBlocks ne consomme pas un filet de ponctuation
   const ids = out.pages[0].blocks.map((b) => b.id);
   assert.equal(ids.includes('rule'), true);
   assert.equal(ids.includes('dots'), true);
+});
+
+test('repairExplodedFreeformSemanticOverlays : experiences géant à côté du PDF → title', () => {
+  const layout = layoutWith([
+    {
+      id: 'exp',
+      type: 'experiences',
+      x: 8,
+      y: 82,
+      w: 48,
+      h: 210,
+      z: 4,
+      bind: 'experiences',
+      style: { section_label: 'EXPÉRIENCE PROFESSIONNELLE' },
+    },
+    {
+      id: 'job1',
+      type: 'text',
+      content: 'Conseillère de vente - Bonpoint',
+      x: 54,
+      y: 79,
+      w: 100,
+      h: 9,
+      z: 2,
+    },
+    {
+      id: 'job2',
+      type: 'text',
+      content: 'Co-Présidente - Association HeForShe',
+      x: 54,
+      y: 132,
+      w: 90,
+      h: 9,
+      z: 2,
+    },
+  ]);
+  const out = cleanupCanvasHeaderOverlays(layout, {
+    prenom: 'Enée',
+    nom: 'Candiolo',
+  });
+  const exp = out.pages[0].blocks.find((b) => b.id === 'exp');
+  assert.equal(exp.type, 'title');
+  assert.ok(exp.h <= 10);
+  assert.equal(exp.style?.lock_height, true);
+  assert.equal(out.pages[0].blocks.some((b) => b.id === 'job1'), true);
+  assert.equal(repairExplodedFreeformSemanticOverlays(layout).pages[0].blocks.find((b) => b.id === 'exp').type, 'title');
+});
+
+test('removeTextDuplicatingContact retire le téléphone PDF à côté du contact', () => {
+  const layout = layoutWith([
+    {
+      id: 'ct',
+      type: 'contact',
+      x: 155,
+      y: 18,
+      w: 43,
+      h: 19,
+      z: 3,
+      bind: ['email', 'telephone'],
+    },
+    {
+      id: 'phone',
+      type: 'text',
+      content: '+33 7 68 56 32 11',
+      x: 168,
+      y: 14,
+      w: 31,
+      h: 8,
+      z: 2,
+    },
+  ]);
+  const out = removeTextDuplicatingContact(layout, { telephone: '+33 7 68 56 32 11' });
+  assert.equal(out.pages[0].blocks.some((b) => b.id === 'phone'), false);
+  assert.equal(out.pages[0].blocks.some((b) => b.id === 'ct'), true);
 });

--- a/frontend/tests/unit/canvasHeaderOverlayCleanup.test.js
+++ b/frontend/tests/unit/canvasHeaderOverlayCleanup.test.js
@@ -1029,6 +1029,87 @@ test('repairExplodedFreeformSemanticOverlays : experiences géant à côté du P
   assert.equal(repairExplodedFreeformSemanticOverlays(layout).pages[0].blocks.find((b) => b.id === 'exp').type, 'title');
 });
 
+test('repairExplodedFreeformSemanticOverlays : widget locké large inchangé', () => {
+  const layout = layoutWith([
+    {
+      id: 'exp',
+      type: 'experiences',
+      x: 70,
+      y: 50,
+      w: 120,
+      h: 60,
+      z: 4,
+      bind: 'experiences',
+      style: { lock_height: true, section_label: 'EXPÉRIENCES' },
+    },
+    {
+      id: 'side',
+      type: 'text',
+      content: 'SQL, Python',
+      x: 8,
+      y: 52,
+      w: 50,
+      h: 8,
+      z: 2,
+    },
+    {
+      id: 'side2',
+      type: 'text',
+      content: 'Anglais C1',
+      x: 8,
+      y: 70,
+      w: 50,
+      h: 8,
+      z: 2,
+    },
+  ]);
+  const out = repairExplodedFreeformSemanticOverlays(layout);
+  const exp = out.pages[0].blocks.find((b) => b.id === 'exp');
+  assert.equal(exp.type, 'experiences');
+  assert.equal(exp.h, 60);
+});
+
+test('repairExplodedFreeformSemanticOverlays : titre étroit déverrouillé → title', () => {
+  const layout = layoutWith([
+    {
+      id: 'skills',
+      type: 'skills',
+      x: 8,
+      y: 62,
+      w: 38,
+      h: 24,
+      z: 4,
+      bind: 'competences.techniques',
+      style: { section_label: 'COMPÉTENCES' },
+    },
+    {
+      id: 'job1',
+      type: 'text',
+      content: 'Conseillère de vente - Bonpoint',
+      x: 54,
+      y: 60,
+      w: 100,
+      h: 9,
+      z: 2,
+    },
+    {
+      id: 'job2',
+      type: 'text',
+      content: 'Co-Présidente - Association HeForShe',
+      x: 54,
+      y: 72,
+      w: 90,
+      h: 9,
+      z: 2,
+    },
+  ]);
+  const out = repairExplodedFreeformSemanticOverlays(layout);
+  const skills = out.pages[0].blocks.find((b) => b.id === 'skills');
+  assert.equal(skills.type, 'title');
+  assert.equal(skills.content, 'COMPÉTENCES');
+  assert.ok(skills.h <= 10);
+});
+
 test('removeTextDuplicatingContact retire le téléphone PDF à côté du contact', () => {
   const layout = layoutWith([
     {
@@ -1055,4 +1136,6 @@ test('removeTextDuplicatingContact retire le téléphone PDF à côté du contac
   const out = removeTextDuplicatingContact(layout, { telephone: '+33 7 68 56 32 11' });
   assert.equal(out.pages[0].blocks.some((b) => b.id === 'phone'), false);
   assert.equal(out.pages[0].blocks.some((b) => b.id === 'ct'), true);
+  const withoutCvPhone = removeTextDuplicatingContact(layout, {});
+  assert.equal(withoutCvPhone.pages[0].blocks.some((b) => b.id === 'phone'), false);
 });

--- a/frontend/tests/unit/canvasHeaderOverlayCleanup.test.js
+++ b/frontend/tests/unit/canvasHeaderOverlayCleanup.test.js
@@ -1178,7 +1178,7 @@ test('removeTextDuplicatingContact retire le téléphone PDF à côté du contac
   assert.equal(out.pages[0].blocks.some((b) => b.id === 'phone'), false);
   assert.equal(out.pages[0].blocks.some((b) => b.id === 'ct'), true);
   const withoutCvPhone = removeTextDuplicatingContact(layout, {});
-  assert.equal(withoutCvPhone.pages[0].blocks.some((b) => b.id === 'phone'), false);
+  assert.equal(withoutCvPhone.pages[0].blocks.some((b) => b.id === 'phone'), true);
 });
 
 test('removeTextDuplicatingContact retire l’email PDF (dots conservés)', () => {
@@ -1208,5 +1208,5 @@ test('removeTextDuplicatingContact retire l’email PDF (dots conservés)', () =
   assert.equal(out.pages[0].blocks.some((b) => b.id === 'mail'), false);
   assert.equal(out.pages[0].blocks.some((b) => b.id === 'ct'), true);
   const withoutCvEmail = removeTextDuplicatingContact(layout, {});
-  assert.equal(withoutCvEmail.pages[0].blocks.some((b) => b.id === 'mail'), false);
+  assert.equal(withoutCvEmail.pages[0].blocks.some((b) => b.id === 'mail'), true);
 });

--- a/frontend/tests/unit/canvasHeaderOverlayCleanup.test.js
+++ b/frontend/tests/unit/canvasHeaderOverlayCleanup.test.js
@@ -1029,6 +1029,47 @@ test('repairExplodedFreeformSemanticOverlays : experiences géant à côté du P
   assert.equal(repairExplodedFreeformSemanticOverlays(layout).pages[0].blocks.find((b) => b.id === 'exp').type, 'title');
 });
 
+test('repairExplodedFreeformSemanticOverlays : widget large déverrouillé haut inchangé', () => {
+  const layout = layoutWith([
+    {
+      id: 'exp',
+      type: 'experiences',
+      x: 70,
+      y: 40,
+      w: 120,
+      h: 160,
+      z: 4,
+      bind: 'experiences',
+      style: { section_label: 'EXPÉRIENCES' },
+    },
+    {
+      id: 'side',
+      type: 'text',
+      content: 'SQL, Python',
+      x: 8,
+      y: 52,
+      w: 50,
+      h: 8,
+      z: 2,
+    },
+    {
+      id: 'side2',
+      type: 'text',
+      content: 'Anglais C1',
+      x: 8,
+      y: 140,
+      w: 50,
+      h: 8,
+      z: 2,
+    },
+  ]);
+  const out = repairExplodedFreeformSemanticOverlays(layout);
+  const exp = out.pages[0].blocks.find((b) => b.id === 'exp');
+  assert.equal(exp.type, 'experiences');
+  assert.equal(exp.h, 160);
+  assert.equal(exp.bind, 'experiences');
+});
+
 test('repairExplodedFreeformSemanticOverlays : widget locké large inchangé', () => {
   const layout = layoutWith([
     {
@@ -1138,4 +1179,34 @@ test('removeTextDuplicatingContact retire le téléphone PDF à côté du contac
   assert.equal(out.pages[0].blocks.some((b) => b.id === 'ct'), true);
   const withoutCvPhone = removeTextDuplicatingContact(layout, {});
   assert.equal(withoutCvPhone.pages[0].blocks.some((b) => b.id === 'phone'), false);
+});
+
+test('removeTextDuplicatingContact retire l’email PDF (dots conservés)', () => {
+  const layout = layoutWith([
+    {
+      id: 'ct',
+      type: 'contact',
+      x: 155,
+      y: 18,
+      w: 43,
+      h: 19,
+      z: 3,
+      bind: ['email', 'telephone'],
+    },
+    {
+      id: 'mail',
+      type: 'text',
+      content: 'enee.candiolo@hec.edu',
+      x: 160,
+      y: 12,
+      w: 40,
+      h: 6,
+      z: 2,
+    },
+  ]);
+  const out = removeTextDuplicatingContact(layout, { email: 'enee.candiolo@hec.edu' });
+  assert.equal(out.pages[0].blocks.some((b) => b.id === 'mail'), false);
+  assert.equal(out.pages[0].blocks.some((b) => b.id === 'ct'), true);
+  const withoutCvEmail = removeTextDuplicatingContact(layout, {});
+  assert.equal(withoutCvEmail.pages[0].blocks.some((b) => b.id === 'mail'), false);
 });

--- a/frontend/tests/unit/cvDualKeyImport.test.js
+++ b/frontend/tests/unit/cvDualKeyImport.test.js
@@ -75,7 +75,59 @@ describe('structuralSemanticBind annotations', () => {
       },
     );
     assert.equal(boundCount, 1);
-    const types = bound.pages[0].blocks.map((b) => b.type);
-    assert.ok(types.includes('experiences'));
+    const block = bound.pages[0].blocks[0];
+    // Titre seul (pas de corps dans la région) : title verrouillé, pas un
+    // widget experiences qui s’auto-agrandit. L’annotation API a quand même
+    // primé : sans elle « Something odd » resterait du texte.
+    assert.equal(block.type, 'title');
+    assert.equal(block.content, 'EXPERIENCES');
+    assert.equal(block.style?.lock_height, true);
+  });
+
+  it('API heading + corps même colonne → widget experiences', () => {
+    const layout = {
+      version: 3,
+      pages: [{
+        blocks: [
+          {
+            id: 't1',
+            type: 'text',
+            x: 10,
+            y: 10,
+            w: 40,
+            h: 8,
+            content: 'Something odd',
+            style: { font_size: 11, bold: true },
+          },
+          {
+            id: 'b1',
+            type: 'text',
+            x: 10,
+            y: 20,
+            w: 80,
+            h: 6,
+            content: 'Product Manager — NovaSoft',
+            style: {},
+          },
+        ],
+      }],
+    };
+    const { layout: bound } = bindStructuralTextToSemanticBlocks(
+      layout,
+      {},
+      {
+        annotations: [{
+          block_id: 't1',
+          type: 'experiences',
+          kind: 'heading',
+          confidence: 0.95,
+          section_label: 'EXPERIENCES',
+        }],
+      },
+    );
+    const exp = bound.pages[0].blocks.find((b) => b.type === 'experiences');
+    assert.ok(exp);
+    assert.equal(exp.style?.lock_height, true);
+    assert.equal(bound.pages[0].blocks.some((b) => b.id === 'b1'), false);
   });
 });

--- a/frontend/tests/unit/structuralSemanticBind.test.js
+++ b/frontend/tests/unit/structuralSemanticBind.test.js
@@ -231,6 +231,7 @@ test('bindStructuralTextToSemanticBlocks : heading + corps → experiences, free
   const form = blocks.find((b) => b.type === 'formations');
   assert.ok(exp);
   assert.equal(exp.bind, 'experiences');
+  assert.equal(exp.style?.lock_height, true);
   // Hauteur = bbox freeform (pas preset 80mm) pour éviter le chevauchement.
   assert.ok(exp.h >= 18 && exp.h < 40, `h inattendu: ${exp.h}`);
   assert.ok(form);
@@ -340,4 +341,63 @@ test('bindStructuralTextToSemanticBlocks : confiance basse → freeform inchang�
   assert.equal(skippedLowConfidence, 0);
   assert.equal(out.pages[0].blocks[0].type, 'text');
   assert.equal(out.pages[0].blocks[0].content.includes('Note'), true);
+});
+
+test('bind : titre seul (corps autre colonne) reste un title, pas un widget experiences', () => {
+  const layout = sanitizeLayoutV3({
+    version: 3,
+    format: 'A4',
+    grid: 'free',
+    unit: 'mm',
+    freeform: true,
+    pages: [{
+      id: 'p1',
+      blocks: [
+        {
+          id: 'h1',
+          type: 'text',
+          content: 'Expérience professionnelle',
+          x: 8,
+          y: 82,
+          w: 48,
+          h: 7,
+          z: 2,
+          style: { bold: true, font_size: 12 },
+        },
+        {
+          id: 'job1',
+          type: 'text',
+          content: 'Conseillère de vente - Bonpoint Avenue Montaigne',
+          x: 54,
+          y: 79,
+          w: 100,
+          h: 9,
+          z: 2,
+          style: {},
+        },
+        {
+          id: 'job2',
+          type: 'text',
+          content: 'Eté 2023 et 2024 - 5 mois',
+          x: 54,
+          y: 85,
+          w: 41,
+          h: 7,
+          z: 2,
+          style: {},
+        },
+      ],
+    }],
+  });
+  const { layout: out } = bindStructuralTextToSemanticBlocks(layout, {
+    prenom: 'Enée',
+    nom: 'Candiolo',
+  });
+  const blocks = out.pages[0].blocks;
+  assert.equal(blocks.some((b) => b.type === 'experiences'), false);
+  const title = blocks.find((b) => b.type === 'title' && b.id === 'h1');
+  assert.ok(title);
+  assert.equal(title.style?.lock_height, true);
+  assert.equal(blocks.some((b) => b.id === 'job1'), true);
+  assert.equal(blocks.some((b) => b.id === 'job2'), true);
 });

--- a/frontend/tests/unit/structuralSemanticBind.test.js
+++ b/frontend/tests/unit/structuralSemanticBind.test.js
@@ -401,3 +401,51 @@ test('bind : titre seul (corps autre colonne) reste un title, pas un widget expe
   assert.equal(blocks.some((b) => b.id === 'job1'), true);
   assert.equal(blocks.some((b) => b.id === 'job2'), true);
 });
+
+test('bind : identity et contact ne reçoivent pas lock_height', () => {
+  const layout = sanitizeLayoutV3({
+    version: 3,
+    format: 'A4',
+    grid: 'free',
+    unit: 'mm',
+    freeform: true,
+    pages: [{
+      id: 'p1',
+      blocks: [
+        {
+          id: 'n1',
+          type: 'text',
+          content: 'Camille Durand',
+          x: 20,
+          y: 12,
+          w: 80,
+          h: 8,
+          z: 2,
+          style: { bold: true, font_size: 18 },
+        },
+        {
+          id: 'c1',
+          type: 'text',
+          content: 'hello@example.fr',
+          x: 140,
+          y: 14,
+          w: 50,
+          h: 5,
+          z: 2,
+          style: {},
+        },
+      ],
+    }],
+  });
+  const { layout: out } = bindStructuralTextToSemanticBlocks(layout, {
+    prenom: 'Camille',
+    nom: 'Durand',
+    email: 'hello@example.fr',
+  });
+  const ident = out.pages[0].blocks.find((b) => b.type === 'identity');
+  const contact = out.pages[0].blocks.find((b) => b.type === 'contact');
+  assert.ok(ident);
+  assert.ok(contact);
+  assert.equal(ident.style?.lock_height, undefined);
+  assert.equal(contact.style?.lock_height, undefined);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

- Un titre PDF seul (corps dans une autre colonne) n’est plus bindé en widget `experiences` / `skills` / `formations` / `resume` : il reste un `title` verrouillé (`lock_height`).
- Un bind heading + corps pose `style.lock_height` pour que l’auto-height n’étire plus le widget sur la page. `identity` / `contact` gardent l’auto-height (Bugbot).
- À l’hydrate / à l’import, `cleanupCanvasHeaderOverlays` ne reconvertit en titre que les widgets **étroits** déverrouillés (`w < 55`) à côté de leftover PDF — un `experiences` large (heading+corps) n’est plus détruit (Bugbot).
- Email leftover : match sur le texte brut (les `.` restent) (Bugbot). Téléphone / e-mail PDF retirés **seulement** s’ils doublent une valeur du CV (CodeRabbit) — sinon on garde la seule copie.
- `applyImportedCvToCanvas` relance toujours le sanitizer, y compris sur le layout choisi dans le chooser.

Hors scope : AXE-404 (landing / Button). Commentaire Linear : https://linear.app/axel-project/issue/AXE-404/improve-button-sur-landing-et-pages-contenu#comment-b7e71171

## Why

En recette AXE-404, l’import structurel d’un CV deux colonnes (Enée Candiolo) transformait les titres de section en widgets sémantiques. L’auto-height les étirait (ex. `experiences` h=297mm) et recouvrait le texte PDF de l’autre colonne.

## Validation

- [x] Backend lint + tests + couverture
- [x] Frontend lint + `test:unit` (698 pass)
- [x] `bash scripts/pre-push.sh --skip-extras --skip-gitleaks` → OK
- [x] Retours Bugbot (3) + CodeRabbit leftover contact
- [x] Sanitizer Enée : 5 titres verrouillés ; phone retiré si `cv.telephone` présent
- [x] No secrets committed

Recette navigateur `/app/cv` : session expirée, pas de mot de passe inventé. Un refresh connecté sur Beta hydrate le layout persisté.

[Import Enée avant / après sanitizer](https://cursor.com/agents/bc-78ab1eb6-15ef-4ef0-bdc8-f8361cfbea14/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenee_import_overlay_before_after.png)

## Risk and rollback

- Risk: un vrai widget sidebar **étroit** sans `lock_height` à côté de leftover PDF peut encore être reconverti en titre. Les binds heading+corps larges (ou lockés) restent des widgets.
- Rollback: revert de la branche / revert du merge.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78ab1eb6-15ef-4ef0-bdc8-f8361cfbea14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78ab1eb6-15ef-4ef0-bdc8-f8361cfbea14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * Amélioration de la mise en page lors de l’import de CV afin de mieux préserver les titres et les blocs de contenu.
  * Les titres de sections importés sont désormais correctement identifiés, mis en forme et maintenus à une hauteur stable.
  * Nettoyage renforcé des mises en page importées : correction de certains blocs de titre déformés et suppression des coordonnées dupliquées.
* **Tests**
  * Ajout de tests couvrant la détection des titres, la stabilité des blocs et le nettoyage des doublons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->